### PR TITLE
Add rebuild program scaffolding for Tasker→Kotlin conversion

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# SessionStart hook for the rebuild program: bootstraps the Android SDK (idempotent,
+# ~4 min on a cold container, instant once cached) and points the session at the
+# cross-session state files. See CLAUDE.md "Session protocol".
+set -euo pipefail
+
+# Only needed in Claude Code on the web (remote container) sessions.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+"$CLAUDE_PROJECT_DIR/scripts/setup-android-sdk.sh"
+
+echo "Android SDK ready; local.properties written."
+echo "Rebuild program: read docs/rebuild/STATE.md first, then your segment brief in docs/rebuild/RUNBOOK.md (protocol in CLAUDE.md)."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(./gradlew:*)",
+      "Bash(/opt/gradle/bin/gradle:*)",
+      "Bash(scripts/setup-android-sdk.sh)",
+      "Bash(./scripts/setup-android-sdk.sh)",
+      "Bash(bash scripts/setup-android-sdk.sh)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .gradle/
 build/
 **/build/
+local.properties
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,105 @@
+# Tideo Auto Brightness — Tasker → Kotlin rebuild
+
+You are one session in a multi-session rebuild program. The program converts the Tasker project
+`Advanced_Auto_Brightness_V3.3.prj_9.xml` (repo root, 1.6 MB — **NEVER read it wholesale; use
+`docs/rebuild/XML_RECIPES.md`**) into a modern Kotlin/Compose Android app with feature parity.
+A previous AI conversion attempt was audited: parts are salvaged (see ledger below), the rest is
+rebuilt segment by segment. Work happens on branch **`claude/modest-bohr-5ybl2i`** only.
+
+## Session protocol (follow in order, every session)
+
+1. Run `scripts/setup-android-sdk.sh` if `local.properties` is missing (~4 min first time).
+   Skip for docs-only segments (S1, S2).
+2. Read `docs/rebuild/STATE.md` — segment log, deviations ledger, blockers left for you.
+3. Read YOUR segment brief in `docs/rebuild/RUNBOOK.md`. Your prompt tells you which segment
+   you are. Stay inside its scope and non-goals. Check its preconditions are DONE in STATE.md.
+4. Do the work. Consult `docs/rebuild/PARITY_CHECKLIST.md` rows you affect.
+5. Run your segment's acceptance commands until green.
+6. Update `docs/rebuild/STATE.md` (append your segment-log row, update "Current state" and
+   "Next up", add any deviations/discoveries) and flip your PARITY_CHECKLIST.md rows.
+7. Commit with message prefix `[Sx] ` and push: `git push -u origin claude/modest-bohr-5ybl2i`.
+
+**Never leave the branch red.** If acceptance cannot go green: revert source changes (or move
+them to side branch `claude/blocked-Sx`), still commit+push the STATE.md update with
+status=BLOCKED, the exact failing command, last ~30 lines of error, suspected cause, and a
+recommended next action (including whether a stronger model should retry).
+
+## Build commands
+
+```bash
+./gradlew :domain:test                  # pure-JVM engine + golden parity tests
+./gradlew :platform:test               # Robolectric adapter tests (after S3)
+./gradlew :app:testDebugUnitTest       # app unit + Robolectric tests
+./gradlew :app:assembleDebug           # APK at app/build/outputs/apk/debug/
+./gradlew :app:lintDebug               # lint vs frozen baseline (after S3)
+```
+
+Until S3 lands, NO gradle target even configures (missing pluginManagement — STATE.md D-007)
+and there is no wrapper; S3 bootstraps via `/opt/gradle/bin/gradle` (8.14.3, Java 21).
+
+## Architecture (target)
+
+- `:domain` — pure JVM/Kotlin. ALL math/decision logic. No Android imports, ever.
+  Golden-tested against a transcribed Tasker reference implementation in `domain/src/test`.
+- `:platform` — Android library (converted from pure-JVM in S3). Real system adapters behind
+  small interfaces: light sensor, brightness writer (OEM range normalization), secure-dimming
+  writer, tiered PrivilegeManager, ContentObserver override detector, battery/wifi/location/
+  foreground-app readers.
+- `:app` — Compose M3 UI (~9 screens), DataStore settings (`AabSettings`), foreground service
+  runtime (`specialUse` type), QS tile, boot receiver, notification with actions.
+- `:data` — orphaned legacy module, retired in S3. Do not add code to it.
+
+Privilege tiers: BASIC = user-grantable WRITE_SETTINGS → full core pipeline works.
+ELEVATED = WRITE_SECURE_SETTINGS via one-time `pm grant` (adb / Shizuku / root) → super
+dimming. Shizuku is used only in the grant flow, never as a runtime binder dependency.
+
+## Facts & corrections ledger (hard-won; trust these over older docs/audits)
+
+- Embedded Java = action **code 474** (40 blocks, census table in XML_RECIPES.md §R7).
+  Code 598 is Variable Search/Replace — an earlier audit confused them.
+- Java source in `arg0` is XML-entity-encoded; decode before use. Tasker substitutes `%var`
+  VALUES textually into the source pre-compile → reference transcriptions parameterize them.
+- **task661 "Map Lux to Brightness (Java) V2" contains NO Java** — runtime curve math is in
+  its Variable Set (547) maths expressions and sub-tasks. The Java 3-zone formula in task663
+  (_GenerateGraph, ~L34405) is a plot-side copy: cross-validate against it, don't port from it.
+- Profile-level `<ConditionList>` blocks are pipeline logic (prof760 holds the absolute lux
+  threshold gate + sensor-accuracy trust gate). Extract profiles, not just their enter tasks.
+- Profiles have a `ve="2"` attribute: awk pattern `/<Profile sr="prof760"/` — no closing `>`.
+- 125 distinct `%AAB_*` variables; ~37 are user-facing settings. Known schema gaps vs
+  `AabSettings.kt`: `%AAB_AnimSteps`, `%AAB_MaxSteps`, `%AAB_ThreshMidpoint` missing;
+  `AnimationConfig` defaults (50/5/30) conflict with AabSettings (25/65) — resolve via S1's
+  defaults_audit.md, not by guessing.
+- form2A / form3A are DERIVED continuity coefficients (task659 _UpdateBrightnessFormulae),
+  not stored settings.
+- prj_9 ≈ prj_4 (only _SuggestCurveParameters V23→V24), so docs/migration/ (Codex-era) is
+  not stale — but it has zero action-level or scene detail; treat as reference only.
+- Salvage KEEP list: `domain/.../brightness/BrightnessEngine.kt` (+tests),
+  `app/.../settings/AabSettings.kt`, `TaskerLegacyProfileSerializer.kt`, SettingsStore/
+  AppDataStores, module split, runtime scaffolding shapes. DISCARD list (deleted by S3/S9):
+  toy `BrightnessPolicyEngine` + `EvaluateAndApplyBrightnessUseCase` + `Ports.kt`, everything
+  in `data/`, `platform/SystemAdapters.kt` fakes, `WebViewGraphFallback`,
+  `PermissionOnboardingStateMachine`.
+- Known compile blocker until S3: `AmbientMonitoringService.kt:85` references
+  `R.mipmap.ic_launcher` but no `res/` exists.
+- Environment: no KVM → no emulator. Verification = compile + JVM/Robolectric tests; on-device
+  behavior is checked by the human at Gates 1–3 (see RUNBOOK).
+
+## Coding conventions
+
+- **Tasker semantics win over taste.** Port behavior exactly, including odd rounding
+  (3-decimal `round3`, `Math.round` tie-toward-+∞, BigDecimal HALF_UP, string-formatted
+  numbers). Modernize the *how* (coroutines, flows), never the *what*.
+- Provenance comments on ported logic: `// Tasker: task535 "Lux Smoothing (Java)" XML L15204`.
+- Golden vectors and the reference implementation are immutable test fixtures: production code
+  conforms to THEM. Changing them requires proof the extraction was wrong + a STATE.md entry.
+- No new dependencies unless your segment brief sanctions them.
+- minSdk 31, target/compile 35. No legacy API branches below 31.
+- Kotlin official code style; match existing file/package layout.
+
+## Git rules
+
+- Branch `claude/modest-bohr-5ybl2i` only. Never force-push. Never push to main.
+- Commit prefix `[Sx] `. Push with `git push -u origin claude/modest-bohr-5ybl2i`
+  (retry up to 4× with backoff 2s/4s/8s/16s on network errors only).
+- If parallel segments raced you (push rejected): `git pull --rebase origin
+  claude/modest-bohr-5ybl2i` — STATE.md conflicts are append-both-sides, trivial to merge.

