### PR TITLE
Add typed AabSettings DataStore, profile import/export, and legacy Tasker migration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     kotlin("android")
+    id("org.jetbrains.kotlin.plugin.serialization")
 }
 
 android {
@@ -45,5 +46,7 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:2.8.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.4")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.4")
+    implementation("androidx.datastore:datastore:1.1.1")
     implementation("androidx.datastore:datastore-preferences:1.1.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
 }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/AabSettings.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/AabSettings.kt
@@ -1,0 +1,104 @@
+package com.tideo.autobrightness.app.settings
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AabSettings(
+    val schemaVersion: Int = CURRENT_SCHEMA_VERSION,
+    val serviceEnabled: Boolean = true,
+    val detectOverrides: Boolean = false,
+    val minBrightness: Int = 10,
+    val maxBrightness: Int = 255,
+    val offset: Int = 0,
+    val scale: Int = 1,
+    val zone1End: Int = 35,
+    val zone2End: Int = 10_000,
+    val form1A: Int = 5,
+    val form2B: Float = 8.8f,
+    val form2C: Int = 18,
+    val dimmingEnabled: Boolean = false,
+    val dimmingStrength: Int = 25,
+    val dimmingExponent: Float = 2.5f,
+    val dimmingThreshold: Int = 15,
+    val dimSpread: Int = 100,
+    val pwmSensitive: Boolean = false,
+    val pwmExponent: Float = 0.8f,
+    val throttleDefaultMs: Long = 1_000,
+    val minWaitMs: Int = 25,
+    val maxWaitMs: Int = 65,
+    val deltaFactor: Float = 1.8f,
+    val thresholdBright: Float = 0.08f,
+    val thresholdDark: Float = 0.3f,
+    val thresholdDim: Float = 0.25f,
+    val thresholdDynamic: Int = 5,
+    val thresholdSteepness: Float = 2.1f,
+    val scalingEnabled: Boolean = false,
+    val scaleSpread: Int = 15,
+    val scaleSteepness: Int = 6,
+    val scaleTaperMidpoint: Int = 190,
+    val scaleTaperSteepness: Float = 0.075f,
+    val scaleTransitionFactor: Float = 0.1f,
+    val trustUnreliableSensor: Boolean = false,
+    val quickSettingsEnabled: Boolean = false,
+    val notificationsEnabled: Boolean = true,
+    val debugLevel: Int = 0,
+)
+
+const val CURRENT_SCHEMA_VERSION = 1
+
+enum class AabValueType {
+    Boolean,
+    Int,
+    Long,
+    Float,
+}
+
+data class AabSettingRule(
+    val taskerVariable: String,
+    val key: String,
+    val type: AabValueType,
+    val defaultValue: String,
+    val validation: String,
+)
+
+object AabSettingsContract {
+    val rules: List<AabSettingRule> = listOf(
+        AabSettingRule("%AAB_Service", "serviceEnabled", AabValueType.Boolean, "true", "must be true|false"),
+        AabSettingRule("%AAB_DetectOverrides", "detectOverrides", AabValueType.Boolean, "false", "must be true|false"),
+        AabSettingRule("%AAB_MinBright", "minBrightness", AabValueType.Int, "10", "range 1..255"),
+        AabSettingRule("%AAB_MaxBright", "maxBrightness", AabValueType.Int, "255", "range 1..255 and >= minBrightness"),
+        AabSettingRule("%AAB_Offset", "offset", AabValueType.Int, "0", "range -255..255"),
+        AabSettingRule("%AAB_Scale", "scale", AabValueType.Int, "1", "range 1..10"),
+        AabSettingRule("%AAB_Zone1End", "zone1End", AabValueType.Int, "35", "range 1..20000"),
+        AabSettingRule("%AAB_Zone2End", "zone2End", AabValueType.Int, "10000", "range 1..100000 and >= zone1End"),
+        AabSettingRule("%AAB_Form1A", "form1A", AabValueType.Int, "5", "range 1..20"),
+        AabSettingRule("%AAB_Form2B", "form2B", AabValueType.Float, "8.8", "range 0.1..30.0"),
+        AabSettingRule("%AAB_Form2C", "form2C", AabValueType.Int, "18", "range 1..50"),
+        AabSettingRule("%AAB_DimmingEnabled", "dimmingEnabled", AabValueType.Boolean, "false", "must be true|false"),
+        AabSettingRule("%AAB_DimmingStrength", "dimmingStrength", AabValueType.Int, "25", "range 0..100"),
+        AabSettingRule("%AAB_DimmingExponent", "dimmingExponent", AabValueType.Float, "2.5", "range 0.5..5.0"),
+        AabSettingRule("%AAB_DimmingThreshold", "dimmingThreshold", AabValueType.Int, "15", "range 0..100"),
+        AabSettingRule("%AAB_DimSpread", "dimSpread", AabValueType.Int, "100", "range 1..300"),
+        AabSettingRule("%AAB_PWMSensitive", "pwmSensitive", AabValueType.Boolean, "false", "must be true|false"),
+        AabSettingRule("%AAB_PWMExp", "pwmExponent", AabValueType.Float, "0.8", "range 0.1..3.0"),
+        AabSettingRule("%AAB_DefaultThrottle", "throttleDefaultMs", AabValueType.Long, "1000", "range 100..60000"),
+        AabSettingRule("%AAB_MinWait", "minWaitMs", AabValueType.Int, "25", "range 1..5000"),
+        AabSettingRule("%AAB_MaxWait", "maxWaitMs", AabValueType.Int, "65", "range 1..5000 and >= minWaitMs"),
+        AabSettingRule("%AAB_DeltaFactor", "deltaFactor", AabValueType.Float, "1.8", "range 0.1..10.0"),
+        AabSettingRule("%AAB_ThreshBright", "thresholdBright", AabValueType.Float, "0.08", "range 0.0..1.0"),
+        AabSettingRule("%AAB_ThreshDark", "thresholdDark", AabValueType.Float, "0.3", "range 0.0..1.0"),
+        AabSettingRule("%AAB_ThreshDim", "thresholdDim", AabValueType.Float, "0.25", "range 0.0..1.0"),
+        AabSettingRule("%AAB_ThreshDynamic", "thresholdDynamic", AabValueType.Int, "5", "range 1..20"),
+        AabSettingRule("%AAB_ThreshSteepness", "thresholdSteepness", AabValueType.Float, "2.1", "range 0.1..10.0"),
+        AabSettingRule("%AAB_ScalingUse", "scalingEnabled", AabValueType.Boolean, "false", "must be true|false"),
+        AabSettingRule("%AAB_ScaleSpread", "scaleSpread", AabValueType.Int, "15", "range 1..100"),
+        AabSettingRule("%AAB_ScaleSteepness", "scaleSteepness", AabValueType.Int, "6", "range 1..20"),
+        AabSettingRule("%AAB_ScaleTaperMidpoint", "scaleTaperMidpoint", AabValueType.Int, "190", "range 1..255"),
+        AabSettingRule("%AAB_ScaleTaperSteepness", "scaleTaperSteepness", AabValueType.Float, "0.075", "range 0.001..1.0"),
+        AabSettingRule("%AAB_ScaleTransitionFactor", "scaleTransitionFactor", AabValueType.Float, "0.1", "range 0.0..1.0"),
+        AabSettingRule("%AAB_TrustUnreliable", "trustUnreliableSensor", AabValueType.Boolean, "false", "must be true|false"),
+        AabSettingRule("%AAB_QSUse", "quickSettingsEnabled", AabValueType.Boolean, "false", "must be true|false"),
+        AabSettingRule("%AAB_NotifyUse", "notificationsEnabled", AabValueType.Boolean, "true", "must be true|false"),
+        AabSettingRule("%AAB_Debug", "debugLevel", AabValueType.Int, "0", "range 0..5"),
+    )
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/AabSettingsMapper.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/AabSettingsMapper.kt
@@ -1,0 +1,60 @@
+package com.tideo.autobrightness.app.settings
+
+import com.tideo.autobrightness.app.state.SettingsState
+
+object AabSettingsMapper {
+    fun toUiState(settings: AabSettings): SettingsState {
+        return SettingsState(
+            enabled = settings.serviceEnabled,
+            minBrightness = (settings.minBrightness / 255f).coerceIn(0f, 1f),
+            maxBrightness = (settings.maxBrightness / 255f).coerceIn(0f, 1f),
+        )
+    }
+
+    fun fromUiState(uiState: SettingsState, current: AabSettings): AabSettings {
+        val min = (uiState.minBrightness.coerceIn(0f, 1f) * 255).toInt().coerceIn(1, 255)
+        val max = (uiState.maxBrightness.coerceIn(0f, 1f) * 255).toInt().coerceIn(min, 255)
+        return current.copy(
+            serviceEnabled = uiState.enabled,
+            minBrightness = min,
+            maxBrightness = max,
+        )
+    }
+}
+
+fun AabSettings.validate(): AabSettings {
+    val clampedMinBrightness = minBrightness.coerceIn(1, 255)
+    val clampedZone1End = zone1End.coerceIn(1, 20_000)
+    val clampedMinWait = minWaitMs.coerceIn(1, 5_000)
+    return copy(
+        minBrightness = clampedMinBrightness,
+        maxBrightness = maxBrightness.coerceIn(clampedMinBrightness, 255),
+        offset = offset.coerceIn(-255, 255),
+        scale = scale.coerceIn(1, 10),
+        zone1End = clampedZone1End,
+        zone2End = zone2End.coerceIn(clampedZone1End, 100_000),
+        form1A = form1A.coerceIn(1, 20),
+        form2B = form2B.coerceIn(0.1f, 30f),
+        form2C = form2C.coerceIn(1, 50),
+        dimmingStrength = dimmingStrength.coerceIn(0, 100),
+        dimmingExponent = dimmingExponent.coerceIn(0.5f, 5f),
+        dimmingThreshold = dimmingThreshold.coerceIn(0, 100),
+        dimSpread = dimSpread.coerceIn(1, 300),
+        pwmExponent = pwmExponent.coerceIn(0.1f, 3f),
+        throttleDefaultMs = throttleDefaultMs.coerceIn(100, 60_000),
+        minWaitMs = clampedMinWait,
+        maxWaitMs = maxWaitMs.coerceIn(clampedMinWait, 5_000),
+        deltaFactor = deltaFactor.coerceIn(0.1f, 10f),
+        thresholdBright = thresholdBright.coerceIn(0f, 1f),
+        thresholdDark = thresholdDark.coerceIn(0f, 1f),
+        thresholdDim = thresholdDim.coerceIn(0f, 1f),
+        thresholdDynamic = thresholdDynamic.coerceIn(1, 20),
+        thresholdSteepness = thresholdSteepness.coerceIn(0.1f, 10f),
+        scaleSpread = scaleSpread.coerceIn(1, 100),
+        scaleSteepness = scaleSteepness.coerceIn(1, 20),
+        scaleTaperMidpoint = scaleTaperMidpoint.coerceIn(1, 255),
+        scaleTaperSteepness = scaleTaperSteepness.coerceIn(0.001f, 1f),
+        scaleTransitionFactor = scaleTransitionFactor.coerceIn(0f, 1f),
+        debugLevel = debugLevel.coerceIn(0, 5),
+    )
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/AabSettingsSerializer.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/AabSettingsSerializer.kt
@@ -1,0 +1,25 @@
+package com.tideo.autobrightness.app.settings
+
+import androidx.datastore.core.Serializer
+import java.io.InputStream
+import java.io.OutputStream
+import kotlinx.serialization.json.Json
+
+object AabSettingsSerializer : Serializer<AabSettings> {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        prettyPrint = true
+    }
+
+    override val defaultValue: AabSettings = AabSettings()
+
+    override suspend fun readFrom(input: InputStream): AabSettings {
+        return runCatching {
+            json.decodeFromString(AabSettings.serializer(), input.readBytes().decodeToString())
+        }.getOrDefault(defaultValue)
+    }
+
+    override suspend fun writeTo(t: AabSettings, output: OutputStream) {
+        output.write(json.encodeToString(AabSettings.serializer(), t).encodeToByteArray())
+    }
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ProfileImportExportManager.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ProfileImportExportManager.kt
@@ -1,0 +1,62 @@
+package com.tideo.autobrightness.app.settings
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import java.io.FileNotFoundException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+class ProfileImportExportManager(
+    private val context: Context,
+) {
+    private val json = Json { ignoreUnknownKeys = true; prettyPrint = true }
+
+    suspend fun exportToAppPrivate(profileName: String, settings: AabSettings): String {
+        val fileName = sanitizeFileName(profileName)
+        context.openFileOutput(fileName, Context.MODE_PRIVATE).use { output ->
+            output.write(json.encodeToString(AabProfilePayload.serializer(), AabProfilePayload(settings.validate())).encodeToByteArray())
+        }
+        return fileName
+    }
+
+    suspend fun exportToDocument(uri: Uri, settings: AabSettings, resolver: ContentResolver = context.contentResolver) {
+        resolver.openOutputStream(uri)?.use { output ->
+            output.write(json.encodeToString(AabProfilePayload.serializer(), AabProfilePayload(settings.validate())).encodeToByteArray())
+        } ?: throw FileNotFoundException("Unable to open output stream for uri=$uri")
+    }
+
+    suspend fun importFromAppPrivate(profileName: String): AabSettings {
+        val content = context.openFileInput(sanitizeFileName(profileName)).bufferedReader().use { it.readText() }
+        return decodePayload(content)
+    }
+
+    suspend fun importFromDocument(uri: Uri, resolver: ContentResolver = context.contentResolver): AabSettings {
+        val content = resolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
+            ?: throw FileNotFoundException("Unable to open input stream for uri=$uri")
+        return decodePayload(content)
+    }
+
+    fun importLegacyTaskerProfile(rawLegacyValues: String): AabSettings {
+        return TaskerLegacyProfileSerializer.deserialize(rawLegacyValues)
+    }
+
+    private fun decodePayload(content: String): AabSettings {
+        return runCatching {
+            json.decodeFromString(AabProfilePayload.serializer(), content).settings.validate()
+        }.getOrElse {
+            TaskerLegacyProfileSerializer.deserialize(content)
+        }
+    }
+
+    private fun sanitizeFileName(profileName: String): String {
+        val safeName = profileName.trim().replace(Regex("[^a-zA-Z0-9._-]"), "_")
+        return if (safeName.endsWith(".json")) safeName else "$safeName.json"
+    }
+}
+
+@Serializable
+private data class AabProfilePayload(
+    val schemaVersion: Int = CURRENT_SCHEMA_VERSION,
+    val settings: AabSettings,
+)

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/SettingsStore.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/SettingsStore.kt
@@ -1,45 +1,35 @@
 package com.tideo.autobrightness.app.settings
 
 import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.booleanPreferencesKey
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.floatPreferencesKey
 import com.tideo.autobrightness.app.state.SettingsState
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
 
 /**
- * DataStore-backed setting persistence replacing Tasker variables/scenes.
+ * Typed DataStore-backed setting persistence replacing Tasker variables/scenes.
  */
 class SettingsStore(
-    private val dataStore: DataStore<Preferences>? = null,
+    private val dataStore: DataStore<AabSettings>? = null,
 ) {
     suspend fun readSettings(): SettingsState {
         val store = dataStore ?: return SettingsState()
-        return store.data
-            .map { prefs ->
-                SettingsState(
-                    enabled = prefs[ENABLED] ?: true,
-                    minBrightness = prefs[MIN_BRIGHTNESS] ?: 0.05f,
-                    maxBrightness = prefs[MAX_BRIGHTNESS] ?: 1f,
-                )
-            }
-            .first()
+        val settings = store.data.first().validate()
+        return AabSettingsMapper.toUiState(settings)
     }
 
     suspend fun writeSettings(settings: SettingsState) {
         val store = dataStore ?: return
-        store.edit { prefs ->
-            prefs[ENABLED] = settings.enabled
-            prefs[MIN_BRIGHTNESS] = settings.minBrightness
-            prefs[MAX_BRIGHTNESS] = settings.maxBrightness
+        store.updateData { current ->
+            AabSettingsMapper.fromUiState(settings, current).validate()
         }
     }
 
-    private companion object {
-        val ENABLED = booleanPreferencesKey("enabled")
-        val MIN_BRIGHTNESS = floatPreferencesKey("min_brightness")
-        val MAX_BRIGHTNESS = floatPreferencesKey("max_brightness")
+    suspend fun readRawSettings(): AabSettings {
+        val store = dataStore ?: return AabSettings()
+        return store.data.first().validate()
+    }
+
+    suspend fun writeRawSettings(settings: AabSettings) {
+        val store = dataStore ?: return
+        store.updateData { settings.validate() }
     }
 }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/TaskerLegacyProfileSerializer.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/TaskerLegacyProfileSerializer.kt
@@ -1,0 +1,66 @@
+package com.tideo.autobrightness.app.settings
+
+object TaskerLegacyProfileSerializer {
+    private val trueValues = setOf("true", "on", "1")
+
+    fun deserialize(raw: String): AabSettings {
+        val map = raw
+            .lineSequence()
+            .map { it.trim() }
+            .filter { it.startsWith("%AAB_") && it.contains('=') }
+            .associate { line ->
+                val index = line.indexOf('=')
+                line.substring(0, index).trim() to line.substring(index + 1).trim()
+            }
+
+        var settings = AabSettings()
+
+        map["%AAB_Service"]?.let { settings = settings.copy(serviceEnabled = it.asBoolean(settings.serviceEnabled)) }
+        map["%AAB_DetectOverrides"]?.let { settings = settings.copy(detectOverrides = it.asBoolean(settings.detectOverrides)) }
+        map["%AAB_MinBright"]?.toIntOrNull()?.let { settings = settings.copy(minBrightness = it) }
+        map["%AAB_MaxBright"]?.toIntOrNull()?.let { settings = settings.copy(maxBrightness = it) }
+        map["%AAB_Offset"]?.toIntOrNull()?.let { settings = settings.copy(offset = it) }
+        map["%AAB_Scale"]?.toIntOrNull()?.let { settings = settings.copy(scale = it) }
+        map["%AAB_Zone1End"]?.toIntOrNull()?.let { settings = settings.copy(zone1End = it) }
+        map["%AAB_Zone2End"]?.toIntOrNull()?.let { settings = settings.copy(zone2End = it) }
+        map["%AAB_Form1A"]?.toIntOrNull()?.let { settings = settings.copy(form1A = it) }
+        map["%AAB_Form2B"]?.toFloatOrNull()?.let { settings = settings.copy(form2B = it) }
+        map["%AAB_Form2C"]?.toIntOrNull()?.let { settings = settings.copy(form2C = it) }
+        map["%AAB_DimmingEnabled"]?.let { settings = settings.copy(dimmingEnabled = it.asBoolean(settings.dimmingEnabled)) }
+        map["%AAB_DimmingStrength"]?.toIntOrNull()?.let { settings = settings.copy(dimmingStrength = it) }
+        map["%AAB_DimmingExponent"]?.toFloatOrNull()?.let { settings = settings.copy(dimmingExponent = it) }
+        map["%AAB_DimmingThreshold"]?.toIntOrNull()?.let { settings = settings.copy(dimmingThreshold = it) }
+        map["%AAB_DimSpread"]?.toIntOrNull()?.let { settings = settings.copy(dimSpread = it) }
+        map["%AAB_PWMSensitive"]?.let { settings = settings.copy(pwmSensitive = it.asBoolean(settings.pwmSensitive)) }
+        map["%AAB_PWMExp"]?.toFloatOrNull()?.let { settings = settings.copy(pwmExponent = it) }
+        map["%AAB_DefaultThrottle"]?.toLongOrNull()?.let { settings = settings.copy(throttleDefaultMs = it) }
+        map["%AAB_MinWait"]?.toIntOrNull()?.let { settings = settings.copy(minWaitMs = it) }
+        map["%AAB_MaxWait"]?.toIntOrNull()?.let { settings = settings.copy(maxWaitMs = it) }
+        map["%AAB_DeltaFactor"]?.toFloatOrNull()?.let { settings = settings.copy(deltaFactor = it) }
+        map["%AAB_ThreshBright"]?.toFloatOrNull()?.let { settings = settings.copy(thresholdBright = it) }
+        map["%AAB_ThreshDark"]?.toFloatOrNull()?.let { settings = settings.copy(thresholdDark = it) }
+        map["%AAB_ThreshDim"]?.toFloatOrNull()?.let { settings = settings.copy(thresholdDim = it) }
+        map["%AAB_ThreshDynamic"]?.toIntOrNull()?.let { settings = settings.copy(thresholdDynamic = it) }
+        map["%AAB_ThreshSteepness"]?.toFloatOrNull()?.let { settings = settings.copy(thresholdSteepness = it) }
+        map["%AAB_ScalingUse"]?.let { settings = settings.copy(scalingEnabled = it.asBoolean(settings.scalingEnabled)) }
+        map["%AAB_ScaleSpread"]?.toIntOrNull()?.let { settings = settings.copy(scaleSpread = it) }
+        map["%AAB_ScaleSteepness"]?.toIntOrNull()?.let { settings = settings.copy(scaleSteepness = it) }
+        map["%AAB_ScaleTaperMidpoint"]?.toIntOrNull()?.let { settings = settings.copy(scaleTaperMidpoint = it) }
+        map["%AAB_ScaleTaperSteepness"]?.toFloatOrNull()?.let { settings = settings.copy(scaleTaperSteepness = it) }
+        map["%AAB_ScaleTransitionFactor"]?.toFloatOrNull()?.let { settings = settings.copy(scaleTransitionFactor = it) }
+        map["%AAB_TrustUnreliable"]?.let { settings = settings.copy(trustUnreliableSensor = it.asBoolean(settings.trustUnreliableSensor)) }
+        map["%AAB_QSUse"]?.let { settings = settings.copy(quickSettingsEnabled = it.asBoolean(settings.quickSettingsEnabled)) }
+        map["%AAB_NotifyUse"]?.let { settings = settings.copy(notificationsEnabled = it.asBoolean(settings.notificationsEnabled)) }
+        map["%AAB_Debug"]?.toIntOrNull()?.let { settings = settings.copy(debugLevel = it) }
+
+        return settings.validate()
+    }
+
+    private fun String.asBoolean(default: Boolean): Boolean {
+        return when (trim().lowercase()) {
+            in trueValues -> true
+            "false", "off", "0" -> false
+            else -> default
+        }
+    }
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/storage/AppDataStores.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/storage/AppDataStores.kt
@@ -1,7 +1,14 @@
 package com.tideo.autobrightness.app.storage
 
 import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.dataStore
 import androidx.datastore.preferences.preferencesDataStore
+import com.tideo.autobrightness.app.settings.AabSettings
+import com.tideo.autobrightness.app.settings.AabSettingsSerializer
 
-val Context.settingsDataStore by preferencesDataStore(name = "auto_brightness_settings")
+val Context.settingsDataStore: DataStore<AabSettings> by dataStore(
+    fileName = "aab_settings.json",
+    serializer = AabSettingsSerializer,
+)
 val Context.serviceHealthDataStore by preferencesDataStore(name = "service_health")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     kotlin("android") version "1.9.24" apply false
     kotlin("jvm") version "1.9.24" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "1.9.24" apply false
     id("com.android.application") version "8.5.2" apply false
 }
 

--- a/docs/migration/aab_settings_schema.md
+++ b/docs/migration/aab_settings_schema.md
@@ -1,0 +1,55 @@
+# AabSettings DataStore Schema
+
+Typed profile schema lives in `AabSettings` and stores migrated Tasker settings in app-private DataStore.
+
+## `%AAB_*` variable map
+
+| Tasker variable | Key | Type | Default | Validation |
+|---|---|---|---|---|
+| `%AAB_Service` | `serviceEnabled` | Boolean | `true` | must be true/false |
+| `%AAB_DetectOverrides` | `detectOverrides` | Boolean | `false` | must be true/false |
+| `%AAB_MinBright` | `minBrightness` | Int | `10` | `1..255` |
+| `%AAB_MaxBright` | `maxBrightness` | Int | `255` | `1..255`, `>= minBrightness` |
+| `%AAB_Offset` | `offset` | Int | `0` | `-255..255` |
+| `%AAB_Scale` | `scale` | Int | `1` | `1..10` |
+| `%AAB_Zone1End` | `zone1End` | Int | `35` | `1..20000` |
+| `%AAB_Zone2End` | `zone2End` | Int | `10000` | `1..100000`, `>= zone1End` |
+| `%AAB_Form1A` | `form1A` | Int | `5` | `1..20` |
+| `%AAB_Form2B` | `form2B` | Float | `8.8` | `0.1..30.0` |
+| `%AAB_Form2C` | `form2C` | Int | `18` | `1..50` |
+| `%AAB_DimmingEnabled` | `dimmingEnabled` | Boolean | `false` | must be true/false |
+| `%AAB_DimmingStrength` | `dimmingStrength` | Int | `25` | `0..100` |
+| `%AAB_DimmingExponent` | `dimmingExponent` | Float | `2.5` | `0.5..5.0` |
+| `%AAB_DimmingThreshold` | `dimmingThreshold` | Int | `15` | `0..100` |
+| `%AAB_DimSpread` | `dimSpread` | Int | `100` | `1..300` |
+| `%AAB_PWMSensitive` | `pwmSensitive` | Boolean | `false` | must be true/false |
+| `%AAB_PWMExp` | `pwmExponent` | Float | `0.8` | `0.1..3.0` |
+| `%AAB_DefaultThrottle` | `throttleDefaultMs` | Long | `1000` | `100..60000` |
+| `%AAB_MinWait` | `minWaitMs` | Int | `25` | `1..5000` |
+| `%AAB_MaxWait` | `maxWaitMs` | Int | `65` | `1..5000`, `>= minWaitMs` |
+| `%AAB_DeltaFactor` | `deltaFactor` | Float | `1.8` | `0.1..10.0` |
+| `%AAB_ThreshBright` | `thresholdBright` | Float | `0.08` | `0.0..1.0` |
+| `%AAB_ThreshDark` | `thresholdDark` | Float | `0.3` | `0.0..1.0` |
+| `%AAB_ThreshDim` | `thresholdDim` | Float | `0.25` | `0.0..1.0` |
+| `%AAB_ThreshDynamic` | `thresholdDynamic` | Int | `5` | `1..20` |
+| `%AAB_ThreshSteepness` | `thresholdSteepness` | Float | `2.1` | `0.1..10.0` |
+| `%AAB_ScalingUse` | `scalingEnabled` | Boolean | `false` | must be true/false |
+| `%AAB_ScaleSpread` | `scaleSpread` | Int | `15` | `1..100` |
+| `%AAB_ScaleSteepness` | `scaleSteepness` | Int | `6` | `1..20` |
+| `%AAB_ScaleTaperMidpoint` | `scaleTaperMidpoint` | Int | `190` | `1..255` |
+| `%AAB_ScaleTaperSteepness` | `scaleTaperSteepness` | Float | `0.075` | `0.001..1.0` |
+| `%AAB_ScaleTransitionFactor` | `scaleTransitionFactor` | Float | `0.1` | `0.0..1.0` |
+| `%AAB_TrustUnreliable` | `trustUnreliableSensor` | Boolean | `false` | must be true/false |
+| `%AAB_QSUse` | `quickSettingsEnabled` | Boolean | `false` | must be true/false |
+| `%AAB_NotifyUse` | `notificationsEnabled` | Boolean | `true` | must be true/false |
+| `%AAB_Debug` | `debugLevel` | Int | `0` | `0..5` |
+
+Legacy migration parser accepts Tasker-style lines:
+
+```
+%AAB_Service=On
+%AAB_MinBright=12
+%AAB_MaxBright=255
+```
+
+Then normalizes and validates into native `AabSettings`.


### PR DESCRIPTION
### Motivation
- Replace the existing untyped preferences/Tasker-variable approach with a versioned, typed profile schema so settings are validated, discoverable, and portable as user profiles. 
- Allow users to import/export profiles safely using app-private storage and SAF document URIs instead of assuming arbitrary filesystem access. 
- Provide a migration path to convert legacy Tasker-exported `%AAB_*` lines into the new native schema.

### Description
- Introduce a typed schema `AabSettings` with a `AabSettingsContract` mapping each `%AAB_*` variable to `key`, `type`, `default`, and `validation` rules in `app/src/main/kotlin/com/tideo/autobrightness/app/settings/AabSettings.kt`.
- Add JSON `Serializer` for typed DataStore as `AabSettingsSerializer` and wire a `DataStore<AabSettings>` instance in `AppDataStores` using `dataStore(fileName=..., serializer=...)`.
- Replace the untyped `SettingsStore` to read/write `AabSettings` via typed DataStore and provide mapping helpers `AabSettingsMapper` plus a `validate()` normalizer that clamps ranges and enforces cross-field constraints (e.g. `max >= min`).
- Implement `ProfileImportExportManager` to export/import profiles to app-private files and to SAF document `Uri`s, encoding profiles as a small JSON payload containing schema version and settings.
- Implement `TaskerLegacyProfileSerializer` to parse legacy Tasker-style `%AAB_*=` exports and convert them into validated `AabSettings` for migration.
- Add `docs/migration/aab_settings_schema.md` documenting the `%AAB_*`→schema mapping and accepted legacy format, and update Gradle files to include Kotlin serialization and `datastore` dependency.

### Testing
- Attempted to run `./gradlew :app:compileDebugKotlin`, but the environment snapshot did not include `./gradlew` so the compilation could not be executed here (no automated build run succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edaf6c1b3c8321b548ce6e938863cc)