### PR TITLE
Create Kotlin multi-module architecture and domain ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.gradle/
+build/
+**/build/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    kotlin("jvm")
+    application
+}
+
+dependencies {
+    implementation(project(":domain"))
+    implementation(project(":data"))
+    implementation(project(":platform"))
+    testImplementation(kotlin("test"))
+}
+
+application {
+    mainClass.set("com.tideo.autobrightness.app.MainKt")
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/AppModule.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/AppModule.kt
@@ -1,0 +1,31 @@
+package com.tideo.autobrightness.app
+
+import com.tideo.autobrightness.domain.BrightnessPolicyEngine
+import com.tideo.autobrightness.domain.EvaluateAndApplyBrightnessUseCase
+import com.tideo.autobrightness.platform.AndroidPermissionStateAdapter
+import com.tideo.autobrightness.platform.FakeAmbientLuxSensorAdapter
+import com.tideo.autobrightness.platform.SystemBrightnessAdapter
+import com.tideo.autobrightness.platform.TaskerOverlayControllerAdapter
+import com.tideo.autobrightness.platform.UsageStatsContextAdapter
+
+/**
+ * Manual DI composition root.
+ * Replace with Hilt/Koin later without touching domain contracts.
+ */
+class AppModule {
+    private val luxSource = FakeAmbientLuxSensorAdapter()
+    private val contextProvider = UsageStatsContextAdapter()
+    private val permissionStateProvider = AndroidPermissionStateAdapter()
+    private val brightnessApplier = SystemBrightnessAdapter()
+    private val overlayController = TaskerOverlayControllerAdapter()
+    private val policyEngine = BrightnessPolicyEngine()
+
+    val evaluateAndApplyBrightnessUseCase = EvaluateAndApplyBrightnessUseCase(
+        luxSource = luxSource,
+        contextProvider = contextProvider,
+        permissionStateProvider = permissionStateProvider,
+        engine = policyEngine,
+        brightnessApplier = brightnessApplier,
+        overlayController = overlayController,
+    )
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/Main.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/Main.kt
@@ -1,0 +1,7 @@
+package com.tideo.autobrightness.app
+
+fun main() {
+    val module = AppModule()
+    val result = module.evaluateAndApplyBrightnessUseCase.run()
+    println("[app] Evaluated brightness result=$result")
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    kotlin("jvm") version "1.9.24" apply false
+}
+
+allprojects {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    kotlin("jvm")
+}
+
+dependencies {
+    implementation(project(":domain"))
+    testImplementation(kotlin("test"))
+}

--- a/data/src/main/kotlin/com/tideo/autobrightness/data/InMemorySettingsRepository.kt
+++ b/data/src/main/kotlin/com/tideo/autobrightness/data/InMemorySettingsRepository.kt
@@ -1,0 +1,11 @@
+package com.tideo.autobrightness.data
+
+class InMemorySettingsRepository : SettingsRepository {
+    private var state = BrightnessSettings()
+
+    override fun read(): BrightnessSettings = state
+
+    override fun write(settings: BrightnessSettings) {
+        state = settings
+    }
+}

--- a/data/src/main/kotlin/com/tideo/autobrightness/data/SettingsFileAdapter.kt
+++ b/data/src/main/kotlin/com/tideo/autobrightness/data/SettingsFileAdapter.kt
@@ -1,0 +1,20 @@
+package com.tideo.autobrightness.data
+
+import java.io.File
+
+class SettingsFileAdapter(
+    private val file: File,
+) {
+    fun export(settings: BrightnessSettings) {
+        file.writeText("${settings.defaultThrottleMs},${settings.overrideDetectionEnabled}")
+    }
+
+    fun import(): BrightnessSettings {
+        if (!file.exists()) return BrightnessSettings()
+        val raw = file.readText().split(',')
+        return BrightnessSettings(
+            defaultThrottleMs = raw.getOrNull(0)?.toLongOrNull() ?: 500,
+            overrideDetectionEnabled = raw.getOrNull(1)?.toBooleanStrictOrNull() ?: true,
+        )
+    }
+}

--- a/data/src/main/kotlin/com/tideo/autobrightness/data/SettingsRepository.kt
+++ b/data/src/main/kotlin/com/tideo/autobrightness/data/SettingsRepository.kt
@@ -1,0 +1,11 @@
+package com.tideo.autobrightness.data
+
+interface SettingsRepository {
+    fun read(): BrightnessSettings
+    fun write(settings: BrightnessSettings)
+}
+
+data class BrightnessSettings(
+    val defaultThrottleMs: Long = 500,
+    val overrideDetectionEnabled: Boolean = true,
+)

--- a/docs/migration/task_to_usecase_map.md
+++ b/docs/migration/task_to_usecase_map.md
@@ -1,0 +1,35 @@
+# Tasker → Kotlin domain use-case mapping
+
+This document maps key Tasker tasks/profiles in `Advanced_Auto_Brightness_V3.3.prj_4.xml` to the new Kotlin architecture.
+
+## Module boundaries
+
+- `app`: entry points and dependency graph composition (`AppModule`, `Main`).
+- `domain`: policy engine + use-cases + interfaces (ports).
+- `data`: persistence and import/export adapters.
+- `platform`: Android/tasker-facing adapters (sensor, overlay, usage stats, system brightness).
+
+## Core mapping
+
+| Tasker task/profile | New module | Domain use-case / service | Notes |
+|---|---|---|---|
+| `Monitor Ambient Light` + `Process Sensor Event (Java)` + `Lux Smoothing (Java)` | `platform` + `domain` | `AmbientLuxSource` + `EvaluateAndApplyBrightnessUseCase` | Sensor capture remains platform; smoothing/evaluation logic migrates into domain policy/use-case flow. |
+| `Evaluate Light Change (Java) V2` + `Dynamic Range Compressed Scale (Java) V2` | `domain` | `BrightnessPolicyEngine.computeTarget()` | Brightness decision logic centralized in pure Kotlin engine for testability. |
+| `Advanced Auto Brightness` (main orchestrator) | `app` | `EvaluateAndApplyBrightnessUseCase.run()` | Main orchestration moved to app composition root + use-case invocation. |
+| `Manual Override` + `Allow Override` + `Resume After Override` | `domain` + `platform` | `PermissionStateProvider`, `OverlayController` and future `HandleManualOverrideUseCase` | Permission/overlay concerns abstracted behind domain ports. |
+| `Context: App Changed`, `Context: Time Changed`, `Context: Battery Changed`, `Context: Location Changed` | `platform` + `domain` | `ContextProvider.currentContext()` | Context aggregation happens in platform adapter, consumed by domain engine. |
+| `Reset Brightness and State` + `Panic (Reset)` | `domain` + `data` | future reset use-case + `SettingsRepository` | Reset behavior should be codified as a dedicated use-case using repository-backed state. |
+| `_ForegroundNotification`, `Repost Foreground Notification`, `Repost Paused Notification` | `platform` | `OverlayController` | Notification/overlay duties move to a dedicated platform adapter. |
+| `Initialize AAB Defaults` + `Throttle Reinitialization` | `data` + `domain` | `SettingsRepository`, `SettingsFileAdapter` | Defaults and persisted runtime params become structured settings data. |
+
+## Interface placement checklist
+
+The following interfaces are defined in `domain` and implemented in `platform`:
+
+- `AmbientLuxSource`
+- `BrightnessApplier`
+- `ContextProvider`
+- `PermissionStateProvider`
+- `OverlayController`
+
+This keeps domain independent of Android APIs while preserving behavior parity during migration.

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    kotlin("jvm")
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+}

--- a/domain/src/main/kotlin/com/tideo/autobrightness/domain/BrightnessPolicyEngine.kt
+++ b/domain/src/main/kotlin/com/tideo/autobrightness/domain/BrightnessPolicyEngine.kt
@@ -1,0 +1,18 @@
+package com.tideo.autobrightness.domain
+
+class BrightnessPolicyEngine {
+    fun computeTarget(lux: Float, context: UserContext): Int {
+        val base = when {
+            lux < 2f -> 8
+            lux < 10f -> 20
+            lux < 60f -> 40
+            lux < 200f -> 65
+            else -> 90
+        }
+
+        val nightBias = if (context.hourOfDay < 6 || context.hourOfDay >= 22) -10 else 0
+        val chargingBias = if (context.isCharging) 5 else 0
+
+        return (base + nightBias + chargingBias).coerceIn(1, 100)
+    }
+}

--- a/domain/src/main/kotlin/com/tideo/autobrightness/domain/EvaluateAndApplyBrightnessUseCase.kt
+++ b/domain/src/main/kotlin/com/tideo/autobrightness/domain/EvaluateAndApplyBrightnessUseCase.kt
@@ -1,0 +1,26 @@
+package com.tideo.autobrightness.domain
+
+class EvaluateAndApplyBrightnessUseCase(
+    private val luxSource: AmbientLuxSource,
+    private val contextProvider: ContextProvider,
+    private val permissionStateProvider: PermissionStateProvider,
+    private val engine: BrightnessPolicyEngine,
+    private val brightnessApplier: BrightnessApplier,
+    private val overlayController: OverlayController,
+) {
+    fun run(): Int? {
+        if (!permissionStateProvider.canAdjustSystemBrightness()) {
+            overlayController.showPausedBanner("Missing system write permission")
+            return null
+        }
+
+        val target = engine.computeTarget(
+            lux = luxSource.currentLux(),
+            context = contextProvider.currentContext(),
+        )
+
+        brightnessApplier.apply(target)
+        overlayController.hidePausedBanner()
+        return target
+    }
+}

--- a/domain/src/main/kotlin/com/tideo/autobrightness/domain/Ports.kt
+++ b/domain/src/main/kotlin/com/tideo/autobrightness/domain/Ports.kt
@@ -1,0 +1,31 @@
+package com.tideo.autobrightness.domain
+
+interface AmbientLuxSource {
+    fun currentLux(): Float
+}
+
+interface BrightnessApplier {
+    fun apply(level: Int)
+}
+
+interface ContextProvider {
+    fun currentContext(): UserContext
+}
+
+interface PermissionStateProvider {
+    fun canAdjustSystemBrightness(): Boolean
+    fun canDrawOverlay(): Boolean
+    fun canReadUsageStats(): Boolean
+}
+
+interface OverlayController {
+    fun showPausedBanner(reason: String)
+    fun hidePausedBanner()
+}
+
+data class UserContext(
+    val packageName: String? = null,
+    val isCharging: Boolean = false,
+    val hourOfDay: Int,
+    val isAtHomeWifi: Boolean = false,
+)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+kotlin.code.style=official
+org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8

--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    kotlin("jvm")
+}
+
+dependencies {
+    implementation(project(":domain"))
+    testImplementation(kotlin("test"))
+}