--- a/docs/rebuild/PARITY_CHECKLIST.md
+++ b/docs/rebuild/PARITY_CHECKLIST.md
@@ -1,0 +1,125 @@
+# PARITY_CHECKLIST — every Tasker artifact, tracked to disposition
+
+Statuses: `pending` → `ported` (with target) / `dropped(reason)` → `device-verified` (human, Gates).
+Segments flip rows they own; S14 enforces zero `pending`; the human flips to `device-verified`.
+XML anchors: profiles/scenes verified line numbers (see XML_RECIPES.md R4/R5/R7); task anchors
+filled by S1/S2 during extraction.
+
+## Profiles (18)
+
+| Profile | XML | Ported to | Status |
+|---|---|---|---|
+| prof753 Hibernate (Display Off) → task585 | L3 | | pending |
+| prof754 Throttle Reinitialization → task566 | L16 | | pending |
+| prof755 Allow Override → task567 | L56 | | pending |
+| prof756 Repost Paused Notification → task567 | L111 | | pending |
+| prof757 Repost Foreground Notification → task584 | L156 | | pending |
+| prof758 Dynamic Scale Engine → task90 | L195 | | pending |
+| prof759 Proximity Detection → task545 | L300 | | pending |
+| prof760 Monitor Ambient Light → task554 (incl. ConditionList gate) | L318 | | pending |
+| prof761 Initialize (Display On) → task618 | L386 | | pending |
+| prof762 Context: App Changed → task43 | L398 | | pending |
+| prof763 Context: Battery Changed → task43 | L456 | | pending |
+| prof764 Context: Time Changed → task43 | L500 | | pending |
+| prof765 Context: Location Listener → task630 | L541 | | pending |
+| prof766 Context: Location Refresher → task631 | L579 | | pending |
+| prof767 Context: Location Changed → task43 | L628 | | pending |
+| prof768 Context: WiFi (Dis)connected → task43 | L676 | | pending |
+| prof769 Panic (Reset) → task528 | L722 | | pending |
+| prof8 Context: Reset Serialized Cache → task26 | L744 | | pending |
+
+## Pipeline & feature task clusters (~25)
+
+| Cluster (tasks) | XML | Ported to | Status |
+|---|---|---|---|
+| Sensor ingest: 554 Process Sensor Event | | | pending |
+| Light-change eval + thresholds: 544, 546 | | | pending |
+| Lux smoothing: 535 | | | pending |
+| Lux→brightness mapping: 661 (+663 Java cross-check) | | | pending |
+| Compressed dynamic scale: 548 | | | pending |
+| Continuity coefficients: 659 _UpdateBrightnessFormulae | | | pending |
+| Animation calc: 543 | | | pending |
+| Brightness transitions: 696, 698 | | | pending |
+| Software/super dimming: 700, 645, 646, 647, 650, 653, 654, 644 | | | pending |
+| Initial brightness on wake: 618 | | | pending |
+| Hibernate/reset: 585 | | | pending |
+| Throttle reset: 566 | | | pending |
+| Manual override detect/resume: 567, 569, 561, 640, 641, 636 | | | pending |
+| Panic reset: 528 | | | pending |
+| Init/defaults: 570 Initialize AAB Defaults | | | pending |
+| Circadian dynamic scale: 90 (+ polar handling) | | | pending |
+| Context evaluation: 43, 623, 624, 625, 626, 628, 630, 631, 633, 105, 26 | | | pending |
+| Privilege detection/grant: 378, 643, 563 | | | pending |
+| QS tile: 551, 552 | | | pending |
+| Foreground notification: 584, 692 | | | pending |
+| Curve suggestion wizard: 38, 655 | | | pending |
+| Formula validation: 583, 707 | | | pending |
+| Power draw calibration: 524 | | | pending |
+| Profiles/import/export/defaults: 592, 637, 622 | | | pending |
+| Debug tooling: 634, 635 | | | pending |
+| Misc UI plumbing tasks (scene-resize 620, exits 656, toggles 547/553/555/558/560/576/587/589/638/648/649, chartjs cache 581, logo 619, color 639/379/579/652, about/license/guide 380/401/512, updates 706, experiments 540/541/542/381/382) | | | pending |
+
+## Scenes (20) → M3 screens (~9, per S2 screen_map.md)
+
+| Scene | XML | Ported to | Status |
+|---|---|---|---|
+| AAB Menu | L4462 | | pending |
+| AAB Brightness Settings | L1415 | | pending |
+| AAB Reactivity Settings | L6739 | | pending |
+| AAB Superdimming Settings | L7533 | | pending |
+| AAB Misc Settings | L4718 | | pending |
+| AAB Experiment Settings | L3334 | | pending |
+| AAB Profile | L5724 | | pending |
+| AAB Debug Scene | L2583 | | pending |
+| AAB Color Filter | L2552 | | pending |
+| AAB Brightness Graph | L1202 | | pending |
+| AAB Alpha Graph | L1038 | | pending |
+| AAB Reactivity Graph | L6563 | | pending |
+| AAB Dimming Graph | L3006 | | pending |
+| AAB Circadian Dimming Graph | L2388 | | pending |
+| AAB Taper Graph | L8387 | | pending |
+| AAB Power Draw Graph | L5611 | | pending |
+| AAB Experiment Graph | L3170 | | pending |
+| AAB About | L799 | | pending |
+| AAB User Guide | L8551 | | pending |
+| AAB Chart.Js License | L2194 | | pending |
+
+## Java blocks (40, anchors verified — see XML_RECIPES.md R7 for the full line↔task table)
+
+| Block (task · line) | Extracted (S1/S2) | Reference impl (S4/S6) | Production port | Status |
+|---|---|---|---|---|
+| task105 L8906 · _GetWifiNoLocation | | | | pending |
+| task378 L9468 · _PrivilegeDetection | | | | pending |
+| task38 L9921 · _SuggestCurveParameters | | | | pending |
+| task43 L12091 · _EvaluateContexts | | | | pending |
+| task524 L14246 · _CalibratePowerDraw | | | | pending |
+| task535 L15204 · Lux Smoothing | | | | pending |
+| task543 L15878 · Calculate Animation | | | | pending |
+| task544 L16062 · Evaluate Light Change | | | | pending |
+| task546 L16481 · Set Thresholds | | | | pending |
+| task548 L16630 · DR Compressed Scale | | | | pending |
+| task549 L17138 · _GenerateCircadianGraph | | | | pending |
+| task554 L18132 · Process Sensor Event | | | | pending |
+| task556 L18359 · _GenerateDimmingCurveGraph | | | | pending |
+| task557 L18959 · _GenerateAlphaGraph | | | | pending |
+| task563 L19677 · _AskPermissionsV7 | | | | pending |
+| task592 L24132 · _CreateDefaultProfiles | | | | pending |
+| task618 L25826+L26096 · Set Initial Brightness (×2) | | | | pending |
+| task620 L26400 · _AdaptiveBrightnessSceneSize | | | | pending |
+| task623 L26926 · _ContextManager | | | | pending |
+| task625 L27185 · _AppPicker | | | | pending |
+| task626 L27355 · _ContextResume | | | | pending |
+| task630 L27585+L27817 · _ContextLocnListener (×2) | | | | pending |
+| task631 L27939+L28432 · _ContextF5NetLoc (×2) | | | | pending |
+| task633 L28827 · _GetWifiForContext | | | | pending |
+| task636 L28993 · _DeleteOverridePoint | | | | pending |
+| task637 L29303 · _ProfileManager | | | | pending |
+| task643 L30505 · _LearnWriteSecure | | | | pending |
+| task655 L32591 · _SetSuggestedVariables | | | | pending |
+| task657 L32986 · _GenerateCompressionGraph | | | | pending |
+| task663 L33944+L34370 · _GenerateGraph (×2) | | | | pending |
+| task696 L35733 · Smooth Brightness Transition | | | | pending |
+| task698 L36043 · Smooth DC-Like Transition | | | | pending |
+| task703 L36847 · _GenerateReactivityGraph | | | | pending |
+| task705 L37517 · _GenerateCircadianDimmingGraph | | | | pending |
+| task90 L40429+L41085 · Dynamic Scale V13 (×2) | | | | pending |

