### PR TITLE
Add foreground monitoring service, WorkManager maintenance, receivers, and service health telemetry

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,6 +39,8 @@ dependencies {
     implementation(project(":platform"))
 
     implementation("androidx.activity:activity-compose:1.9.1")
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.work:work-runtime-ktx:2.9.1")
     implementation("androidx.compose.material3:material3:1.2.1")
     implementation("androidx.navigation:navigation-compose:2.8.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.4")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
     <application
         android:allowBackup="true"
         android:label="Tideo Auto Brightness"
@@ -12,5 +15,30 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".app.runtime.AmbientMonitoringService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
+
+        <receiver
+            android:name=".app.runtime.BootCompletedReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
+            android:name=".app.runtime.ScreenStateReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.SCREEN_ON" />
+                <action android:name="android.intent.action.SCREEN_OFF" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/Main.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/Main.kt
@@ -3,11 +3,13 @@ package com.tideo.autobrightness.app
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import com.tideo.autobrightness.app.runtime.AutoBrightnessRuntime
 import com.tideo.autobrightness.app.ui.AutoBrightnessApp
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        AutoBrightnessRuntime.bootstrap(this)
         setContent {
             AutoBrightnessApp()
         }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/navigation/NavGraph.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/navigation/NavGraph.kt
@@ -33,10 +33,11 @@ object Routes {
 fun AppNavGraph(navController: NavHostController, viewModel: SettingsViewModel = viewModel()) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val graphState by viewModel.graphState.collectAsStateWithLifecycle()
+    val healthState by viewModel.healthState.collectAsStateWithLifecycle()
 
     NavHost(navController = navController, startDestination = Routes.Dashboard) {
         composable(Routes.Dashboard) {
-            DashboardScreen(navController = navController, state = state, onToggle = viewModel::setEnabled)
+            DashboardScreen(navController = navController, state = state, healthState = healthState, onToggle = viewModel::setEnabled)
         }
         composable(Routes.BrightnessSettings) {
             BrightnessSettingsScreen(state = state, onUpdate = viewModel::updateBrightness)

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
@@ -1,0 +1,105 @@
+package com.tideo.autobrightness.app.runtime
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import com.tideo.autobrightness.app.AppModule
+import com.tideo.autobrightness.app.R
+import com.tideo.autobrightness.app.settings.SettingsStore
+import com.tideo.autobrightness.app.storage.serviceHealthDataStore
+import com.tideo.autobrightness.app.storage.settingsDataStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+class AmbientMonitoringService : Service() {
+    private val scope = CoroutineScope(Dispatchers.Default + Job())
+    private lateinit var settingsStore: SettingsStore
+    private lateinit var healthStore: ServiceHealthStore
+    private val appModule = AppModule()
+    private var monitoringJob: Job? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        settingsStore = SettingsStore(applicationContext.settingsDataStore)
+        healthStore = ServiceHealthStore(applicationContext.serviceHealthDataStore)
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        startForeground(NOTIFICATION_ID, buildNotification())
+        if (monitoringJob?.isActive != true) {
+            monitoringJob = scope.launch {
+                monitorLoop()
+            }
+        }
+        return START_STICKY
+    }
+
+    private suspend fun monitorLoop() {
+        while (true) {
+            val settings = settingsStore.readSettings()
+            if (!settings.enabled) {
+                stopSelf()
+                return
+            }
+
+            val now = System.currentTimeMillis()
+            val result = appModule.evaluateAndApplyBrightnessUseCase.run()
+            if (result.sampledLux != null) {
+                healthStore.markSensorSampled(now)
+            }
+            if (result.applied) {
+                healthStore.markApplied(now)
+            } else {
+                healthStore.markDegraded("Continuous sensing paused: permissions or OS restrictions")
+            }
+
+            delay(SAMPLE_INTERVAL_MS)
+        }
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = getSystemService(NotificationManager::class.java)
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Ambient monitoring",
+            NotificationManager.IMPORTANCE_LOW,
+        )
+        manager.createNotificationChannel(channel)
+    }
+
+    private fun buildNotification(): Notification {
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Auto Brightness active")
+            .setContentText("Monitoring ambient changes")
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setOngoing(true)
+            .build()
+    }
+
+    override fun onDestroy() {
+        monitoringJob?.cancel()
+        scope.cancel()
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    companion object {
+        const val ACTION_START = "com.tideo.autobrightness.runtime.action.START"
+        const val EXTRA_REASON = "reason"
+        private const val CHANNEL_ID = "ambient_monitoring"
+        private const val NOTIFICATION_ID = 1001
+        private const val SAMPLE_INTERVAL_MS = 15_000L
+    }
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AutoBrightnessRuntime.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AutoBrightnessRuntime.kt
@@ -1,0 +1,90 @@
+package com.tideo.autobrightness.app.runtime
+
+import android.app.ForegroundServiceStartNotAllowedException
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import com.tideo.autobrightness.app.settings.SettingsStore
+import com.tideo.autobrightness.app.storage.serviceHealthDataStore
+import com.tideo.autobrightness.app.storage.settingsDataStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.util.concurrent.TimeUnit
+
+object AutoBrightnessRuntime {
+    fun bootstrap(context: Context) {
+        scheduleMaintenance(context)
+        CoroutineScope(Dispatchers.Default).launch {
+            val settings = SettingsStore(context.settingsDataStore).readSettings()
+            if (settings.enabled) {
+                startMonitoring(context, "bootstrap")
+            }
+        }
+    }
+
+    fun onSettingChanged(context: Context, enabled: Boolean) {
+        scheduleMaintenance(context)
+        if (enabled) {
+            startMonitoring(context, "settings_enabled")
+        } else {
+            stopMonitoring(context)
+        }
+    }
+
+    fun startMonitoring(context: Context, reason: String) {
+        val appContext = context.applicationContext
+        val intent = Intent(appContext, AmbientMonitoringService::class.java).apply {
+            action = AmbientMonitoringService.ACTION_START
+            putExtra(AmbientMonitoringService.EXTRA_REASON, reason)
+        }
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                appContext.startForegroundService(intent)
+            } else {
+                appContext.startService(intent)
+            }
+        } catch (error: ForegroundServiceStartNotAllowedException) {
+            CoroutineScope(Dispatchers.IO).launch {
+                ServiceHealthStore(appContext.serviceHealthDataStore).markDegraded(
+                    "Foreground start blocked: ${error.javaClass.simpleName}",
+                )
+            }
+        } catch (error: IllegalStateException) {
+            CoroutineScope(Dispatchers.IO).launch {
+                ServiceHealthStore(appContext.serviceHealthDataStore).markDegraded(
+                    "Background restricted: ${error.javaClass.simpleName}",
+                )
+            }
+        }
+    }
+
+    fun stopMonitoring(context: Context) {
+        context.applicationContext.stopService(Intent(context, AmbientMonitoringService::class.java))
+    }
+
+    fun scheduleMaintenance(context: Context) {
+        val request = PeriodicWorkRequestBuilder<MaintenanceWorker>(15, TimeUnit.MINUTES)
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.NOT_REQUIRED)
+                    .build(),
+            )
+            .addTag(MAINTENANCE_TAG)
+            .build()
+
+        WorkManager.getInstance(context.applicationContext).enqueueUniquePeriodicWork(
+            UNIQUE_MAINTENANCE_WORK,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            request,
+        )
+    }
+
+    private const val UNIQUE_MAINTENANCE_WORK = "auto_brightness_maintenance"
+    const val MAINTENANCE_TAG = "maintenance"
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/BootCompletedReceiver.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/BootCompletedReceiver.kt
@@ -1,0 +1,23 @@
+package com.tideo.autobrightness.app.runtime
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.tideo.autobrightness.app.settings.SettingsStore
+import com.tideo.autobrightness.app.storage.settingsDataStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class BootCompletedReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        if (intent?.action != Intent.ACTION_BOOT_COMPLETED) return
+        CoroutineScope(Dispatchers.Default).launch {
+            val enabled = SettingsStore(context.settingsDataStore).readSettings().enabled
+            AutoBrightnessRuntime.scheduleMaintenance(context)
+            if (enabled) {
+                AutoBrightnessRuntime.startMonitoring(context, "boot_completed")
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/MaintenanceWorker.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/MaintenanceWorker.kt
@@ -1,0 +1,37 @@
+package com.tideo.autobrightness.app.runtime
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.tideo.autobrightness.app.AppModule
+import com.tideo.autobrightness.app.settings.SettingsStore
+import com.tideo.autobrightness.app.storage.serviceHealthDataStore
+import com.tideo.autobrightness.app.storage.settingsDataStore
+
+class MaintenanceWorker(
+    appContext: Context,
+    workerParams: WorkerParameters,
+) : CoroutineWorker(appContext, workerParams) {
+    private val settingsStore = SettingsStore(appContext.settingsDataStore)
+    private val healthStore = ServiceHealthStore(appContext.serviceHealthDataStore)
+    private val appModule = AppModule()
+
+    override suspend fun doWork(): Result {
+        val settings = settingsStore.readSettings()
+        if (!settings.enabled) return Result.success()
+
+        val now = System.currentTimeMillis()
+        val result = appModule.evaluateAndApplyBrightnessUseCase.run()
+        if (result.sampledLux != null) {
+            healthStore.markSensorSampled(now)
+        }
+        if (result.applied) {
+            healthStore.markApplied(now)
+        } else {
+            healthStore.markDegraded("Maintenance-only mode active")
+        }
+
+        AutoBrightnessRuntime.startMonitoring(applicationContext, "maintenance_reinit")
+        return Result.success()
+    }
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/ScreenStateReceiver.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/ScreenStateReceiver.kt
@@ -1,0 +1,24 @@
+package com.tideo.autobrightness.app.runtime
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.tideo.autobrightness.app.settings.SettingsStore
+import com.tideo.autobrightness.app.storage.settingsDataStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class ScreenStateReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        CoroutineScope(Dispatchers.Default).launch {
+            val enabled = SettingsStore(context.settingsDataStore).readSettings().enabled
+            if (!enabled) return@launch
+
+            when (intent?.action) {
+                Intent.ACTION_SCREEN_ON -> AutoBrightnessRuntime.startMonitoring(context, "screen_on")
+                Intent.ACTION_SCREEN_OFF -> AutoBrightnessRuntime.stopMonitoring(context)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/ServiceHealthStore.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/ServiceHealthStore.kt
@@ -1,0 +1,56 @@
+package com.tideo.autobrightness.app.runtime
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+data class ServiceHealthTelemetry(
+    val lastSensorTimestampMs: Long? = null,
+    val lastApplyTimestampMs: Long? = null,
+    val degradedMode: Boolean = false,
+    val degradedReason: String? = null,
+)
+
+class ServiceHealthStore(
+    private val dataStore: DataStore<Preferences>,
+) {
+    val telemetry: Flow<ServiceHealthTelemetry> = dataStore.data.map { prefs ->
+        ServiceHealthTelemetry(
+            lastSensorTimestampMs = prefs[LAST_SENSOR_TS],
+            lastApplyTimestampMs = prefs[LAST_APPLY_TS],
+            degradedMode = prefs[DEGRADED_MODE] ?: false,
+            degradedReason = prefs[DEGRADED_REASON],
+        )
+    }
+
+    suspend fun markSensorSampled(timestampMs: Long) {
+        dataStore.edit { it[LAST_SENSOR_TS] = timestampMs }
+    }
+
+    suspend fun markApplied(timestampMs: Long) {
+        dataStore.edit {
+            it[LAST_APPLY_TS] = timestampMs
+            it[DEGRADED_MODE] = false
+            it.remove(DEGRADED_REASON)
+        }
+    }
+
+    suspend fun markDegraded(reason: String) {
+        dataStore.edit {
+            it[DEGRADED_MODE] = true
+            it[DEGRADED_REASON] = reason
+        }
+    }
+
+    private companion object {
+        val LAST_SENSOR_TS = longPreferencesKey("last_sensor_timestamp_ms")
+        val LAST_APPLY_TS = longPreferencesKey("last_apply_timestamp_ms")
+        val DEGRADED_MODE = booleanPreferencesKey("degraded_mode")
+        val DEGRADED_REASON = stringPreferencesKey("degraded_reason")
+    }
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/state/SettingsState.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/state/SettingsState.kt
@@ -25,6 +25,13 @@ enum class GraphType {
     PowerDraw,
 }
 
+data class ServiceHealthUiState(
+    val lastSensorTimestampMs: Long? = null,
+    val lastApplyTimestampMs: Long? = null,
+    val degradedMode: Boolean = false,
+    val degradedReason: String? = null,
+)
+
 data class GraphState(
     val points: Map<GraphType, List<Float>> = GraphType.entries.associateWith {
         List(24) { i -> ((i % 10) + 1) / 10f }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/state/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/state/SettingsViewModel.kt
@@ -1,20 +1,22 @@
 package com.tideo.autobrightness.app.state
 
 import android.app.Application
-import androidx.datastore.preferences.preferencesDataStore
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.tideo.autobrightness.app.runtime.AutoBrightnessRuntime
+import com.tideo.autobrightness.app.runtime.ServiceHealthStore
 import com.tideo.autobrightness.app.settings.SettingsStore
+import com.tideo.autobrightness.app.storage.serviceHealthDataStore
+import com.tideo.autobrightness.app.storage.settingsDataStore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-private val Application.dataStore by preferencesDataStore(name = "auto_brightness_settings")
-
 class SettingsViewModel(application: Application) : AndroidViewModel(application) {
-    private val settingsStore = SettingsStore(application.dataStore)
+    private val settingsStore = SettingsStore(application.settingsDataStore)
+    private val healthStore = ServiceHealthStore(application.serviceHealthDataStore)
 
     private val mutableState = MutableStateFlow(SettingsState())
     val state: StateFlow<SettingsState> = mutableState.asStateFlow()
@@ -22,13 +24,30 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     private val mutableGraphState = MutableStateFlow(GraphState())
     val graphState: StateFlow<GraphState> = mutableGraphState.asStateFlow()
 
+    private val mutableHealthState = MutableStateFlow(ServiceHealthUiState())
+    val healthState: StateFlow<ServiceHealthUiState> = mutableHealthState.asStateFlow()
+
     init {
         viewModelScope.launch {
             mutableState.value = settingsStore.readSettings()
         }
+        viewModelScope.launch {
+            healthStore.telemetry.collect { telemetry ->
+                mutableHealthState.value = ServiceHealthUiState(
+                    lastSensorTimestampMs = telemetry.lastSensorTimestampMs,
+                    lastApplyTimestampMs = telemetry.lastApplyTimestampMs,
+                    degradedMode = telemetry.degradedMode,
+                    degradedReason = telemetry.degradedReason,
+                )
+            }
+        }
     }
 
-    fun setEnabled(enabled: Boolean) = mutate { copy(enabled = enabled) }
+    fun setEnabled(enabled: Boolean) {
+        mutate { copy(enabled = enabled) }
+        AutoBrightnessRuntime.onSettingChanged(getApplication(), enabled)
+    }
+
     fun updateBrightness(min: Float, max: Float) = mutate { copy(minBrightness = min, maxBrightness = max) }
     fun updateDimming(group: SettingGroup) = mutate { copy(dimming = group) }
     fun updateReactivity(group: SettingGroup) = mutate { copy(reactivity = group) }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/storage/AppDataStores.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/storage/AppDataStores.kt
@@ -1,0 +1,7 @@
+package com.tideo.autobrightness.app.storage
+
+import android.content.Context
+import androidx.datastore.preferences.preferencesDataStore
+
+val Context.settingsDataStore by preferencesDataStore(name = "auto_brightness_settings")
+val Context.serviceHealthDataStore by preferencesDataStore(name = "service_health")

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/DashboardScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/DashboardScreen.kt
@@ -11,17 +11,27 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.tideo.autobrightness.app.navigation.Routes
+import com.tideo.autobrightness.app.state.ServiceHealthUiState
 import com.tideo.autobrightness.app.state.SettingsState
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 @Composable
 fun DashboardScreen(
     navController: NavHostController,
     state: SettingsState,
+    healthState: ServiceHealthUiState,
     onToggle: (Boolean) -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         Text("Auto Brightness")
         Switch(checked = state.enabled, onCheckedChange = onToggle)
+        Text("Last sensor sample: ${healthState.lastSensorTimestampMs.toHumanTime()}")
+        Text("Last brightness apply: ${healthState.lastApplyTimestampMs.toHumanTime()}")
+        Text("Degraded mode: ${if (healthState.degradedMode) "Yes" else "No"}")
+        healthState.degradedReason?.let { Text("Reason: $it") }
+
         Button(onClick = { navController.navigate(Routes.BrightnessSettings) }) { Text("Brightness Settings") }
         Button(onClick = { navController.navigate(Routes.Dimming) }) { Text("Dimming") }
         Button(onClick = { navController.navigate(Routes.Reactivity) }) { Text("Reactivity") }
@@ -34,4 +44,11 @@ fun DashboardScreen(
         Button(onClick = { navController.navigate(Routes.GraphTaper) }) { Text("Taper Graph") }
         Button(onClick = { navController.navigate(Routes.GraphPowerDraw) }) { Text("Power Draw Graph") }
     }
+}
+
+private fun Long?.toHumanTime(): String {
+    if (this == null) return "Never"
+    return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(
+        Instant.ofEpochMilli(this).atZone(ZoneId.systemDefault()).toLocalDateTime(),
+    )
 }

--- a/domain/src/main/kotlin/com/tideo/autobrightness/domain/EvaluateAndApplyBrightnessUseCase.kt
+++ b/domain/src/main/kotlin/com/tideo/autobrightness/domain/EvaluateAndApplyBrightnessUseCase.kt
@@ -1,5 +1,11 @@
 package com.tideo.autobrightness.domain
 
+data class BrightnessEvaluationResult(
+    val target: Int? = null,
+    val sampledLux: Float? = null,
+    val applied: Boolean = false,
+)
+
 class EvaluateAndApplyBrightnessUseCase(
     private val luxSource: AmbientLuxSource,
     private val contextProvider: ContextProvider,
@@ -8,19 +14,20 @@ class EvaluateAndApplyBrightnessUseCase(
     private val brightnessApplier: BrightnessApplier,
     private val overlayController: OverlayController,
 ) {
-    fun run(): Int? {
+    fun run(): BrightnessEvaluationResult {
         if (!permissionStateProvider.canAdjustSystemBrightness()) {
             overlayController.showPausedBanner("Missing system write permission")
-            return null
+            return BrightnessEvaluationResult(applied = false)
         }
 
+        val sampledLux = luxSource.currentLux()
         val target = engine.computeTarget(
-            lux = luxSource.currentLux(),
+            lux = sampledLux,
             context = contextProvider.currentContext(),
         )
 
         brightnessApplier.apply(target)
         overlayController.hidePausedBanner()
-        return target
+        return BrightnessEvaluationResult(target = target, sampledLux = sampledLux, applied = true)
     }
 }


### PR DESCRIPTION
### Motivation
- Provide continuous ambient-lux monitoring while the feature is enabled by running a resilient foreground service and recover when possible. 
- Run periodic maintenance and reinitialization to recover from OS/background restrictions using `WorkManager`.
- React to device lifecycle events (`screen on/off`, `boot`) via broadcast receivers to start/stop or re-bootstrap sensing.
- Surface service health (last sensor sample, last apply, degraded state/reason) to aid debugging and user trust and degrade gracefully when system restrictions prevent continuous sensing.

### Description
- Added `AmbientMonitoringService` as a foreground `Service` that runs a sampling loop, posts an ongoing notification, and records telemetry to `ServiceHealthStore` on each iteration. 
- Added `AutoBrightnessRuntime` to `bootstrap` on app start, schedule a periodic `MaintenanceWorker`, and start/stop the service with graceful degradation when foreground starts are blocked. 
- Implemented `MaintenanceWorker`, `BootCompletedReceiver`, and `ScreenStateReceiver` to periodically reinitialize and to react to `BOOT_COMPLETED` and screen state changes. 
- Introduced `ServiceHealthStore` and `AppDataStores` (DataStore bindings) and wired telemetry into `SettingsViewModel` and the `DashboardScreen` UI, plus updated the domain use case `EvaluateAndApplyBrightnessUseCase` to return a `BrightnessEvaluationResult` so the runtime can record `sampledLux` and `applied` reliably. 
- Updated `AndroidManifest.xml` to declare the service and receivers and added `WorkManager`/core dependencies in `app/build.gradle.kts`.

### Testing
- Attempted to run `gradle :app:assembleDebug :domain:test` in this environment but the build/tests failed due to a Java/Android toolchain mismatch (`25.0.1`), so full compile/test verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edaa648cb88321be02843d0c00286e)