--- a/platform/src/main/kotlin/com/tideo/autobrightness/platform/SystemAdapters.kt
+++ b/platform/src/main/kotlin/com/tideo/autobrightness/platform/SystemAdapters.kt
@@ -1,0 +1,46 @@
+package com.tideo.autobrightness.platform
+
+import com.tideo.autobrightness.domain.AmbientLuxSource
+import com.tideo.autobrightness.domain.BrightnessApplier
+import com.tideo.autobrightness.domain.ContextProvider
+import com.tideo.autobrightness.domain.OverlayController
+import com.tideo.autobrightness.domain.PermissionStateProvider
+import com.tideo.autobrightness.domain.UserContext
+import kotlin.random.Random
+
+class FakeAmbientLuxSensorAdapter : AmbientLuxSource {
+    override fun currentLux(): Float = Random.nextDouble(from = 1.0, until = 180.0).toFloat()
+}
+
+class SystemBrightnessAdapter : BrightnessApplier {
+    override fun apply(level: Int) {
+        println("[platform] Applying brightness=$level")
+    }
+}
+
+class UsageStatsContextAdapter : ContextProvider {
+    override fun currentContext(): UserContext {
+        return UserContext(
+            packageName = "com.example.reader",
+            isCharging = false,
+            hourOfDay = 21,
+            isAtHomeWifi = true,
+        )
+    }
+}
+
+class AndroidPermissionStateAdapter : PermissionStateProvider {
+    override fun canAdjustSystemBrightness(): Boolean = true
+    override fun canDrawOverlay(): Boolean = true
+    override fun canReadUsageStats(): Boolean = true
+}
+
+class TaskerOverlayControllerAdapter : OverlayController {
+    override fun showPausedBanner(reason: String) {
+        println("[platform] Overlay ON: $reason")
+    }
+
+    override fun hidePausedBanner() {
+        println("[platform] Overlay OFF")
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "TideoAutoBrightness"
+
+include(":app", ":domain", ":data", ":platform")


### PR DESCRIPTION
### Motivation

- Introduce a clear multi-module Kotlin architecture to separate UI/entry points, domain logic, persistence, and platform adapters for easier migration from Tasker logic to a testable Kotlin codebase.
- Define domain-facing ports so the policy engine and use-cases remain pure and independent of Android/Tasker APIs to enable safe adapter swaps and DI-driven composition.

### Description

- Add a Gradle multi-module layout with `:app`, `:domain`, `:data`, and `:platform` and root build files to establish dependency directions (`app -> domain/data/platform`, `data/platform -> domain`).
- Implement domain contracts and core logic in `domain`: `AmbientLuxSource`, `BrightnessApplier`, `ContextProvider`, `PermissionStateProvider`, `OverlayController`, `UserContext`, `BrightnessPolicyEngine`, and `EvaluateAndApplyBrightnessUseCase`.
- Provide `platform` adapters that implement the domain ports (`FakeAmbientLuxSensorAdapter`, `SystemBrightnessAdapter`, `UsageStatsContextAdapter`, `AndroidPermissionStateAdapter`, `TaskerOverlayControllerAdapter`) and `data` persistence/adapters (`SettingsRepository`, `InMemorySettingsRepository`, `SettingsFileAdapter`).
- Wire dependencies with a manual composition root in `app/AppModule.kt` and add a simple entry point `app/Main.kt`, plus a migration doc `docs/migration/task_to_usecase_map.md` mapping Tasker tasks to domain use-cases and a `.gitignore` for Gradle artifacts.

### Testing

- Attempted `gradle -q :app:run`, which failed in this environment with a Gradle/Java toolchain error (`What went wrong: 25.0.1`).
- No automated unit tests were executed in this run (no test sources added); project compiles/runs should be re-verified in a proper JVM/Gradle environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eda4e3309083219a0346427969ee93)