--- a/docs/rebuild/RUNBOOK.md
+++ b/docs/rebuild/RUNBOOK.md
@@ -1,0 +1,687 @@
+# RUNBOOK — segment briefs for the Tasker → Kotlin rebuild
+
+How to run a segment: start a fresh Claude Code session with the model/effort listed, prompt it
+with: *"Execute segment Sx of docs/rebuild/RUNBOOK.md"* (nothing else is required — CLAUDE.md
+routes the session through the protocol). Segments must check their **preconditions** against
+`STATE.md` and refuse to start if unmet (log a BLOCKED row instead).
+
+Models are Opus / Sonnet / Haiku at reasoning effort low / medium / high. Where a brief says
+"Opus if budget allows", Sonnet-high is acceptable.
+
+## Execution DAG
+
+```
+S0 ─┬─ S1 ─┬──────────── S4 ── S5 ─┬─ S6 ─────┐
+    ├─ S2 ─┤(S2 feeds S6,S10,S12+) ├─ S7 ─────┼─ S9 ─┬─ S10 ─┬─ S12 ── S13 ── S14
+    └─ S3 ─┴─(gates all builds)────┴─ S8 ─────┘GATE1 └─ S11 ─┘ GATE2          GATE3
+```
+
+Parallel windows (disjoint files; if raced, `git pull --rebase` before push):
+**A:** S1 ∥ S2 ∥ S3 · **B:** S6 ∥ S7 ∥ S8 (after S5; S6 also needs S2) · **C:** S10 ∥ S11 (after S9).
+Serial spine: S0 → A → S4 → S5 → B → S9 → C → S12 → S13 → S14.
+
+## Global failure protocol
+
+Referenced by every segment; defined in CLAUDE.md: never leave the branch red; BLOCKED/PARTIAL
+rows in STATE.md carry failing command + error tail + suspected cause + recommended next
+action/model escalation; side branch `claude/blocked-Sx` for unfinishable code.
+
+---
+
+## S1 — Ground-truth extraction A: core pipeline + all 40 Java blocks
+
+**Model:** Opus / high · **Size:** large · **Preconditions:** S0 (this scaffolding).
+**SDK not needed** (docs-only segment — skip setup script).
+
+**Objective:** Verbatim, provenance-stamped extraction of every embedded Java block and
+action-by-action specs of the core pipeline tasks + their triggering profiles, so no later
+segment ever re-reads the XML for pipeline logic.
+
+**Inputs:** `docs/rebuild/XML_RECIPES.md` (mandatory read; use R7's census table as your work
+queue); XML strictly via recipes; `docs/migration/variable_contracts.md` and
+`docs/migration/aab_settings_schema.md` as cross-checks only (they are NOT ground truth).
+
+**Deliverables:**
+1. `docs/rebuild/extraction/java/<taskid>_<n>_<slug>.java` — all 40 blocks (`<n>` = 1 or 2 for
+   dual-block tasks), XML-entity-decoded verbatim, header comment: task id, task name, XML line
+   range, `arg1` output variable, list of `%vars` consumed (these become parameters in S4).
+   Decode with python3 `html.unescape` or equivalent — do not hand-decode.
+2. `docs/rebuild/extraction/tasks/task<id>_<slug>.md` for EACH of: 554, 544, 535, 546, 661,
+   548, 659, 543, 696, 698, 700, 618, 585, 566, 567, 569, 561, 528, 570, 645, 646, 647, 650,
+   653, 654, 644, 551, 584. Per file: every action in order — code, decoded args, condition
+   expressions, loop/goto structure, labels — plus variables read/written. For Variable Set
+   (547) actions capture the maths expression EXACTLY (task661's curve math lives there, see
+   STATE.md D-002).
+3. `docs/rebuild/extraction/profiles.md` — for profiles 753–761, 769: context type+code+args
+   AND the full `<ConditionList>` semantics (D-003: prof760 carries the absolute-threshold
+   gate: `%as_values1` vs `%AAB_ThreshAbsLow/High`, accuracy trust, `%AAB_MainLoop`), enter/exit
+   task ids, priority. (Context profiles 762–768 + 8 belong to S2 — skip.)
+4. `docs/rebuild/extraction/pipeline_spec.md` — prose+pseudocode end-to-end flow: sensor event
+   → profile gate → ingest → threshold/smoothing → mapping → scale → animation plan →
+   per-frame writes with read-back override detection → super dimming; PLUS the override
+   detect/pause/resume state machine (567/569/561 + profiles 755/756), hibernate (753/585),
+   throttle reinit (754/566), initial brightness on wake (761/618), panic (769/528).
+   State variables table: every runtime (non-settings) `%AAB_*` var with meaning + lifecycle.
+5. `docs/rebuild/extraction/defaults_audit.md` — ALL 125 `%AAB_*` vars: default value (from
+   task570 Initialize AAB Defaults + task592 _CreateDefaultProfiles + task637), type,
+   user-facing-setting vs runtime-state classification, present-in-`AabSettings.kt`? Explicitly
+   resolve D-004 (`%AAB_AnimSteps`, `%AAB_MaxSteps`, `%AAB_ThreshMidpoint`, AnimationConfig
+   default conflicts → state which values are canonical).
+6. `docs/rebuild/extraction/INDEX.md` — inventory of all produced files; incrementally-built
+   action-code legend (code → meaning, derived from in-place evidence); **"unresolved"
+   section** for any action whose semantics you could not establish — record code + raw XML
+   snippet + location, NEVER guess; spot-check section: 3 formulas with XML line provenance
+   cross-checked against `domain/.../brightness/BrightnessEngine.kt` (note match/mismatch —
+   do not fix code).
+
+**Non-goals:** No Kotlin/gradle changes. No scene extraction, no task90/38/contexts (S2 owns
+them — but extract their Java blocks anyway: ALL 40 means all 40). No "improving" Tasker logic.
+
+**Steps:** (1) Work through R7's table: for each line anchor, `sed -n` a window, find the
+enclosing `<Str sr="arg0">…</Str>`, decode, save; verify
+`ls docs/rebuild/extraction/java | wc -l` == 40. (2) awk-extract each listed task; transcribe
+actions using R8 histograms to size them first. (3) Extract listed profiles (R4 — mind the
+`ve="2"` pattern). (4) Build pipeline_spec.md from the above. (5) defaults_audit.md: awk task570
+(+592/637 deltas). (6) INDEX.md + flip PARITY_CHECKLIST "Extracted" cells for your rows.
+(7) STATE.md row + push.
+
+**Acceptance:** 40 java files; all listed task/profile docs exist; INDEX.md complete with
+legend + unresolved section (empty is fine, absent is not); checklist cells flipped; pushed.
+
+**Failure notes:** If a Java block spans nested CDATA-like oddities or an action's arg encoding
+is ambiguous → unresolved section, continue. Context-window pressure: process tasks one at a
+time, never hold multiple raw dumps.
+
+---
+
+## S2 — Ground-truth extraction B: features, contexts, scenes → screen map
+
+**Model:** Opus / medium · **Size:** large · **Preconditions:** S0. Parallel-safe with S1/S3.
+**SDK not needed.**
+
+**Objective:** Extract the non-pipeline features and the entire UI surface; produce the
+scene→screen consolidation matrix that S11–S13 implement.
+
+**Inputs:** XML_RECIPES.md (R4/R5 anchors are your map); `docs/migration/tasker_feature_spec.md`
+as an outline checklist (verify, don't trust).
+
+**Deliverables:**
+1. `docs/rebuild/extraction/tasks/task090_dynamic_scale.md` — all ~80 actions of task90 + its
+   two Java blocks' logic explained: solar inputs (does it COMPUTE sunrise/sunset or consume
+   Tasker built-ins like %SUNRISE? — answer explicitly, it decides S6's approach), tanh ramp,
+   polar day/night branches, location/timezone handling, `%AAB_Scale*` parameter semantics.
+2. `…/tasks/task038_curve_wizard.md` — all ~95 actions of the suggestion wizard: inputs
+   gathered, fitting/suggestion algorithm, outputs (which `%AAB_Form*` it writes via task655).
+3. `…/contexts_spec.md` — profiles 762–768 + 8 and tasks 43, 623, 624, 625, 626, 628, 630,
+   631, 633, 105, 26: per-app/WiFi/battery/time/location override semantics, the serialized
+   context cache + daily reset, precedence/conflict rules (use profile `<pri>` values),
+   what an "override" changes (scale? min/max? disable?), resume semantics (626).
+4. `…/features_spec.md` — QS tile (551/552), foreground notification incl. button actions
+   (584, 692), power-draw calibration (524), debug levels + log surface (634/635), formula
+   validation rules (583 _RedInvalidFormulae + 707 _ValidateBrightnessParams — exact per-field
+   rules for S8's `validate()`), import/export + default profiles (592/637/622), privilege
+   detection/learn flows (378, 643, 563 — feeds S7's PrivilegeManager UX).
+5. `docs/rebuild/extraction/scenes/<slug>.md` × 20 — per scene: every element (type, name,
+   bound variable, value range, tap/long-tap handler task), WebElement chart contents (which
+   series/axes the Chart.js HTML plots — extract from the generator tasks 549/556/557/657/663/
+   703/705 rather than the HTML blobs).
+6. `docs/rebuild/screen_map.md` — THE consolidation matrix: 20 scenes / 450 elements → target
+   M3 screens (default proposal: Dashboard · Curve & Brightness · Reactivity · Animation &
+   Dimming · Dynamic Scale · Contexts · Tools (wizard/calibration/debug/experiments) ·
+   Profiles & Import/Export · About+Guide+Onboarding). Per element: `kept-as <target>` /
+   `merged-into <target>` / `dropped(<reason>)`. Every Chart.js WebElement maps to a named
+   Compose chart (BrightnessCurveChart, ReactivityChart, DimmingChart, CircadianChart,
+   TaperChart, PowerDrawChart, ExperimentChart). Zero unmapped elements.
+
+**Non-goals:** No code. No pipeline tasks (S1's list). No visual design beyond the matrix.
+
+**Steps:** size each scene/task with R8/`wc -l` before dumping; tabulate elements; derive
+context precedence from `<pri>`; cross-check feature list against docs/migration/
+tasker_feature_spec.md and record anything it missed; flip checklist "Extracted"/scene-anchor
+cells; STATE.md row; push.
+
+**Acceptance:** 20 scene files; screen_map.md has a disposition for all 450 elements (spot
+count: `grep -c 'kept-as\|merged-into\|dropped' screen_map.md` ≥ 450); contexts_spec.md covers
+all 8 context profiles; task090/task038 docs answer the solar-source question explicitly;
+pushed.
+
+---
+
+## S3 — Toolchain modernization + first green build
+
+**Model:** Sonnet / medium · **Size:** medium · **Preconditions:** S0. Parallel-safe with S1/S2
+(touches only build files, res/, manifest).
+
+**Objective:** Modern reproducible build: wrapper, version catalog, Kotlin 2.0.x, AGP 8.7.x,
+compose BOM, minimal res/ (kills the `R.mipmap.ic_launcher` blocker), correct manifest,
+`:platform` → Android library, `:data` retired, lint baseline frozen.
+
+**Inputs:** run `scripts/setup-android-sdk.sh` first; all `*.gradle.kts`, `gradle.properties`,
+`app/src/main/AndroidManifest.xml`.
+
+**Steps & deliverables:**
+1. `/opt/gradle/bin/gradle wrapper --gradle-version 8.14.3` → commit gradlew + wrapper dir
+   (ensure `gradle-wrapper.jar` is committed; check .gitignore doesn't eat it).
+2. Fix D-007 FIRST: `settings.gradle.kts` needs `pluginManagement { repositories { google();
+   mavenCentral(); gradlePluginPortal() } }` + `dependencyResolutionManagement` — without it
+   NOTHING configures (AGP is not on the Gradle Plugin Portal alone).
+3. `gradle/libs.versions.toml`: kotlin `2.0.21`, AGP `8.7.3`, compose-bom `2024.12.01`,
+   activity-compose `1.9.3`, navigation-compose `2.8.5`, lifecycle `2.8.7`, datastore `1.1.1`,
+   work-runtime-ktx `2.10.0`, kotlinx-serialization-json `1.7.3`, coroutines `1.9.0`,
+   robolectric `4.14.1`, androidx-test-core/junit, shizuku-api+provider `13.1.5` (declare only;
+   first used in S7). On any resolution failure: step DOWN one minor version at a time, record
+   the final matrix in STATE.md. Migrate every build file to catalog refs.
+4. Kotlin 2 compose migration: apply `org.jetbrains.kotlin.plugin.compose` in `:app`; DELETE
+   `composeOptions { kotlinCompilerExtensionVersion = … }`.
+5. `gradle.properties`: `org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8`,
+   `android.useAndroidX=true`, `org.gradle.caching=true`.
+6. `app/src/main/res/`: `values/strings.xml` (app_name "Tideo Auto Brightness"),
+   `values/themes.xml` (Theme.Material3.DayNight.NoActionBar parent),
+   `drawable/ic_launcher_foreground.xml` (simple brightness-sun vector),
+   `mipmap-anydpi-v26/ic_launcher.xml` adaptive icon (+ `values/ic_launcher_background.xml`
+   color). Notification small icon: `drawable/ic_stat_brightness.xml` vector.
+7. Manifest: `<uses-permission>` WRITE_SETTINGS (+`tools:ignore="ProtectedPermissions"`),
+   WRITE_SECURE_SETTINGS (same), POST_NOTIFICATIONS, FOREGROUND_SERVICE,
+   FOREGROUND_SERVICE_SPECIAL_USE, RECEIVE_BOOT_COMPLETED, PACKAGE_USAGE_STATS
+   (`tools:ignore`), ACCESS_COARSE_LOCATION + ACCESS_FINE_LOCATION (wifi SSID/location
+   contexts; runtime-requested later). Service: `foregroundServiceType="specialUse"` +
+   child `<property android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+   android:value="Continuous ambient-light monitoring to drive adaptive screen brightness"/>`.
+   `application android:theme="@style/Theme.TideoAutoBrightness"
+   android:icon="@mipmap/ic_launcher"`. Verify activity name matches the class in `Main.kt`.
+8. `app/build.gradle.kts`: minSdk **31**, compileSdk/targetSdk 35, namespace unchanged,
+   buildFeatures.compose true, deps via BOM. Replace the
+   `R.mipmap.ic_launcher` reference in `AmbientMonitoringService.kt:85` with
+   `R.drawable.ic_stat_brightness` (this is the ONLY permitted source-file edit).
+9. `:platform` → `com.android.library` (namespace `com.tideo.autobrightness.platform`,
+   minSdk 31, compileSdk 35, Robolectric-ready: `testOptions.unitTests
+   { isIncludeAndroidResources = true; isReturnDefaultValues = true }`). Keep
+   `SystemAdapters.kt` compiling as-is (deleted in S9, not now).
+10. Retire `:data`: `grep -rn "autobrightness.data" app domain platform` — if (expected) zero
+   references: remove from `settings.gradle.kts`, `git rm -r data/`. If referenced: record in
+   STATE.md and defer deletion to S9.
+11. Lint baseline: `./gradlew :app:lintDebug` → commit `app/lint-baseline.xml`
+    (`lint { baseline = file("lint-baseline.xml") }`). Policy: baseline never grows.
+12. STATE.md (record exact final version matrix) + checklist untouched (no parity rows here) +
+    push.
+
+**Non-goals:** No behavior changes, no new features, no DI framework, no source edits beyond
+step 8's single line, no res beyond the minimal set.
+
+**Acceptance:** `./gradlew :app:assembleDebug :domain:test :platform:test :app:lintDebug` all
+green; `ls app/build/outputs/apk/debug/app-debug.apk` succeeds; pushed.
+
+**Failure notes:** AGP/Kotlin/SDK mismatch errors name the required versions — follow them one
+step at a time and log. If `:domain:test` was already failing pre-segment, note it but your
+gate is "no NEW failures" (record exact pre/post failure lists in STATE.md).
+
+---
+
+## S4 — Tasker reference implementation + golden vectors
+
+**Model:** Opus / medium · **Size:** large · **Preconditions:** S1 DONE, S3 DONE.
+
+**Objective:** Transcribe S1's extracted Java into a test-only JVM "Tasker reference
+implementation", generate committed golden vectors, wire parity tests. The reference is the
+behavioral oracle for all later domain work.
+
+**Inputs:** `docs/rebuild/extraction/java/` (pipeline blocks: 554, 544, 535, 546, 548, 543,
+696, 698, 700, 618 + task661's action-math from `extraction/tasks/task661_*.md` and 659's
+continuity math), `pipeline_spec.md`, `defaults_audit.md`;
+`domain/.../brightness/BrightnessEngine.kt`, `BrightnessPolicyInput.kt`.
+
+**Deliverables:**
+1. `domain/src/test/kotlin/com/tideo/autobrightness/domain/reference/TaskerReference.kt` —
+   one function per Java block / per task661+659 math unit. **Java semantics preserved
+   exactly**: `Math.round` (ties toward +∞ — differs from `kotlin.math.round` on negative
+   halves), `BigDecimal.setScale(n, RoundingMode.HALF_UP)` where Tasker used it, string
+   formatting where Tasker produced strings, int truncation. Every `%var` the block consumed
+   is a parameter (S1 headers list them). Provenance header per function.
+2. `…/reference/GoldenVectorGenerator.kt` — main() (or test gated on
+   `System.getProperty("regenGolden")`) writing CSVs to `domain/src/test/resources/golden/`.
+3. Committed vectors `golden/{threshold,smoothing,mapping,formulae,animation,taper,dimming,
+   transition}.csv` — header row naming inputs/outputs; ≥500 rows each: log-spaced lux
+   0.01→120000, × ≥4 settings variants (extracted defaults + edge variants: min==max bright,
+   zone1End boundary, negative effective-delta ties, scale >1 and <1); explicit boundary rows
+   (lux == zone1End, == zone2End, 0, sensor max).
+4. `domain/src/test/kotlin/.../parity/CorePipelineParityTest.kt` — asserts CURRENT
+   `BrightnessEngine` (and helpers) against the vectors. Numeric tolerance 1e-9; strings exact.
+5. `docs/rebuild/parity_gaps.md` — every failing case triaged: gap id, vector file+row range,
+   reference value vs engine value, root-cause hypothesis. Mark failing parity tests
+   `@Ignore("S5: gap-<id>")` INDIVIDUALLY (never blanket-ignore).
+
+**Non-goals:** Do NOT fix `BrightnessEngine` (S5's job). No circadian/wizard (S6). No app/
+platform changes. No gradle changes beyond (if needed) a test-resources stanza.
+
+**Steps:** transcribe block-by-block with the original Java in a side comment where subtle;
+sanity-test each reference function against hand-computed values from XML comments/Flash
+debug strings; generate vectors; run `./gradlew :domain:test`; triage failures; STATE.md +
+checklist ("Reference impl" cells) + push.
+
+**Acceptance:** `./gradlew :domain:test` green (documented `@Ignore`s only); vectors
+committed; `parity_gaps.md` enumerates every ignored case (cross-check:
+`grep -c @Ignore domain/src/test` == gap count); pushed.
+
+**Failure notes:** If extraction proves ambiguous mid-transcription (e.g. operator precedence
+in a Variable Set maths expression), re-derive from XML via recipes, update the extraction doc
++ note in STATE.md (extraction docs are correctable by EVIDENCE, never by convenience).
+
+---
+
+## S5 — Domain engine parity completion
+
+**Model:** Sonnet / high · **Size:** large · **Preconditions:** S4 DONE.
+
+**Objective:** Make production domain code match the reference exactly; add the missing pure
+components; finalize the domain API the runtime consumes.
+
+**Inputs:** `parity_gaps.md`, golden CSVs + `TaskerReference.kt`, extraction docs for tasks
+659, 700, 567/569/561, 618; `defaults_audit.md`.
+
+**Deliverables:**
+1. `BrightnessEngine.kt` fixed: every gap closed, all `@Ignore`s removed.
+2. `domain/.../brightness/BrightnessFormulae.kt` — `deriveContinuityCoefficients(...)` →
+   form2A/form3A per task659 (golden-tested via `formulae.csv`).
+3. `domain/.../brightness/SoftwareDimming.kt` — reduce_bright_colors level calculation incl.
+   PWM-sensitive exponent compression, dimmingThreshold/strength/spread semantics (task700 +
+   645–654 privileged/unprivileged variants — the privilege SPLIT is platform's job; the MATH
+   is yours).
+4. `domain/.../brightness/OverrideRules.kt` — pure detect/pause/resume decision logic
+   (tasks 567/569/561): when is an external write "manual override", when does auto resume
+   (lux delta? timer? screen cycle? — per extraction).
+5. `domain/.../brightness/InitialBrightness.kt` — wake-time initial set logic (task618).
+6. Config data classes reconciled with `defaults_audit.md` canonical values (D-004): update
+   `BrightnessPolicyInput.kt` defaults; keep the 6 existing `BrightnessEngineContractTest`
+   tests passing (update only if extraction proves them wrong — STATE.md note).
+
+**Non-goals:** No platform/app changes. NEVER edit reference impl or vectors to make tests
+pass (only evidence-backed extraction corrections, logged).
+
+**Acceptance:** `./gradlew :domain:test` fully green; `grep -rn "@Ignore"
+domain/src/test` → empty; pushed.
+
+---
+
+## S6 — Circadian solar engine + curve-wizard math
+
+**Model:** Sonnet / high · **Size:** medium-large · **Preconditions:** S2 DONE, S5 DONE.
+Parallel window B (with S7, S8).
+
+**Objective:** Port task90 (dynamic scale: solar times, tanh ramp, polar handling) and task38
+(curve suggestion wizard) into pure domain code with reference + goldens.
+
+**Inputs:** `extraction/tasks/task090_dynamic_scale.md`, `task038_curve_wizard.md`, their Java
+blocks in `extraction/java/`, `TaskerReference.kt` conventions.
+
+**Deliverables:** `domain/.../circadian/SolarTimes.kt` (IF task90 computes sun times: port its
+exact algorithm; IF it consumed Tasker's built-in %SUNRISE/%SUNSET: implement the NOAA solar
+equations and golden-test against published NOAA tables for ≥6 lat/date combos incl. polar
+day/night — S2's doc says which case applies; record choice in STATE.md);
+`domain/.../circadian/DynamicScaleEngine.kt` (absorb/refactor `computeDynamicScale` +
+`rampProgress` out of BrightnessEngine, driven by SolarTimes + manual-times fallback);
+`domain/.../wizard/CurveSuggestionEngine.kt` (task38 + task655 output mapping); reference
+functions + `golden/{circadian,wizard}.csv` + parity tests; polar assertions (progress pins
+1/0 when sunlightDurationMinutes ≷ 1380 — verify against extraction, the current
+BrightnessEngine hardcodes 1380).
+
+**Non-goals:** No location acquisition (platform S7), no UI, no scheduling.
+
+**Acceptance:** `./gradlew :domain:test` green incl. new parity + polar tests; pushed.
+
+---
+
+## S7 — Platform adapters + tiered privilege manager
+
+**Model:** Sonnet / medium · **Size:** large · **Preconditions:** S3 DONE, S5 DONE.
+Parallel window B.
+
+**Objective:** Replace every fake with real Android adapters behind small interfaces,
+including the BASIC/ELEVATED privilege model and OEM brightness-range normalization.
+
+**Inputs:** `pipeline_spec.md` (sensor + write semantics), `extraction/tasks/task700_*.md` +
+645–654 (dimming write paths), `features_spec.md` privilege section (378/643/563),
+existing `platform/SystemAdapters.kt` (supersede, don't delete).
+
+**Deliverables** (all in `platform/src/main/kotlin/com/tideo/autobrightness/platform/`, each
+as interface + impl + Robolectric/fake test):
+- `sensor/LightSensorSource.kt` — `SensorManager.getDefaultSensor(Sensor.TYPE_LIGHT)`,
+  `registerListener(..., SENSOR_DELAY_NORMAL)`, expose `callbackFlow<LightSample>`
+  (lux + accuracy + timestamp; accuracy matters: prof760 trust-gate), `awaitClose
+  { unregisterListener }`.
+- `brightness/ScreenBrightnessController.kt` — read/write `Settings.System.SCREEN_BRIGHTNESS`;
+  force `SCREEN_BRIGHTNESS_MODE_MANUAL` on enable (restore prior mode on disable); **range
+  normalization**: device max via `Resources.getSystem().getIdentifier(
+  "config_screenBrightnessSettingMaximum", "integer", "android")` (fallback 255), expose
+  domain-facing 0–255 (Tasker parity) mapped to device scale; suppress-echo hook: caller
+  registers expected values so self-writes aren't "manual overrides".
+- `brightness/SecureDimmingController.kt` — `Settings.Secure.putInt(resolver,
+  "reduce_bright_colors_level", n)` + `"reduce_bright_colors_activated"` 0/1; returns
+  Result.failure with status when tier < ELEVATED (callers degrade gracefully).
+- `privilege/PrivilegeManager.kt` — `enum Tier { NONE, BASIC, ELEVATED }`;
+  BASIC ⇔ `Settings.System.canWrite(context)` (request via
+  `Settings.ACTION_MANAGE_WRITE_SETTINGS` intent w/ package uri);
+  ELEVATED ⇔ `context.checkSelfPermission(Manifest.permission.WRITE_SECURE_SETTINGS) ==
+  PERMISSION_GRANTED`; grant helpers: (a) adb instruction string
+  `adb shell pm grant com.tideo.autobrightness android.permission.WRITE_SECURE_SETTINGS`,
+  (b) Shizuku: `Shizuku.pingBinder()`, `Shizuku.checkSelfPermission()`/`requestPermission(code)`,
+  then run the same `pm grant` via Shizuku (`Shizuku.newProcess` or user-service exec) —
+  add `ShizukuProvider` to app manifest (S11 wires UI; you land the manifest entry + deps),
+  (c) root: `Runtime.exec(arrayOf("su","-c","pm grant …"))`. After grant the app writes
+  Settings.Secure DIRECTLY — Shizuku is not a runtime dependency. Expose `tierFlow`.
+- `observe/BrightnessObserver.kt` — `ContentObserver` on
+  `Settings.System.getUriFor(SCREEN_BRIGHTNESS)` via `registerContentObserver(uri, false, …)`
+  → callbackFlow of external changes, filtered through the suppress-echo hook.
+- `context/BatteryStateReader.kt` (sticky `ACTION_BATTERY_CHANGED` + `BatteryManager`),
+  `context/LocationReader.kt` (`LocationManager.getLastKnownLocation(PASSIVE_PROVIDER)`,
+  nullable; manual lat/lon fallback comes from settings),
+  `context/ForegroundAppMonitor.kt` (`UsageStatsManager.queryEvents` trailing-window →
+  current foreground package; permission check via `AppOpsManager.unsafeCheckOpNoThrow(
+  OPSTR_GET_USAGE_STATS, …)`; grant intent `Settings.ACTION_USAGE_ACCESS_SETTINGS`),
+  `context/WifiInfoReader.kt` (`ConnectivityManager.registerNetworkCallback` with
+  `FLAG_INCLUDE_LOCATION_INFO`, read `transportInfo as WifiInfo` SSID; document
+  FINE_LOCATION requirement).
+- Mark `SystemAdapters.kt` classes `@Deprecated("S9 removes")` (toy loop still uses them).
+
+**Non-goals:** No service/runtime rewiring (S9), no UI, no context POLICY (S10 — you build
+readers only), no deletion of fakes.
+
+**Acceptance:** `./gradlew :platform:test :app:assembleDebug` green. Robolectric coverage:
+brightness write/read + mode force (`ShadowSettings`), tier detection (shadow grant),
+observer dispatch (`ShadowContentResolver.notifyChange`), dimming controller tier-gating;
+sensor source covered by a fake-driven flow test (Robolectric sensors are limited — instantiation
++ unregister-on-cancel is enough). Pushed.
+
+**Failure notes:** Shizuku exec API friction → land the interface + adb/root paths + a
+`ShizukuGrantGateway` stub recording the limitation in STATE.md; S11 can finish the flow.
+
+---
+
+## S8 — Settings schema v2, persistence, import/export
+
+**Model:** Sonnet / medium · **Size:** medium · **Preconditions:** S1 DONE, S5 DONE.
+Parallel window B.
+
+**Objective:** Close every settings-schema gap, version the schema with migration, make
+import/export + default profiles real, expose validation for the UI.
+
+**Inputs:** `defaults_audit.md` (canonical), `extraction/features_spec.md` (592/637/622 +
+583/707 validation rules), existing `app/.../settings/*` + `storage/AppDataStores.kt`.
+
+**Deliverables:** `AabSettings` v2 — add `animSteps`, `maxSteps`(if distinct), `thresholdMidpoint`,
+and every var `defaults_audit.md` classifies user-facing that's missing; ALL defaults
+reconciled to audit values; `CURRENT_SCHEMA_VERSION = 2` + migration (v1 JSON → v2 fills new
+fields with audit defaults) + migration unit test; `AabSettingsMapper` completed: settings →
+`ThresholdConfig`/`AnimationConfig`/`BrightnessCurveConfig`/`DynamicScalingConfig` incl.
+derived form2A/form3A via `BrightnessFormulae` (D-002 chain); built-in default profile set per
+task637/592; legacy Tasker import round-trip test (fixture built from audit defaults through
+`TaskerLegacyProfileSerializer`); `SettingsValidator.validate(AabSettings):
+List<FieldError(field, message)>` implementing 583/707 rules exactly (for S12's red-invalid UI);
+context-override rules storage MODEL (data classes + serializer only — engine is S10).
+
+**Non-goals:** No UI, no runtime wiring, no DataStore re-architecture.
+
+**Acceptance:** `./gradlew :app:testDebugUnitTest :app:assembleDebug` green incl. migration +
+round-trip + validator tests; pushed.
+
+---
+
+## S9 — Runtime integration: the real pipeline service (+ legacy rip-out)
+
+**Model:** Sonnet / high (Opus / medium if budget allows — cheapest insurance before Gate 1)
+· **Size:** large · **Preconditions:** S5, S6, S7, S8 all DONE.
+
+**Objective:** Rebuild the runtime as the sensor-event-driven Tasker pipeline with animated
+writes, override detect/resume, hibernate, throttle, panic, boot start, QS tile, actionable
+notification; delete every legacy fake.
+
+**Inputs:** `pipeline_spec.md` (THE spec), extraction docs for 554/544/535/661/548/543/696/
+698/700/618/585/566/567/569/561/528/551/584, all S7 adapters, S8 mapper, existing
+`app/.../runtime/*`.
+
+**Deliverables:**
+1. `app/.../runtime/BrightnessPipelineController.kt` — owns Tasker runtime state (smoothedLux,
+   lastRawLux, thresholds-abs, cycleTime, scaleDynamic, dimming state…); consumes
+   LightSensorSource flow → profile-gate conditions (D-003: absolute thresholds, accuracy
+   trust, main-loop flag) → throttle gate → `BrightnessEngine.evaluate` → animation plan.
+2. `runtime/AnimationRunner.kt` — coroutine executing N steps × waitMs: per-frame
+   `ScreenBrightnessController.write` + read-back compare (Tasker parity, task696/698) —
+   abort + signal override on external mismatch; respects suppress-echo registration.
+3. `runtime/OverrideMonitor.kt` — `BrightnessObserver` flow + `OverrideRules` → pause/resume
+   state machine incl. resume conditions and notification-text updates (profiles 755/756).
+4. `AmbientMonitoringService.kt` REBUILT — `ServiceCompat.startForeground(...,
+   FOREGROUND_SERVICE_TYPE_SPECIAL_USE)`; notification: live lux/target (throttled updates),
+   actions Pause/Resume/Disable + panic-reset (528: restore sane brightness, clear state);
+   SCREEN_OFF → hibernate (sensor unregister, state reset per 585), SCREEN_ON → reinit
+   (throttle reset 566 + initial brightness 618 via domain `InitialBrightness`).
+5. Super dimming: below threshold engage `SecureDimmingController` (math from domain
+   `SoftwareDimming`) when tier ELEVATED; clean disengage path (645–654 semantics).
+6. `runtime/BrightnessTileService.kt` — `TileService` toggling the service; manifest entry
+   with `android.permission.BIND_QUICK_SETTINGS_TILE` + icon.
+7. `BootCompletedReceiver` — start service if enabled (specialUse FGS is boot-eligible;
+   if start fails log + post notification prompting open).
+8. RIP-OUT: delete `domain/BrightnessPolicyEngine.kt`, `domain/EvaluateAndApplyBrightnessUseCase.kt`,
+   `domain/Ports.kt`, `platform/SystemAdapters.kt`, `app/ui/graph/WebViewGraphFallback.kt`,
+   `app/onboarding/PermissionOnboardingStateMachine.kt`, leftover `data/` references; rewrite
+   `AppModule.kt` composing the real graph; keep `ServiceHealthStore` telemetry.
+9. Robolectric tests: service start → foreground notification posted; SCREEN_OFF/ON
+   hibernate/reinit (sensor flow subscription state); observer event → paused state;
+   tile instantiation; pipeline controller unit-tested with fake adapters end-to-end
+   (lux sequence → expected write sequence from goldens).
+
+**Non-goals:** Context-override policy (S10), UI screens (S11/S12), onboarding flow (S11).
+
+**Acceptance:** `./gradlew :app:assembleDebug :app:testDebugUnitTest :domain:test
+:platform:test :app:lintDebug` green; `grep -rn "FakeAmbientLux\|BrightnessPolicyEngine\|
+EvaluateAndApplyBrightnessUseCase" app domain platform` → empty; STATE.md row notes "GATE 1
+READY"; pushed. → **HUMAN GATE 1** (checklist below).
+
+**Failure notes:** `ForegroundServiceTypeException` on start → re-check manifest property +
+type flag pairing; Robolectric TileService gaps → downgrade to instantiation-only test +
+STATE.md note.
+
+---
+
+## S10 — Context override engine
+
+**Model:** Sonnet / medium · **Size:** medium · **Preconditions:** S2, S7, S9 DONE.
+Parallel window C (with S11).
+
+**Objective:** Port the context system: per-app / WiFi / battery / time / location overrides
+with serialized cache + daily reset and Tasker-priority-faithful precedence.
+
+**Inputs:** `extraction/contexts_spec.md`, extraction docs 43/623–633/105/26, S7 readers,
+S8 rules storage model, `BrightnessPipelineController`.
+
+**Deliverables:** `domain/.../context/ContextOverrideResolver.kt` — pure precedence/merge
+logic + table-driven unit tests mirroring the spec's precedence matrix;
+`app/.../runtime/ContextEngine.kt` — foreground-app polling (2–3 s) ONLY while screen on ∧
+service running ∧ ≥1 app rule configured; battery/wifi via S7 reader flows; time windows
+evaluated on pipeline cycles; location = coarse radius check on passive provider; serialized
+context cache + daily reset via existing `MaintenanceWorker`; pipeline hook applying resolved
+override (scale/min/max/disable per spec) + notification context line; persistence wiring for
+rule CRUD (model from S8).
+
+**Non-goals:** Rule-editing UI (S12), AccessibilityService, geofencing, background location.
+
+**Acceptance:** `./gradlew :domain:test :app:testDebugUnitTest :app:assembleDebug` green;
+resolver test matrix matches spec table 1:1; pushed.
+
+---
+
+## S11 — UI shell, onboarding/privileges, dashboard
+
+**Model:** Sonnet / medium · **Size:** large · **Preconditions:** S7, S8, S9 DONE.
+Parallel window C (with S10 — disjoint packages; rebase before push).
+
+**Objective:** Compose M3 navigation shell (screen set per `screen_map.md`), privilege
+onboarding via ActivityResultContracts, live Dashboard.
+
+**Inputs:** `screen_map.md`, existing `app/.../ui/*` + `navigation/*` + `state/
+SettingsViewModel.kt`, `PrivilegeManager`, `ServiceHealthStore`, pipeline state flows.
+
+**Deliverables:** rebuilt `AppRoute`/`NavGraph` for the target screens (stubs OK for S12-owned
+screens — `Text("S12")` placeholders are acceptable, navigation must resolve);
+`ui/onboarding/OnboardingScreen.kt` — stepper: POST_NOTIFICATIONS
+(`ActivityResultContracts.RequestPermission`), WRITE_SETTINGS
+(`StartActivityForResult(ACTION_MANAGE_WRITE_SETTINGS + package uri)` + `canWrite` re-check in
+`onResume`), optional ELEVATED step (adb command with copy button, Shizuku request flow,
+root attempt button, live tier badge; all three paths from S7 `PrivilegeManager`; skippable),
+usage-access step shown only when app rules exist (deep-link `ACTION_USAGE_ACCESS_SETTINGS`);
+`ui/screens/DashboardScreen.kt` rebuilt — live lux + smoothed lux + current/target brightness
+(pipeline flows), service master switch (start/stop FGS), pause/resume, active context line,
+tier badge → onboarding, service health (last sensor event, degraded flags); M3 dynamic color
++ DayNight; first-run routing → onboarding when tier == NONE.
+
+**Non-goals:** Parameter screens, charts, tools, context CRUD (all S12/S13). Notification
+styling (S9 owns it).
+
+**Acceptance:** `./gradlew :app:assembleDebug :app:lintDebug :app:testDebugUnitTest` green;
+Robolectric compose smoke test: launch → Dashboard renders, each route navigates; pushed.
+
+---
+
+## S12 — Settings & tools screens + chart engine core
+
+**Model:** Sonnet / medium · **Size:** large · **Preconditions:** S8, S10, S11 DONE
+(S6 for wizard/chart math).
+
+**Objective:** Every parameter/tool/profile screen with Tasker-faithful validation, plus the
+reusable Compose-Canvas chart engine with the brightness-curve chart as template instance.
+
+**Inputs:** `screen_map.md` + `extraction/scenes/*` (element dispositions), S8
+`SettingsValidator`, S6 `CurveSuggestionEngine`, existing `LineGraph.kt` (extend or replace —
+your call, record it), `extraction/features_spec.md` (calibration/debug).
+
+**Deliverables:** screens per screen_map: Curve & Brightness (min/max/offset/scale, zone ends,
+form params + LIVE derived form2A/form3A readout), Reactivity (thresholds incl. midpoint/
+steepness, deltaFactor, trust-unreliable), Animation & Dimming (animSteps, min/max wait,
+throttle; dimming enable/strength/exponent/threshold/spread, PWM toggle + exponent; ELEVATED-
+gated rows disabled w/ tier hint + onboarding link), Dynamic Scale (enable, spread, steepness,
+taper midpoint/steepness, transition factor, sun source: location vs manual times), Contexts
+(rule list CRUD: app picker via `PackageManager.getInstalledApplications` + launcher-intent
+filter, SSID field, time window, charging toggle, per-rule override values), Tools (wizard
+runner UI over CurveSuggestionEngine w/ apply-suggestions per task655; power-draw calibration
+flow per task524; debug level selector + in-app log view), Profiles (defaults reset, named
+profile save/load, export/import via `ActivityResultContracts.CreateDocument/OpenDocument`
+using S8 manager incl. legacy Tasker format). EVERY numeric field: outlined text field with
+red error state + message from `SettingsValidator` (583/707 parity), debounced persist on
+valid. `ui/graph/ChartCanvas.kt`: axes + ticks, linear & log10 x-scale, gridlines, multi-series
+polylines, threshold/marker lines, M3 theming, modest size; `ui/graph/BrightnessCurveChart.kt`
+— lux→brightness sampled from domain `mapLuxToBrightness` + taper overlay + current-point
+marker — written as THE template (clear "copy this pattern" comment for S13/Haiku).
+
+**Non-goals:** The remaining 6 charts and About/Guide (S13). No new chart libraries.
+
+**Acceptance:** `./gradlew :app:assembleDebug :app:testDebugUnitTest :app:lintDebug` green;
+validator-to-UI unit test (invalid input → FieldError rendered); screen_map.md + checklist
+scene rows flipped for covered scenes; pushed. → **HUMAN GATE 2.**
+
+---
+
+## S13 — Chart replication + static screens
+
+**Model:** Haiku / high · **Size:** medium · **Preconditions:** S12 DONE (template exists),
+S6 DONE (chart math), S2 scene docs.
+
+**Objective:** Replicate the remaining charts from the template and port static content
+screens. Pure pattern work.
+
+**Inputs:** `ui/graph/BrightnessCurveChart.kt` (THE template — copy its structure exactly),
+`ChartCanvas.kt` (read-only!), `extraction/scenes/scene_*graph*.md` (series/axis definitions
+per chart), domain functions: smoothing-alpha curve (reactivity), `SoftwareDimming` (dimming),
+`DynamicScaleEngine` (circadian), taper from engine, calibration data store (power draw),
+`extraction/scenes/` About/User Guide content.
+
+**Deliverables:** `ui/graph/{ReactivityChart,DimmingChart,CircadianChart,TaperChart,
+PowerDrawChart,ExperimentChart}.kt` each: sample its domain function per the scene doc's
+series/axes, render via ChartCanvas, wire into its host screen (slots were left by S12);
+`ui/screens/AboutScreen.kt` + `UserGuideScreen.kt` porting the extracted text (drop Chart.js
+license screen — flip its checklist row `dropped(Chart.js removed)`); a trivial compose
+instantiation test per chart.
+
+**Non-goals (HARD FENCE):** Do NOT modify `ChartCanvas.kt`, anything in `domain/`, `runtime/`,
+gradle files, manifest, or `SettingsValidator`. If a chart needs a ChartCanvas capability that
+doesn't exist: SKIP that chart, record precisely what's missing in STATE.md (status PARTIAL),
+move on. Do not redesign APIs.
+
+**Acceptance:** `./gradlew :app:assembleDebug :app:lintDebug :app:testDebugUnitTest` green;
+checklist graph-scene rows flipped; pushed.
+
+---
+
+## S14 — Final integration review, parity audit, release prep
+
+**Model:** Opus / high · **Size:** large · **Preconditions:** S1–S13 DONE; Gate 1 & 2
+findings triaged (any open BLOCKED rows resolved or explicitly accepted by the human).
+
+**Objective:** Whole-system review against the XML and checklist; close every gap; prepare the
+device acceptance script and release artifacts.
+
+**Inputs:** `PARITY_CHECKLIST.md` (every row), `STATE.md` full ledger + gate findings,
+`git log --stat` whole-program diff review, XML via recipes for any suspicious row.
+
+**Deliverables:** every checklist row → `ported`/`dropped(reason)` (zero `pending`; re-verify a
+sample of `ported` rows against extraction docs); fixes for findings (engine edge cases,
+missed notification actions, validation gaps, dead code, TODOs:
+`grep -rn "TODO\|FIXME" app domain platform` triaged); `docs/rebuild/DEVICE_TEST_SCRIPT.md` —
+Gate-3 numbered steps with expected outcomes covering every profile-equivalent behavior;
+`README.md` — features, install, privilege setup incl. exact
+`adb shell pm grant com.tideo.autobrightness android.permission.WRITE_SECURE_SETTINGS`,
+Shizuku walkthrough, troubleshooting (OEM brightness quirks, battery optimization);
+`versionName "0.9.0"`; optional `.github/workflows/build.yml` (assembleDebug + all tests) —
+attempt push ONCE, if rejected for workflow scope: delete the file, record in STATE.md, move
+on; lint-baseline shrink pass (delete entries that no longer fire).
+
+**Acceptance:** `./gradlew build` (full: all modules, lint, all tests) green;
+`grep -c pending docs/rebuild/PARITY_CHECKLIST.md` → 0; pushed. → **HUMAN GATE 3.**
+
+---
+
+## Human gates (the user + their phone; findings go to STATE.md "Gate findings")
+
+**GATE 1 — core loop (after S9).** Install `app/build/outputs/apk/debug/app-debug.apk`.
+Grant notifications + WRITE_SETTINGS via onboarding-less path if S11 not done yet (Settings →
+Apps → Special access → Modify system settings). Enable service. Verify: cover light sensor →
+brightness animates DOWN smoothly (no jumps); shine light → animates UP; drag system slider
+mid-run → auto pauses (notification says so), resumes per rules; screen off→on → reinit +
+initial brightness; reboot → service self-starts; notification Pause/Resume/Disable work;
+optionally `adb shell pm grant … WRITE_SECURE_SETTINGS` → in darkness below dimming threshold
+extra dimming engages and disengages cleanly.
+
+**GATE 2 — surfaces & tiers (after S12).** Full UI walkthrough: every field edits/persists/
+rejects-invalid-with-red; derived form2A/form3A update live; wizard produces and applies
+suggestions; Shizuku ELEVATED flow end-to-end on-device; QS tile add + toggle; per-app
+override (grant usage access → switch apps → rule applies); charging + time contexts;
+brightness chart shape sanity vs the old Tasker graph scene; legacy Tasker profile import.
+
+**GATE 3 — acceptance (after S14).** Run `docs/rebuild/DEVICE_TEST_SCRIPT.md` end-to-end;
+24 h soak: survives doze, battery drain acceptable, no ANRs; flip checklist rows to
+`device-verified`; remaining findings → STATE.md for a punch-list session (re-run an S9/S12
+style segment scoped to the findings).
+
+## Verification architecture (program-wide)
+
+- Per-session: SessionStart hook bootstraps SDK; acceptance ladder
+  `./gradlew :domain:test :platform:test :app:testDebugUnitTest :app:assembleDebug
+  :app:lintDebug` (subset per brief); segment ends green + pushed, else failure protocol.
+- Parity: committed golden CSVs from the test-only Tasker reference implementation (Java
+  semantics preserved). Vectors/reference immutable except evidence-backed extraction fixes
+  (STATE.md-logged). Tolerance 1e-9; Tasker-string outputs compared exactly.
+- Robolectric: service lifecycle/FGS, receivers, ContentObserver (ShadowContentResolver),
+  Settings shadows, privilege tiers, DataStore migration, compose smoke, tile instantiation.
+  NOT covered (→ human gates): real sensor timing, OEM ranges, Shizuku binder, doze.
+- Traceability: PARITY_CHECKLIST.md flipped per segment; S14 enforces zero pending.
+
+## Risk register
+
+| # | Risk | Mitigation | Owner |
+|---|---|---|---|
+| 1 | Extraction misreading | Opus on S1/S2/S4; verbatim dumps + line provenance; census reconciliation (40/18/20/125); "unresolved" over guessing | S1/S2 |
+| 2 | Rounding/tie divergence (Math.round ties, BigDecimal HALF_UP, string outputs) | Reference keeps Java semantics; explicit tie/boundary golden rows | S4/S5 |
+| 3 | Kotlin 2 / AGP migration friction | Pinned matrix; step-down-one-minor protocol; STATE log | S3 |
+| 4 | FGS specialUse / boot policy (API 34/35) | Manifest property + type flag pairing; Gate-1 reboot test; dataSync abandoned | S3/S9 |
+| 5 | OEM brightness range ≠ 255 | config_screenBrightnessSettingMaximum lookup + normalization; Gate-1 sweep | S7 |
+| 6 | Shizuku integration complexity | One-time-grant design (no runtime binder); adb fallback always present; gateway faked in tests | S7/S11 |
+| 7 | Scene-consolidation feature loss | S2 450-element disposition matrix; Gate 2 walkthrough; S14 zero-pending | S2/S12/S14 |
+| 8 | Settings schema drift | S1 full 125-var audit; schema v2 + migration tests | S1/S8 |
+| 9 | Parallel-segment push races | Disjoint file ownership per window; rebase-before-push rule; STATE.md append-merges | all |

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -1,0 +1,63 @@
+# STATE — cross-session memory for the rebuild program
+
+Every session: read this first; append/update before your final commit. Keep entries terse and
+factual. This file is the ONLY shared memory between sessions — if it isn't written here, the
+next session does not know it.
+
+## Segment log
+
+| Segment | Date | Model | Status | Commit | Notes |
+|---|---|---|---|---|---|
+| S0 scaffolding | 2026-06-11 | Fable (planning session) | DONE | (this commit) | CLAUDE.md, RUNBOOK, recipes, checklist, SDK script, hook authored. No source/gradle changes. |
+
+Status values: DONE · PARTIAL · BLOCKED (see failure protocol in CLAUDE.md).
+
+## Current state
+
+Repo contains the Tasker XML (ground truth), the audited Codex conversion (salvage/discard per
+CLAUDE.md ledger), Codex-era reference docs in docs/migration/, and the rebuild program
+scaffolding in docs/rebuild/. No segment work has started. The build does not even CONFIGURE
+yet (D-007: missing pluginManagement; plus missing res/, no wrapper) — first green gradle
+output of any kind is S3's deliverable. Android SDK bootstrap script verified working (15 s
+on this container; idempotent re-run verified).
+
+## Next up
+
+- S1 (Opus, high) — extraction A: pipeline + 40 Java blocks. No preconditions besides S0.
+- S2 (Opus, medium) — extraction B: features/contexts/scenes. No preconditions besides S0.
+- S3 (Sonnet, medium) — toolchain modernization + first green build. No preconditions besides S0.
+- S1 ∥ S2 ∥ S3 are parallel-safe (disjoint files; rebase before push if raced).
+
+## Deviations & discoveries ledger
+
+Seeded by the S0 audit (details in CLAUDE.md "Facts & corrections ledger"):
+
+- D-001: Java blocks are action code 474 (40), not 598. (Affects S1.)
+- D-002: task661 has no Java; curve math is in Variable Set expressions. task663's Java is a
+  plot-side copy for cross-validation only. (Affects S1, S4.)
+- D-003: Profile-level ConditionLists carry pipeline gating (prof760: absolute thresholds,
+  sensor-accuracy trust, %AAB_MainLoop). (Affects S1, S9.)
+- D-004: AabSettings schema gaps: %AAB_AnimSteps, %AAB_MaxSteps, %AAB_ThreshMidpoint;
+  AnimationConfig defaults conflict with AabSettings. (Affects S1 defaults_audit, S8.)
+- D-005: :platform is currently kotlin("jvm"); becomes com.android.library in S3.
+- D-006: 125 distinct %AAB_* variables (not 122 as older docs say).
+- D-007: settings.gradle.kts has NO pluginManagement block → AGP unresolvable → gradle
+  CONFIGURATION fails for every target, even pure-JVM `:domain:test` (verified 2026-06-11 with
+  Gradle 8.14.3: "Plugin com.android.application 8.5.2 was not found"). The Codex build was
+  never runnable. S3 must add `pluginManagement { repositories { google(); mavenCentral();
+  gradlePluginPortal() } }` (or migrate plugin decls accordingly). Until S3: no gradle target
+  works at all. (Affects S3; S4 is safe — it depends on S3.)
+
+Append new entries as D-007, D-008, … with which segments they affect.
+
+## Blockers
+
+(none)
+
+## Gate findings
+
+### Gate 1 (after S9) — pending
+### Gate 2 (after S12) — pending
+### Gate 3 (after S14) — pending
+
+The human records on-device findings here; the next session triages them.

--- a/docs/rebuild/XML_RECIPES.md
+++ b/docs/rebuild/XML_RECIPES.md
@@ -1,0 +1,207 @@
+# XML_RECIPES — verified access patterns for Advanced_Auto_Brightness_V3.3.prj_9.xml
+
+The Tasker export `Advanced_Auto_Brightness_V3.3.prj_9.xml` (repo root) is 1.6 MB / 41,291 lines.
+**NEVER read it wholesale** (it would consume your entire context window). Every recipe below was
+executed and verified on 2026-06-11 against this exact file. `$X` means the XML path.
+
+```bash
+X=Advanced_Auto_Brightness_V3.3.prj_9.xml
+```
+
+## R1 — Censuses (use these to sanity-check your extraction is complete)
+
+```bash
+grep -c '<Profile sr=' $X    # => 18
+grep -c '<Task sr=' $X       # => 276   (Task elements; ~159 carry <nme> names)
+grep -c '<Scene sr=' $X      # => 20
+grep -c '<Action sr=' $X     # => 2274
+grep -c '<code>474</code>' $X  # => 40  (embedded Java blocks — see R7)
+grep -o '%AAB_[A-Za-z0-9_]*' $X | sort -u | wc -l   # => 125 distinct project variables
+```
+
+## R2 — Extract one task by id (verified: task535 => 64 lines)
+
+```bash
+awk '/<Task sr="task535">/,/<\/Task>/' $X
+```
+
+Task elements have NO attributes after the sr, so the closing `>` in the pattern is safe.
+Pipe long tasks through `head -c`/`wc -l` first to size them before dumping into context.
+
+## R3 — Task id/name census
+
+```bash
+grep -A6 '<Task sr=' $X | grep -E '<(id|nme)>'
+```
+
+Emits `<id>` and (when present) `<nme>` pairs in file order. Unnamed Task elements are
+anonymous (scene-embedded/click handlers); the named ~159 are the real inventory.
+
+## R4 — Profiles. ⚠️ Profiles carry a `ve="2"` attribute — do NOT close the pattern with `>`
+
+```bash
+awk '/<Profile sr="prof760"/,/<\/Profile>/' $X      # correct
+# awk '/<Profile sr="prof760">/,...'                # WRONG — matches nothing
+```
+
+Profile block line anchors (verified): prof753 L3, prof754 L16, prof755 L56, prof756 L111,
+prof757 L156, prof758 L195, prof759 L300, prof760 L318, prof761 L386, prof762 L398,
+prof763 L456, prof764 L500, prof765 L541, prof766 L579, prof767 L628, prof768 L676,
+prof769 L722, prof8 L744. (All 18 live in lines 3–798, before the scenes.)
+
+Inside a profile: `<id>`, `<nme>`, `<mid0>` = enter task id, `<mid1>` = exit task id,
+`<pri>` = priority, then context children (`<Event sr="con0">`, `<State ...>`, `<App ...>`,
+`<Time ...>`, `<Day ...>`) each with a `<code>` (context type) and args.
+
+**⚠️ Profile-level `<ConditionList sr="if">` blocks are load-bearing pipeline logic.**
+Example: prof760 "Monitor Ambient Light" (Event code 2088 = Sensor, type 5 = light, arg2=1000ms)
+gates on `%as_values1` vs `%AAB_ThreshAbsLow`/`%AAB_ThreshAbsHigh`, `%AAB_TrustUnreliable` vs
+`%as_accuracy`, and `%AAB_MainLoop` — i.e. the absolute-threshold gate runs BEFORE the enter
+task fires. Extraction that only reads enter tasks will miss this.
+
+## R5 — Scenes (verified line anchors)
+
+```bash
+grep -n '<Scene sr=' $X
+```
+
+| Scene | Line |
+|---|---|
+| AAB About | 799 |
+| AAB Alpha Graph | 1038 |
+| AAB Brightness Graph | 1202 |
+| AAB Brightness Settings | 1415 |
+| AAB Chart.Js License | 2194 |
+| AAB Circadian Dimming Graph | 2388 |
+| AAB Color Filter | 2552 |
+| AAB Debug Scene | 2583 |
+| AAB Dimming Graph | 3006 |
+| AAB Experiment Graph | 3170 |
+| AAB Experiment Settings | 3334 |
+| AAB Menu | 4462 |
+| AAB Misc Settings | 4718 |
+| AAB Power Draw Graph | 5611 |
+| AAB Profile | 5724 |
+| AAB Reactivity Graph | 6563 |
+| AAB Reactivity Settings | 6739 |
+| AAB Superdimming Settings | 7533 |
+| AAB Taper Graph | 8387 |
+| AAB User Guide | 8551 |
+
+Scene names contain spaces and dots — extract by line window (`sed -n '1415,2193p' $X`) or
+`awk '/<Scene sr="sceneAAB Brightness Settings"/,/<\/Scene>/'`. Scenes end at the next
+`</Scene>`; the last scene ends before the first `<Task sr=` block (~L8560+).
+Element histogram across all 20: 224 RectElement, 129 TextElement, 28 WebElement,
+22 EditTextElement, 20 PropertiesElement, 16 SwitchElement, 6 SliderElement, 5 ButtonElement.
+
+## R6 — Window peek by line numbers
+
+```bash
+sed -n '15204,15260p' $X
+```
+
+Use after `grep -n` to inspect a region. Keep windows ≤ 150 lines.
+
+## R7 — The 40 embedded Java blocks (action `<code>474</code>`)
+
+**Java Code actions are `<code>474</code>`. NOT 598** (598 = Variable Search/Replace; it also
+appears 35× — an earlier audit confused the two). The Java source is in `<Str sr="arg0">`,
+XML-entity-encoded (`&lt; &gt; &amp; &quot;`) — decode before saving. `arg1` = output variable.
+
+Census mapping (verified line → enclosing task; note several tasks have TWO blocks):
+
+| Line | Task | Name |
+|---|---|---|
+| L8906 | task105 | _GetWifiNoLocation V3 |
+| L9468 | task378 | _PrivilegeDetection V5 (Java) |
+| L9921 | task38 | _SuggestCurveParameters V24 (Hybrid) |
+| L12091 | task43 | _EvaluateContexts V2 |
+| L14246 | task524 | _CalibratePowerDraw |
+| L15204 | task535 | Lux Smoothing (Java) |
+| L15878 | task543 | Calculate Animation (Java) V2 |
+| L16062 | task544 | Evaluate Light Change (Java) V2 |
+| L16481 | task546 | Set Thresholds (Java) |
+| L16630 | task548 | Dynamic Range Compressed Scale (Java) V2 |
+| L17138 | task549 | _GenerateCircadianGraph V8 (Java) |
+| L18132 | task554 | Process Sensor Event (Java) |
+| L18359 | task556 | _GenerateDimmingCurveGraph (Java) |
+| L18959 | task557 | _GenerateAlphaGraph (Java) |
+| L19677 | task563 | _AskPermissionsV7 |
+| L24132 | task592 | _CreateDefaultProfiles |
+| L25826, L26096 | task618 | Set Initial Brightness (Java) V3 (×2) |
+| L26400 | task620 | _AdaptiveBrightnessSceneSize V4 |
+| L26926 | task623 | _ContextManager |
+| L27185 | task625 | _AppPicker |
+| L27355 | task626 | _ContextResume |
+| L27585, L27817 | task630 | _ContextLocnListener V4 (×2) |
+| L27939, L28432 | task631 | _ContextF5NetLoc V8 (×2) |
+| L28827 | task633 | _GetWifiForContext |
+| L28993 | task636 | _DeleteOverridePoint |
+| L29303 | task637 | _ProfileManager |
+| L30505 | task643 | _LearnWriteSecure |
+| L32591 | task655 | _SetSuggestedVariables |
+| L32986 | task657 | _GenerateCompressionGraph (Java) |
+| L33944, L34370 | task663 | _GenerateGraph (Java) (×2) |
+| L35733 | task696 | Smooth Brightness Transition V5 (Java) |
+| L36043 | task698 | Smooth DC-Like Brightness Transition V5 (Java) |
+| L36847 | task703 | _GenerateReactivityGraph (Java) |
+| L37517 | task705 | _GenerateCircadianDimmingGraph (Java) |
+| L40429, L41085 | task90 | Dynamic Scale V13 (Java) App Version (×2) |
+
+Reusable census command (regenerates the table above):
+
+```bash
+python3 - <<'EOF'
+import re
+lines = open('Advanced_Auto_Brightness_V3.3.prj_9.xml', encoding='utf-8').read().splitlines()
+task_re, nme_re = re.compile(r'<Task sr="task(\d+)">'), re.compile(r'<nme>([^<]*)</nme>')
+cur, name, pending = None, None, False
+for i, l in enumerate(lines, 1):
+    m = task_re.search(l)
+    if m: cur, name, pending = m.group(1), None, True; continue
+    if pending:
+        n = nme_re.search(l)
+        if n: name, pending = n.group(1), False
+    if '<code>474</code>' in l: print(f"L{i}\ttask{cur}\t{name}")
+EOF
+```
+
+**⚠️ task661 "Map Lux to Brightness (Java) V2" has NO Java block** despite its name — its 32
+actions are Tasker `Variable Set` (code 547, supports maths expressions), `Perform Task` (130),
+If/Else, one built-in `Set Display Brightness` (810). The 3-zone curve formula in *Java* form
+exists inside graph generator task663 (~L34405) as a plot-side reimplementation — use it to
+cross-validate the runtime math extracted from task661's actions, not as its source.
+
+**⚠️ `%var` substitution semantics:** Tasker textually substitutes variable VALUES into the Java
+source before compiling (e.g. `double par1 = %par1;` becomes `double par1 = 42.0;`). When
+transcribing to a reference implementation, each `%X` becomes a function parameter.
+
+## R8 — Action-code histogram inside a task
+
+```bash
+awk '/<Task sr="task661">/,/<\/Task>/' $X | grep -o '<code>[0-9]*</code>' | sort | uniq -c | sort -rn
+```
+
+Frequent codes in this project (derive others from context/`<label>` hints, record unknowns —
+do not guess): 547 Variable Set · 37 If · 38 End If · 43 Else/Else-If · 130 Perform Task ·
+548 Flash · 549 Variable Clear · 474 Java Code · 598 Variable Search/Replace · 30 Wait ·
+137 Stop · 810 Set Display Brightness · 235 Custom Setting · 779(?) shell-adjacent ·
+523 Notify · 159/165(?) — verify in place.
+
+## R9 — Whole-file pattern hunting
+
+```bash
+grep -n 'reduce_bright_colors' $X     # super-dimming secure setting writes
+grep -n 'Settings.System' $X          # direct settings API usage in Java blocks
+grep -n 'Shizuku' $X                  # privilege escalation path (14 hits)
+grep -n 'pm grant' $X                 # adb grant instructions
+```
+
+## R10 — prj_4 (older revision, for archaeology only)
+
+```bash
+git show 9d36d36^:Advanced_Auto_Brightness_V3.3.prj_4.xml | grep -c '<Task sr='
+```
+
+prj_9 ≈ prj_4: only `_SuggestCurveParameters` bumped V23→V24 (task id 41→38). Codex-era
+docs in docs/migration/ were derived from prj_4 and are therefore NOT stale, just shallow.

--- a/scripts/setup-android-sdk.sh
+++ b/scripts/setup-android-sdk.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Idempotent Android SDK bootstrap for Claude Code cloud sessions.
+# Usage: scripts/setup-android-sdk.sh   (takes ~3-5 min on first run, instant after)
+# Installs commandline-tools + platform-tools + android-35 + build-tools 35.0.0
+# into $HOME/android-sdk and writes local.properties at the repo root.
+set -eu
+
+SDK_ROOT="${ANDROID_SDK_ROOT:-$HOME/android-sdk}"
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CLT_URL="https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip"
+
+write_local_properties() {
+    printf 'sdk.dir=%s\n' "$SDK_ROOT" > "$REPO_DIR/local.properties"
+}
+
+if [ -d "$SDK_ROOT/platforms/android-35" ] && [ -x "$SDK_ROOT/platform-tools/adb" ]; then
+    write_local_properties
+    echo "[setup-android-sdk] SDK already present at $SDK_ROOT; local.properties refreshed."
+    exit 0
+fi
+
+start="$(date +%s)"
+echo "[setup-android-sdk] installing SDK into $SDK_ROOT ..."
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+curl -fsSL "$CLT_URL" -o "$tmp/clt.zip"
+unzip -q "$tmp/clt.zip" -d "$tmp"
+mkdir -p "$SDK_ROOT/cmdline-tools"
+rm -rf "$SDK_ROOT/cmdline-tools/latest"
+mv "$tmp/cmdline-tools" "$SDK_ROOT/cmdline-tools/latest"
+
+SDKMANAGER="$SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+# `yes` dies of SIGPIPE when sdkmanager exits; the subshell || true keeps set -e happy.
+(yes || true) | "$SDKMANAGER" --sdk_root="$SDK_ROOT" --licenses > /dev/null
+"$SDKMANAGER" --sdk_root="$SDK_ROOT" "platform-tools" "platforms;android-35" "build-tools;35.0.0" > /dev/null
+
+write_local_properties
+echo "[setup-android-sdk] done in $(( $(date +%s) - start ))s. sdk.dir=$SDK_ROOT"


### PR DESCRIPTION
## Summary

This commit establishes the complete scaffolding and documentation framework for a multi-session AI-driven rebuild of the Tasker-based Advanced Auto Brightness project into a modern Kotlin/Compose Android application. No source code or gradle configuration changes are included; this is purely organizational and instructional infrastructure.

## Key Changes

- **CLAUDE.md** — Master protocol document defining the multi-session workflow, architecture target, build commands, and a corrections ledger capturing hard-won facts about the Tasker XML structure (e.g., Java blocks are action code 474, not 598; task661 contains no Java despite its name).

- **docs/rebuild/RUNBOOK.md** — Detailed segment briefs (S0–S14) specifying objectives, inputs, deliverables, acceptance criteria, and failure protocols for each phase. Includes an execution DAG showing dependencies and parallel windows.

- **docs/rebuild/XML_RECIPES.md** — Verified access patterns and census commands for the 1.6 MB Tasker XML file, with line-number anchors for all 18 profiles, 20 scenes, and 40 embedded Java blocks. Prevents context-window waste by providing surgical extraction recipes rather than wholesale file reads.

- **docs/rebuild/PARITY_CHECKLIST.md** — Comprehensive inventory of all Tasker artifacts (18 profiles, ~25 task clusters, 20 scenes, 40 Java blocks) with status tracking from `pending` → `ported` → `device-verified`. Segments flip rows they own; S14 enforces zero pending items.

- **docs/rebuild/STATE.md** — Cross-session memory file: segment log, current state summary, next-up queue, and a deviations/discoveries ledger (D-001 through D-007) capturing audit findings that override older documentation.

- **scripts/setup-android-sdk.sh** — Idempotent Android SDK bootstrap script for Claude Code cloud sessions. Installs commandline-tools, platform-tools, android-35, and build-tools 35.0.0 into `$HOME/android-sdk` and writes `local.properties`. Runs in ~3–5 minutes on first invocation, instant thereafter.

- **.claude/settings.json** — Claude Code session configuration: SessionStart hook, bash command permissions for gradle and SDK setup.

- **.claude/hooks/session-start.sh** — SessionStart hook that runs the SDK bootstrap script on remote container sessions and logs readiness.

- **.gitignore** — Added `local.properties` and `.claude/settings.local.json` to prevent committing machine-specific or session-local configuration.

## Notable Details

- The RUNBOOK execution DAG shows S0–S3 as parallel-safe (disjoint files), with S1 and S2 extracting ground truth from the Tasker XML in parallel, and S3 modernizing the build toolchain independently.
- The corrections ledger in CLAUDE.md and STATE.md captures critical findings: the 40 Java blocks are scattered across 25 tasks (some with two blocks each), profile-level ConditionLists carry pipeline gating logic that must not be missed, and task661's curve math lives in Variable Set expressions, not Java.
- The XML_RECIPES.md provides census commands (e.g., `grep -c '<code>474</code>'` → 40) and line-number anchors verified against the actual XML file as of 2026-06-11, enabling future sessions to extract artifacts surgically without loading the entire 41,291-line file.
- No gradle wrapper or build configuration is present yet; S3 will bootstrap via `/opt/gradle/bin/gradle` (8.14.3) and then commit the wrapper.

This scaffolding enables a structured, auditable, multi-session rebuild with clear handoff points, shared state, and failure recovery protocols.

https://claude.ai/code/session_01SmLFxkxVWnh5ca7m4KtXTB