### PR TITLE
S3.5 errata: owner-review corrections to extraction docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ You are one session in a multi-session rebuild program. The program converts the
 `Advanced_Auto_Brightness_V3.3.prj_9.xml` (repo root, 1.6 MB — **NEVER read it wholesale; use
 `docs/rebuild/XML_RECIPES.md`**) into a modern Kotlin/Compose Android app with feature parity.
 A previous AI conversion attempt was audited: parts are salvaged (see ledger below), the rest is
-rebuilt segment by segment. Work happens on branch **`claude/modest-bohr-5ybl2i`** only.
+rebuilt segment by segment. Work happens on **your session's assigned `claude/*` branch** (see Git rules).
 
 ## Session protocol (follow in order, every session)
 
@@ -17,7 +17,7 @@ rebuilt segment by segment. Work happens on branch **`claude/modest-bohr-5ybl2i`
 5. Run your segment's acceptance commands until green.
 6. Update `docs/rebuild/STATE.md` (append your segment-log row, update "Current state" and
    "Next up", add any deviations/discoveries) and flip your PARITY_CHECKLIST.md rows.
-7. Commit with message prefix `[Sx] ` and push: `git push -u origin claude/modest-bohr-5ybl2i`.
+7. Commit with message prefix `[Sx] ` and push: `git push -u origin <your-session-branch>`.
 
 **Never leave the branch red.** If acceptance cannot go green: revert source changes (or move
 them to side branch `claude/blocked-Sx`), still commit+push the STATE.md update with
@@ -83,6 +83,15 @@ dimming. Shizuku is used only in the grant flow, never as a runtime binder depen
   `R.mipmap.ic_launcher` but no `res/` exists.
 - Environment: no KVM → no emulator. Verification = compile + JVM/Robolectric tests; on-device
   behavior is checked by the human at Gates 1–3 (see RUNBOOK).
+- S3.5 owner-review corrections (trust these; details in extraction docs + STATE.md D-020…D-026):
+  ConditionList semantics = plain And/Or bind tighter (And > Or), And2/Or2 join those groups
+  left-to-right; ⚠️ ConditionList children are ALPHABETICAL in the XML — re-sort numerically
+  (this scrambled S1's prof758 transcription). Action 590 = Variable Split, 105 = Set Clipboard.
+  %AAB_Debug = 10 named toast categories (Debug-scene selector labels), not verbosity.
+  %AAB_Test = curve-wizard diagnostics report → clipboard (user-facing — surface it). prof759/
+  task545 sets %AAB_Proximity near/far → damps LuxAlpha ×0.1, never pauses. prof769 panic =
+  upside-down + shake. 168/276 tasks are anonymous scene handlers → see
+  extraction/tasks/anonymous_handlers.md. Never read Tasker prefs (adbwp) in the rebuild.
 
 ## Coding conventions
 
@@ -98,8 +107,12 @@ dimming. Shizuku is used only in the grant flow, never as a runtime binder depen
 
 ## Git rules
 
-- Branch `claude/modest-bohr-5ybl2i` only. Never force-push. Never push to main.
-- Commit prefix `[Sx] `. Push with `git push -u origin claude/modest-bohr-5ybl2i`
+- Each cloud session gets its OWN `claude/<codename>` branch, named in the session directive.
+  This is **by design** (D-020): the owner merges each segment to `main` via PR after stage
+  completion, and new sessions start from fresh main. Develop and push ONLY on your session's
+  assigned branch. Do NOT log, explain, or try to reconcile branch-name differences between
+  sessions — that question is settled. Never force-push. Never push to main.
+- Commit prefix `[Sx] `. Push with `git push -u origin <your-session-branch>`
   (retry up to 4× with backoff 2s/4s/8s/16s on network errors only).
-- If parallel segments raced you (push rejected): `git pull --rebase origin
-  claude/modest-bohr-5ybl2i` — STATE.md conflicts are append-both-sides, trivial to merge.
+- Parallel segments (S6∥S7∥S8) land on separate session branches; the owner's stage merges
+  absorb STATE.md append-both-sides conflicts.

--- a/docs/rebuild/PARITY_CHECKLIST.md
+++ b/docs/rebuild/PARITY_CHECKLIST.md
@@ -62,6 +62,7 @@ filled by S1/S2 during extraction.
 | Profiles/import/export/defaults: 592, 637, 622 | | S2 extracted → features_spec.md | pending |
 | Debug tooling: 634, 635 | | S2 extracted → features_spec.md | pending |
 | Misc UI plumbing tasks (scene-resize 620, exits 656, toggles 547/553/555/558/560/576/587/589/638/648/649, chartjs cache 581, logo 619, color 639/379/579/652, about/license/guide 380/401/512, updates 706, experiments 540/541/542/381/382) | | S2 extracted → screen_map.md (scene dispositions) | pending |
+| **Anonymous scene-handler tasks (168 unnamed**, incl. 34 `keyTask` back-key handlers) | various | S3.5 census → extraction/tasks/anonymous_handlers.md | pending (S12/S13: every row ported or dropped(reason)) |
 
 ## Scenes (20) → M3 screens (~9, per S2 screen_map.md)
 
@@ -82,7 +83,7 @@ filled by S1/S2 during extraction.
 | AAB Alpha Graph | L1038 | Reactivity (alpha overlay) | pending (S2 extracted) |
 | AAB Reactivity Graph | L6563 | Reactivity (ReactivityChart) | pending (S2 extracted) |
 | AAB Dimming Graph | L3006 | Animation & Dimming (DimmingChart) | pending (S2 extracted) |
-| AAB Circadian Dimming Graph | L2388 | Dynamic Scale (CircadianChart) | pending (S2 extracted) |
+| AAB Circadian Dimming Graph | L2388 | Animation & Dimming (CircadianChart; re-homed S3.5/D-026, visible only when %AAB_ScalingUse on) | pending (S2 extracted) |
 | AAB Taper Graph | L8387 | Dynamic Scale (TaperChart) | pending (S2 extracted) |
 | AAB Power Draw Graph | L5611 | Tools (PowerDrawChart) | pending (S2 extracted) |
 | AAB Experiment Graph | L3170 | Dynamic Scale (ExperimentChart) | pending (S2 extracted) |

--- a/docs/rebuild/RUNBOOK.md
+++ b/docs/rebuild/RUNBOOK.md
@@ -514,7 +514,9 @@ resolver test matrix matches spec table 1:1; pushed.
 Parallel window C (with S10 — disjoint packages; rebase before push).
 
 **Objective:** Compose M3 navigation shell (screen set per `screen_map.md`), privilege
-onboarding via ActivityResultContracts, live Dashboard.
+onboarding via ActivityResultContracts, live Dashboard. Onboarding parity contract = task563's
+8 gates + order (features_spec); the polling-dialog flow itself is a sanctioned deviation
+(D-024) — do not port it, and never read Tasker prefs (`adbwp`) in privilege detection.
 
 **Inputs:** `screen_map.md`, existing `app/.../ui/*` + `navigation/*` + `state/
 SettingsViewModel.kt`, `PrivilegeManager`, `ServiceHealthStore`, pipeline state flows.
@@ -548,9 +550,12 @@ Robolectric compose smoke test: launch → Dashboard renders, each route navigat
 **Objective:** Every parameter/tool/profile screen with Tasker-faithful validation, plus the
 reusable Compose-Canvas chart engine with the brightness-curve chart as template instance.
 
-**Inputs:** `screen_map.md` + `extraction/scenes/*` (element dispositions), S8
-`SettingsValidator`, S6 `CurveSuggestionEngine`, existing `LineGraph.kt` (extend or replace —
-your call, record it), `extraction/features_spec.md` (calibration/debug).
+**Inputs:** `screen_map.md` + `extraction/scenes/*` (element dispositions) +
+`extraction/tasks/anonymous_handlers.md` (S3.5/D-026: **168 anonymous scene-handler tasks —
+every row owned by your screens must end up ported or dropped(reason); includes the 34
+`keyTask` rows = per-scene back-key behavior**), S8 `SettingsValidator`, S6
+`CurveSuggestionEngine`, existing `LineGraph.kt` (extend or replace — your call, record it),
+`extraction/features_spec.md` (calibration/debug — debug selector uses the 10 verbatim labels, D-023).
 
 **Deliverables:** screens per screen_map: Curve & Brightness (min/max/offset/scale, zone ends,
 form params + LIVE derived form2A/form3A readout), Reactivity (thresholds incl. midpoint/
@@ -581,7 +586,7 @@ scene rows flipped for covered scenes; pushed. → **HUMAN GATE 2.**
 ## S13 — Chart replication + static screens
 
 **Model:** Haiku / high · **Size:** medium · **Preconditions:** S12 DONE (template exists),
-S6 DONE (chart math), S2 scene docs.
+S6 DONE (chart math), S2 scene docs + `extraction/tasks/anonymous_handlers.md` (S3.5).
 
 **Objective:** Replicate the remaining charts from the template and port static content
 screens. Pure pattern work.

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -12,6 +12,7 @@ next session does not know it.
 | S1 extraction A | 2026-06-11 | Opus/high | DONE | (this commit) | 40 Java blocks decoded; 28 task docs; profiles.md (753–761,769); pipeline_spec.md; defaults_audit.md (125 vars); INDEX.md. Docs-only. Java "Extracted" checklist cells flipped. |
 | S2 extraction B | 2026-06-11 | Opus/medium | DONE | (this commit) | task090_dynamic_scale.md (+solar answer), task038_curve_wizard.md, contexts_spec.md, features_spec.md, 20 scene docs + 4 _disp fragments, screen_map.md (450-element matrix → 9 M3 screens). Docs-only. Scene/context-profile/non-pipeline-cluster checklist cells annotated "S2 extracted". |
 | S3 toolchain | 2026-06-11 | Sonnet/medium | DONE | (see push) | Gradle 8.14.3 wrapper; D-007 fixed (pluginManagement); libs.versions.toml (Kotlin 2.0.21, AGP 8.7.3, compose-bom 2024.12.01); :platform → com.android.library; :data retired (git rm); res/ created; manifest updated (specialUse FGS + all permissions); lint-baseline.xml frozen. Pre-existing compile bugs fixed (D-019). :app:assembleDebug ✅ :platform:test ✅ :app:lintDebug ✅; :domain:test 4/5 pass (1 pre-existing parity failure — rapidLuxSpike, D-019, S4/S5 fix). |
+| S3.5 errata (owner review) | 2026-06-11 | Fable | DONE | (this commit) | Owner-review corrections folded into extraction docs + CLAUDE.md (D-020…D-026): branch policy settled; And2/Or2 rule validated + alphabetical-XML-ordering trap found (prof758 bool sequence fixed); prof759/769 semantics corrected; debug = 10 named categories; 590=Variable Split, 105=Set Clipboard; %AAB_Test = wizard report→clipboard; non-AAB globals censused; Circadian Dimming Graph re-homed; 168-anonymous-task census added (tasks/anonymous_handlers.md) + task545 doc. Docs-only — build untouched. |
 
 Status values: DONE · PARTIAL · BLOCKED (see failure protocol in CLAUDE.md).
 
@@ -22,6 +23,8 @@ all pass. APK at `app/build/outputs/apk/debug/app-debug.apk` (28 MB). Gradle 8.1
 committed; version catalog at `gradle/libs.versions.toml`; :platform is now an Android library;
 :data retired. One pre-existing domain test failure remains (`rapidLuxSpike_isSmoothedByTaskerFormula`
 — engine parity bug per D-019, not a new regression). S4 is now unblocked.
+S3.5 (owner-review errata) applied on top: extraction docs corrected per D-020…D-026 — read those
+entries before trusting any pre-S3.5 reading of profile gates, debug levels, or action codes 590/105.
 
 ## Next up
 
@@ -124,7 +127,45 @@ Seeded by the S0 audit (details in CLAUDE.md "Facts & corrections ledger"):
   Final version matrix: Kotlin 2.0.21, AGP 8.7.3, Compose BOM 2024.12.01, Gradle 8.14.3, minSdk 31,
   compileSdk/targetSdk 35. (Affects S4: note the domain compile fix; S5: fix engine parity.)
 
-Append new entries as D-020, D-021, … with which segments they affect.
+- D-020: BRANCH POLICY RESOLVED (closes D-011, D-012). Per-session `claude/*` branches are BY DESIGN:
+  the owner merges each segment to main via PR after stage completion; sessions start from fresh main.
+  CLAUDE.md rewritten accordingly. Future sessions: do NOT log or reconcile branch-name differences.
+- D-021: ConditionList semantics VALIDATED (owner-confirmed prof760 staging incl. `%AAB_MainLoop != On`
+  mutex polarity; cross-checked on prof758): plain `And`/`Or` bind tighter (inner groups, `And` > `Or`);
+  `And2`/`Or2` join those groups left-to-right. Resolves D-009 + INDEX unresolved #1; S9 runtime
+  validation downgraded to a Gate-1 sanity check. DISCOVERY: ConditionList children are stored
+  ALPHABETICALLY in the XML (`bool10` < `bool2`) — S1's prof758 bool sequence was scrambled by this;
+  fixed in profiles.md; recipe R4 updated. task551 act0 reading resolved (D-018 leftover).
+  (Affects S4 gate vectors, S9.)
+- D-022: prof769 contexts verified (XML L722–743): Event 2083 (significant-motion/shake) + State 120
+  arg0=3 (orientation upside-down) + State 123 arg0=1 — panic = flip + shake → max brightness, listeners
+  off, `%AAB_Service=Off`. prof759/task545 "Detect Proximity" (L16424, new doc
+  tasks/task545_detect-proximity.md) sets `%AAB_Proximity` near/far; damps LuxAlpha ×0.1 in task544 —
+  it never pauses the pipeline. (Affects S9.)
+- D-023: `%AAB_Debug` = 10 named info categories from the Debug-scene selector (XML L2773–2782): Off /
+  Skip Animations / Animation Details / Light Eval Thresholds / Dynamic Scale Calcs / Super Dimming
+  Info / Overlay Preview / Graph Metrics / Context Automation / Context Location. S1's inferred glosses
+  for 7/8/9 were wrong; features_spec corrected. (Affects S12 debug UI.)
+- D-024: SANCTIONED DEVIATIONS (owner): (a) privilege detection must NOT read Tasker pref `adbwp`
+  (drop ADB-WiFi probing; elevated truth = checkPermission(WRITE_SECURE_SETTINGS); ADB/Shizuku/root are
+  grant channels only — matches existing S7/S11 design); (b) task563's polling-dialog onboarding flow is
+  NOT the parity contract — only its 8 gates + order are; S11 keeps its ActivityResultContracts design.
+  (Affects S7, S11.)
+- D-025: `%AAB_Test` = curve-wizard diagnostics report (R²/nRMSE/bias; task38 logBuffer), copied to
+  clipboard via the single code-105 action (L9864), documented to users (guide L8715) — surface in the
+  rebuilt wizard UI (S6/S12). INDEX action codes fixed: 590 = Variable Split (was mislabeled "Array
+  Push"), 105 = Set Clipboard. defaults_audit: added the 4 non-AAB capital-letter globals
+  (%SmoothedLux 15× / %AutoBrightRunning 13× / %LastAAB 10× / %LuxAlpha 9×); `%AAB_MaxSteps`
+  owner-confirmed legacy (abandoned predecessor of AnimSteps — do not port). (Affects S4, S6, S8, S12.)
+- D-026: ANONYMOUS TASKS: 168 of 276 tasks are unnamed scene-element handlers; ALL are wired from
+  scenes (none dead); 34 are `keyTask` = per-scene back/hardware-key behavior that S2 dropped as scene
+  chrome. Census: extraction/tasks/anonymous_handlers.md — S12/S13 precondition (every row ported or
+  dropped(reason)). Circadian Dimming Graph re-homed Dynamic Scale → Animation & Dimming (owner; opened
+  from Superdimming Settings via task517, button visible only when `%AAB_ScalingUse` on; screen_map +
+  superdimming_settings gloss fixed — old `_CalibratePowerDraw` gloss was wrong; _disp_group4 already
+  agreed). (Affects S12, S13.)
+
+Append new entries as D-027, D-028, … with which segments they affect.
 
 ## Blockers
 

--- a/docs/rebuild/XML_RECIPES.md
+++ b/docs/rebuild/XML_RECIPES.md
@@ -12,7 +12,7 @@ X=Advanced_Auto_Brightness_V3.3.prj_9.xml
 
 ```bash
 grep -c '<Profile sr=' $X    # => 18
-grep -c '<Task sr=' $X       # => 276   (Task elements; ~159 carry <nme> names)
+grep -c '<Task sr=' $X       # => 276   (Task elements; 108 carry <nme> names — S3.5 verified; the old "~159" counted ALL <nme> in the file incl. profiles/scenes)
 grep -c '<Scene sr=' $X      # => 20
 grep -c '<Action sr=' $X     # => 2274
 grep -c '<code>474</code>' $X  # => 40  (embedded Java blocks — see R7)
@@ -35,7 +35,8 @@ grep -A6 '<Task sr=' $X | grep -E '<(id|nme)>'
 ```
 
 Emits `<id>` and (when present) `<nme>` pairs in file order. Unnamed Task elements are
-anonymous (scene-embedded/click handlers); the named ~159 are the real inventory.
+anonymous scene handlers (168 of them — see R11 + `extraction/tasks/anonymous_handlers.md`);
+the 108 named tasks are the by-name inventory (S3.5-corrected count; was misstated as ~159).
 
 ## R4 — Profiles. ⚠️ Profiles carry a `ve="2"` attribute — do NOT close the pattern with `>`
 
@@ -52,6 +53,12 @@ prof769 L722, prof8 L744. (All 18 live in lines 3–798, before the scenes.)
 Inside a profile: `<id>`, `<nme>`, `<mid0>` = enter task id, `<mid1>` = exit task id,
 `<pri>` = priority, then context children (`<Event sr="con0">`, `<State ...>`, `<App ...>`,
 `<Time ...>`, `<Day ...>`) each with a `<code>` (context type) and args.
+
+**⚠️ ConditionList children are stored ALPHABETICALLY, not numerically** (`bool10`/`bool11`/`bool12`
+sort before `bool2`; `c10` before `c2`). Re-sort by numeric index before reading a gate, or the boolean
+sequence comes out scrambled — this mis-transcribed prof758 in S1 (fixed S3.5, D-021). Boolean
+semantics (owner-validated, D-021): plain `And`/`Or` bind tighter (inner groups, `And` > `Or`);
+`And2`/`Or2` join those groups left-to-right.
 
 **⚠️ Profile-level `<ConditionList sr="if">` blocks are load-bearing pipeline logic.**
 Example: prof760 "Monitor Ambient Light" (Event code 2088 = Sensor, type 5 = light, arg2=1000ms)
@@ -205,3 +212,16 @@ git show 9d36d36^:Advanced_Auto_Brightness_V3.3.prj_4.xml | grep -c '<Task sr='
 
 prj_9 ≈ prj_4: only `_SuggestCurveParameters` bumped V23→V24 (task id 41→38). Codex-era
 docs in docs/migration/ were derived from prj_4 and are therefore NOT stale, just shallow.
+
+## R11 — Anonymous (unnamed) tasks → scene handlers (S3.5)
+
+168 of 276 tasks have no `<nme>` — all are scene-element handlers (`<clickTask>`, `<checkchangeTask>`,
+`<valueselectedTask>`, `<keyTask>`, …) referenced by id from `<Scene>` blocks. Census + wiring +
+action summaries: `extraction/tasks/anonymous_handlers.md`. Find the callers of task N:
+
+```bash
+grep -n ">N</" $X | grep -v "<id>"     # e.g. <clickTask>517</clickTask>
+```
+
+Extract the body with R2. Named tasks are never wired by id from scenes (they are invoked by name via
+Perform Task / scene-HTML `performTask('Name', pri)`).

--- a/docs/rebuild/extraction/INDEX.md
+++ b/docs/rebuild/extraction/INDEX.md
@@ -47,12 +47,13 @@ task535 → `%output` and task548 → `%dr_results`.)
 | 355 | Array Push (value at index) | `%AAB_Overrides` push (task561 act6/9) |
 | 356 | Array element delete | `%AAB_Overrides` delete at index (task561 act14) |
 | 389 | Multiple Variables Set | newline-separated `name=value` block (task544 act2/14/27) |
+| 105 | Set Clipboard (S3.5, owner-corrected) | single use: `%AAB_Test` → clipboard (L9864, curve-wizard report — D-025) |
 | 474 | Java Code | arg0 = source (entity-encoded), arg1 = optional output var |
 | 523 / 779 | Notify / Notify Cancel(by title) | task567 act19 notify; task567/569 cancel |
 | 547 | Variable Set | arg0=name, arg1=value; arg2=Recurse, **arg3=DoMaths**, arg4=Append |
 | 548 | Flash | arg0=text |
 | 549 | Variable Clear | arg0=name |
-| 590 | Array Push (split by sep) | `%lux_results` split on `,` (task544 act26) |
+| 590 | **Variable Split** (S3.5, owner-corrected — was mislabeled "Array Push") | arg0=var, arg1=separator (`,`), arg2=delete-base; e.g. `%lux_results` split (task544 act26); 9 uses |
 | 598 | Variable Search/Replace | R7 (NOT Java — see D-001) |
 | 810 | Set Display Brightness | arg0=brightness (task661 act45) |
 
@@ -64,16 +65,19 @@ Condition `<op>` codes (project-wide histogram): `0 ~` · `1 !~` · `2 =` · `3 
 
 ## Unresolved (recorded, NOT guessed)
 
-1. **Tasker `And2`/`Or2` boolean grouping** in multi-clause profile gates (prof760 accuracy/abs/main-loop;
-   prof758 dawn/dusk windows). The literal condition+bool sequences are captured verbatim in
-   `profiles.md`; the parenthesized reading is best-effort (And2/Or2 = tighter binding). **S4/S9 must
-   confirm the exact grouping against runtime behavior** before relying on the polarity of
-   `%AAB_MainLoop != On` and the abs-dead-band OR.
-2. **`%AAB_MaxSteps`** appears in the 125-var census but is **never assigned a default** (task570/592/637).
-   Treat as legacy/unused; do not invent a value. S8 to decide (recompute from `AnimSteps` if a cap is needed).
-3. **Context subtype codes 165 (State vs Time), 123, 2083** — best-guess given (periodic/state/panic);
-   exact Tasker context subtype IDs not cross-referenced to an external table. Effect is unambiguous from
-   the gate + enter task; only the raw code label is uncertain.
+1. **RESOLVED (S3.5, owner-verified → D-021).** `And2`/`Or2` grouping: plain `And`/`Or` bind tighter
+   (inner groups, `And` > `Or`); `And2`/`Or2` join those groups left-to-right. prof760's reading
+   confirmed by the owner (incl. the `%AAB_MainLoop != On` mutex polarity); prof758 re-derived in
+   `profiles.md` — whose bool sequence was also FIXED there (⚠️ ConditionList children are stored
+   ALPHABETICALLY in the XML; re-sort numerically — see R4). task551 act0 reading updated in
+   `features_spec.md`. Residual: Gate-1 runtime sanity check only.
+2. **RESOLVED (S3.5, owner-confirmed → D-025).** `%AAB_MaxSteps` is legacy — the abandoned predecessor
+   of `AAB_AnimSteps`. Do not port; do not invent a default.
+3. **Context subtype codes 165 (State vs Time), 123** — best-guess given (periodic/state); exact Tasker
+   context subtype IDs not cross-referenced to an external table. Effect is unambiguous from the gate +
+   enter task; only the raw code label is uncertain. **2083 resolved (S3.5, owner):** prof769's trigger
+   is the significant-motion/shake event; its companion State 120 arg0=3 = Orientation "upside down"
+   (123 arg0=1 label still inferred).
 4. **Action codes 49, 135, 300, 355, 356** — meanings inferred from in-place evidence (hide-scene, goto,
    loop anchor, array push, array delete), not from a canonical Tasker code table. High confidence but
    flagged. **389 = Multiple Variables Set** is confident.

--- a/docs/rebuild/extraction/defaults_audit.md
+++ b/docs/rebuild/extraction/defaults_audit.md
@@ -14,6 +14,24 @@ Source of truth: **task570 _Initialize AAB Defaults_** (`extraction/tasks/task57
 
 **Settings present in census but MISSING from `AabSettings.kt`:** `AAB_AnimSteps`, `AAB_ContextOverride` (per-profile override flag), `AAB_SetupTitle` (UI string), plus DERIVED `AAB_ThreshMidpoint`. → S8 schema-v2 work.
 
+## Non-`%AAB_` globals (S3.5 addendum, owner-prompted — D-025)
+
+Tasker namespacing: a variable is **global iff its name contains a capital letter anywhere**
+(`%sHeep` = `%Sheep` = `%SHEEP` = global). The S1 census scanned only `%AAB_*` and missed the
+pipeline's four bare globals (all RUNTIME, no defaults; already specced in `pipeline_spec.md`
+§state-vars — this fixes the audit's scope, not the pipeline spec):
+
+| Variable | XML hits | Meaning |
+|---|---|---|
+| `%SmoothedLux` | 15 | EMA-smoothed lux (task544/535; cleared by task585) |
+| `%AutoBrightRunning` | 13 | 1 while the pipeline is writing brightness (echo suppression) |
+| `%LastAAB` | 10 | TIMEMS of last accepted tick (throttle gate) |
+| `%LuxAlpha` | 9 | last smoothing alpha → animation pacing (prox-damped ×0.1) |
+
+(Scan: `grep -oE '%[A-Za-z][A-Za-z0-9_]*' | grep [A-Z]`, minus `%AAB_*` and ALL-CAPS Tasker
+built-ins; the two remaining one-off hits are HTML/Java false positives. Future audits must
+include this scan.)
+
 ## Full table
 
 | Variable | Default (task570 unless noted) | Class | In AabSettings.kt? | Meaning |
@@ -76,7 +94,7 @@ Source of truth: **task570 _Initialize AAB Defaults_** (`extraction/tasks/task57
 | `%AAB_MainLoop` | — | RUNTIME | NO | On/Off main-loop gate flag (prof760 gate) |
 | `%AAB_Manual_Override` | — | RUNTIME | NO | true when user manually overrode brightness (pause) |
 | `%AAB_MaxBright` | 255 | SETTING | yes | User setting (see task570) |
-| `%AAB_MaxSteps` | — | RUNTIME | NO | Referenced but NEVER assigned a default in task570 — legacy/unused (see D-004 resolution) |
+| `%AAB_MaxSteps` | — | LEGACY | NO | Never assigned a default; owner-confirmed (S3.5, D-025): abandoned predecessor of `AAB_AnimSteps` — do not port (see D-004 resolution) |
 | `%AAB_MaxWait` | 65 | SETTING | yes | User setting (see task570) |
 | `%AAB_MinBright` | 10 | SETTING | yes | User setting (see task570) |
 | `%AAB_MinThrottle` | — | RUNTIME | NO | Referenced lower bound for throttle — not defaulted in 570 (runtime/legacy) |
@@ -124,7 +142,7 @@ Source of truth: **task570 _Initialize AAB Defaults_** (`extraction/tasks/task57
 | `%AAB_Sunnoon` | — | RUNTIME | NO | Solar noon |
 | `%AAB_Sunrise` | — | RUNTIME | NO | Sunrise time |
 | `%AAB_Sunset` | — | RUNTIME | NO | Sunset time |
-| `%AAB_Test` | — | RUNTIME | NO | Debug/test scratch var |
+| `%AAB_Test` | — | RUNTIME | NO | **Curve-wizard diagnostics report** (R²/nRMSE/bias log built by task38 `setVariable("AAB_Test", logBuffer)` L10510/L10867), **copied to clipboard** via the project's only Set Clipboard action (code 105, L9864) and documented to users in the guide (L8715). Key explainability output — surface it in the rebuilt wizard UI (S6/S12; owner-corrected S3.5, D-025) |
 | `%AAB_ThreshAbsHigh` | — | RUNTIME | NO | Absolute upper lux gate (prof760) — set by task546 Set Thresholds, NOT task570 |
 | `%AAB_ThreshAbsLow` | — | RUNTIME | NO | Absolute lower lux gate (prof760) — set by task546 Set Thresholds, NOT task570 |
 | `%AAB_ThreshBright` | 0.08 | SETTING | yes | User setting (see task570) |

--- a/docs/rebuild/extraction/features_spec.md
+++ b/docs/rebuild/extraction/features_spec.md
@@ -19,10 +19,11 @@ Condition `<op>`: 2 `=` · 3 `!=` · 6 `<` · 7 `>` · 12 isSet · 13 isNotSet.
 ### task551 `_QSToggleAABService V2` (L17325-17718, code-0 driven)
 Master service ON/OFF toggle. Triggered by the QS tile tap and by resume/context callers.
 
-**Branch decision (act0):** `IF %AAB_Service = On  OR caller1 !~ *Resume After Override*  OR caller1 = *_ContextResume*`
-→ treat as **turn OFF**; else **turn ON**. (And2/Or2 grouping flagged unresolved in INDEX.md #1; literal
-sequence is `bool0=And, bool1=Or`. Effect: if service already On, or caller is a resume/contextresume, go to
-the OFF path. The Off path is the `act1..act25` block; the On path is `act27..act47`.)
+**Branch decision (act0):** conditions `%AAB_Service = On` **And** `caller1 !~ *Resume After Override*`
+**Or** `caller1 = *_ContextResume*`; per the validated D-021 rule (plain `And` binds tighter than `Or`):
+`(%AAB_Service=On AND caller1 !~ *Resume After Override*) OR caller1 ~ *_ContextResume*` → **turn OFF**;
+else **turn ON**. (Resolves the D-018 leftover; sanity-check the ContextResume leg at runtime in S9.
+The Off path is the `act1..act25` block; the On path is `act27..act47`.)
 
 **OFF path (act1-act25):**
 - `%AAB_Service = Off` (act1).
@@ -129,26 +130,43 @@ INITIAL_SETTLE_MS=6000.
 ## 4. Debug levels + log surface
 
 ### task635 `_SetDebugLevel` (L28955-28978)
-One action: `IF %par1 isSet → %AAB_Debug = %par1`. So `%AAB_Debug` is the debug verbosity level, set
-from a UI selector (`<select id=debug-selector>`, value bound to int `%AAB_Debug`, L2868-2876).
+One action: `IF %par1 isSet → %AAB_Debug = %par1`. So `%AAB_Debug` is the debug *category* selector
+value — 10 named categories, NOT a verbosity level (owner-corrected S3.5, D-023; see table below) —
+set from a UI selector (`<select id=debug-selector>`, options L2772-2783, JS binding L2868-2876).
 
 ### task634 `_ShowDebugScene` (L28895-28954)
 Shows scene "AAB Debug Scene" (code 47, fullscreen overlay 100×100%). If `%err` isSet AND
 `%AAB_Package = *com.tideo.aab*`, hide+re-show (refresh) the scene. (Self-debug guard for the dev build.)
 
-### `%AAB_Debug` level semantics
-- **Default 0** (off). Selector-driven integer; default `'3000'`-style fallbacks elsewhere are unrelated.
-- Conditions across the project gate on it almost exclusively with **op 2 (`=`)**, i.e. **discrete
-  named levels, not a `≥` threshold**. Observed equality targets: **1, 2, 3, 4, 5, 6, 7, 8, 9**
-  (one `op 3 !=1` at L16386 — "any debug on"). Histogram of distinct rhs values:
-  1×2, 2×2, 3×1, 4×1, 5×4, 6×1, 7×7, 8×1, 9×1.
-- Level **8** is the verbose context-evaluation log gate (e.g. task623 `isDebug=AAB_Debug.equals("8")`
-  writes `%eval_log` "Veto: …" diagnostics, L12183; task637 "System restored missing Default.json").
-- Level **7** is the most-used (pipeline-math logging). Levels gate `code 548` toasts tagged
-  `aab_debug` and `%eval_log`/`%err` surfaces.
+### `%AAB_Debug` level semantics — 10 named categories (authoritative; owner-verified S3.5, D-023)
 
-> Rebuild note: model `%AAB_Debug` as an enum/int 0–9 where each level *selectively* unlocks a category
-> of diagnostic logging (equality-matched), NOT a monotonic severity threshold. Default 0.
+The Debug scene's selector (XML L2773–2782) names every level. They are **distinct info categories,
+shown mostly as toasts — NOT verbosity tiers**:
+
+| Level | Label (verbatim from the selector) |
+|---|---|
+| 0 | Off |
+| 1 | Skip Animations |
+| 2 | Animation Details |
+| 3 | Light Eval Thresholds |
+| 4 | Dynamic Scale Calcs |
+| 5 | Super Dimming Info |
+| 6 | Overlay Preview |
+| 7 | Graph Metrics |
+| 8 | Context Automation |
+| 9 | Context Location |
+
+- **Default 0** (off). Selector-driven integer; default `'3000'`-style fallbacks elsewhere are unrelated.
+- Conditions across the project gate on it almost exclusively with **op 2 (`=`)** — consistent with the
+  discrete categories above (one `op 3 !=1` at L16386 — "any debug on"). Histogram of equality targets:
+  1×2, 2×2, 3×1, 4×1, 5×4, 6×1, 7×7, 8×1, 9×1.
+- Level 8 "Context Automation" gates the context-evaluation log (task623 `isDebug=AAB_Debug.equals("8")`
+  writes `%eval_log` "Veto: …" diagnostics, L12183; task637 "System restored missing Default.json").
+  ⚠️ S1's *inferred* glosses were wrong here — 7 is **Graph Metrics**, not "pipeline-math logging".
+- Levels gate `code 548` toasts tagged `aab_debug` and `%eval_log`/`%err` surfaces.
+
+> Rebuild note: model `%AAB_Debug` as an enum 0–9 with the labels above (equality-matched category
+> selector, NOT a monotonic severity threshold). Default 0. S12 UI = dropdown with these exact labels.
 
 ---
 
@@ -286,6 +304,12 @@ Detection order (first hit wins → `hasPrivilegeFound`):
 5. **Fallback** → `"None"` + toast "⚠️ Unprivileged will draw a semi-transparent overlay and eat your
    battery. Not recommended!"
 
+> **Sanctioned deviation (owner, S3.5 → D-024):** step 4 reads the **Tasker pref `adbwp`** for the ADB
+> port — a Tasker-host artifact with no business in a standalone app. The rebuild must NOT read Tasker
+> prefs (and drops ADB-WiFi probing altogether): elevated-tier truth is
+> `checkPermission(WRITE_SECURE_SETTINGS)`; ADB / Shizuku / root remain *grant channels* only (matches
+> the S7 PrivilegeManager + S11 onboarding design and D-016).
+
 If caller `~ *anon*` and final privilege ≠ None, toasts "Current privilege: <x>."
 
 > Tier mapping to CLAUDE.md model: `Root` / `Write Secure` / `Shizuku` / `ADB WiFi` are all the
@@ -302,6 +326,11 @@ WRITE_SECURE_SETTINGS → returns immediately. Otherwise builds:
 NOT grant; it instructs the user to run ADB. (Shizuku is the grant channel elsewhere, not here.)
 
 ### task563 `_AskPermissionsV7` (Java L19678-20042) — the BASIC/runtime permission wizard
+
+> **Sanctioned deviation (owner, S3.5 → D-024):** the 8 capability gates below and their order are the
+> parity contract; the dialog-polling *flow* is not. S11 replaces it with modern Compose onboarding
+> (ActivityResultContracts + lifecycle re-checks), as its RUNBOOK brief already specifies.
+
 Sets `%AAB_Package = context.getPackageName()`. Polling loop that walks the user through 8 sequential
 permission "steps", each with a Grant dialog + the matching Settings intent, re-checking each pass:
 1. **Write Settings** (`Settings.System.canWrite`) — the BASIC tier gate.

--- a/docs/rebuild/extraction/pipeline_spec.md
+++ b/docs/rebuild/extraction/pipeline_spec.md
@@ -20,7 +20,7 @@ ROUND_HALF_UP)`, string-formatted returns (`a + "," + b`), int truncation. See p
 | State (paused, screen on) | prof756 | task567 | repost paused notif |
 | Time periodic | prof757 | task584 | repost running notif |
 | Time windows (dawn/dusk) | prof758 | task90 | dynamic scale recompute |
-| Proximity | prof759 (pri 4) | task545 | pause near-face |
+| Proximity | prof759 (pri 4) | task545 | set %AAB_Proximity near/far → LuxAlpha damp ×0.1 (no pause) |
 | Throttle drift | prof754 | task566 | throttle reinit |
 | Panic event | prof769 (pri 15) | task528 | emergency reset |
 
@@ -95,6 +95,10 @@ Exponential smoothing with hysteresis:
 ### 1e. task548 Dynamic Range Compressed Scale (`java/task548_1`)
 Applies `%AAB_ScaleDynamic`/`%AAB_ScaleDynamicCompress` compression to `mapped` brightness when dynamic
 scaling is active (circadian multiplier from task90). Returns compressed brightness. Math in Java file.
+**Why it exists (owner, S3.5):** it compresses the circadian *multiplier* toward the top of the
+brightness range — without it a high base (e.g. 240) with a >1 multiplier (e.g. 1.15) pins at 255 for
+too long, and a sub-1 multiplier (e.g. 0.85) could never reach 255 no matter how bright the ambient
+light. Rationale only — behavior is ported from the Java unchanged.
 
 ### 1f. task543 Calculate Animation (`java/task543_1`) → returns `"%loops,%wait"`
 Computes step count `loops` and per-step `wait` (ms) for the transition, from `lux_alpha` and the
@@ -185,7 +189,7 @@ These guarantee C0 continuity across the 3 zones. Identical expressions appear i
 | `%AAB_Sun*` / `%AAB_calc_*` / `%AAB_Polar*` / `%AAB_*Duration` | solar times & polar state | task90 (S2/S6) |
 | `%AAB_MorningStart/End`, `%AAB_EveningStart/End` | dawn/dusk ramp windows | task90; prof758 gate |
 | `%AAB_Initializing` | true during initial-brightness write | task618; gates prof755 |
-| `%AAB_Proximity` | near/far | prof759 / task545 |
+| `%AAB_Proximity` | near/far | prof759 / task545 "Detect Proximity"; damps LuxAlpha ×0.1 in 544 |
 | `%AAB_Privilege` / `%AAB_SecondaryPrivilege` | detected tier | task378/643 (S2/S7) |
 | `%AAB_ActiveContext` / `%AAB_ContextCache` / `%AAB_NextContextTime` | context-engine state | task43/623 (S2/S10) |
 | `%AutoBrightRunning`, `%as_values1`, `%as_accuracy`, `%TRUN` | Tasker built-ins / sensor array | system |

--- a/docs/rebuild/extraction/profiles.md
+++ b/docs/rebuild/extraction/profiles.md
@@ -8,7 +8,8 @@ Extraction notes:
 - `<mid0>` = enter task, `<mid1>` = exit task, `<pri>` = profile priority.
 - A profile **fires its enter task only when its context is active AND its `<ConditionList sr="if">` gate passes**. These gates are load-bearing pipeline logic (D-003).
 - Condition op codes (empirically derived, project-wide histogram): `2 ==` · `3 !=` · `6 <` · `7 >` · `9 >=` · `0 ~(matches)` · `1 !~` · `12 isSet` · `13 isNotSet`.
-- ⚠️ **Tasker `And2`/`Or2` booleans denote a tighter-binding sub-group** (a second precedence level). Exact grouping for the multi-clause gates (prof760, prof758) is given as a *best-effort reading* and flagged in `INDEX.md` "unresolved" for S4/S9 runtime validation.
+- **ConditionList boolean semantics (owner-verified 2026-06-11, D-021):** plain `And`/`Or` bind *tighter* and form inner sub-expressions (with conventional `And` > `Or` precedence); `And2`/`Or2` are the *outer* joins between those sub-expressions, evaluated left-to-right. Validated against prof760 (owner confirmed the staged semantics) and prof758 (rule yields the only design-sensible reading). Resolves INDEX.md unresolved #1 / D-009.
+- ⚠️ **ConditionList children are stored ALPHABETICALLY in the XML** (`bool10` sorts before `bool2`, `c10` before `c2`) — re-sort numerically before transcribing. S1's prof758 bool sequence was scrambled by this (fixed below; D-021, recipe R4 updated).
 
 | Profile | Line | Enter | Exit | Pri | Context (code) |
 |---|---|---|---|---|---|
@@ -21,7 +22,7 @@ Extraction notes:
 | prof759 Proximity Detection | L300 | task545 | task545 | 4 | State **Proximity** (125, arg0=1) |
 | prof760 Monitor Ambient Light | L318 | task554 | — | 7 | Event **Light Sensor** (2088, type=5, 1000 ms) |
 | prof761 Initialize (Display On) | L386 | task618 | — | 7 | Event **Display On** (208) |
-| prof769 Panic (Reset) | L722 | task528 | — | 15 | Event (2083, panic trigger) |
+| prof769 Panic (Reset) | L722 | task528 | — | 15 | Event 2083 (shake/sig-motion) + State 120/3 (upside down) + State 123/1 |
 
 ---
 
@@ -40,12 +41,12 @@ Extraction notes:
   | c4 | `%as_values1 > %AAB_ThreshAbsHigh` | And2 |
   | c5 | `%AAB_MainLoop != On` | — |
 
-- **Best-effort reading** (And2/Or2 bind tighter than And/Or):
+- **Confirmed reading** (owner-verified 2026-06-11, D-021 — plain And/Or = inner groups, And2/Or2 = outer joins left-to-right):
   `((TrustUnreliable=On) OR (TrustUnreliable=Off AND as_accuracy>1)) AND ((as_values1 < ThreshAbsLow) OR (as_values1 > ThreshAbsHigh)) AND (MainLoop != On)`
-  - **Accuracy-trust gate:** either the user trusts unreliable readings, or the reading must be accuracy>1 (Medium/High). Low-accuracy readings are dropped unless `TrustUnreliable=On`.
-  - **Absolute-threshold dead-band:** the profile only re-fires when lux has moved **outside** the absolute band `[ThreshAbsLow, ThreshAbsHigh]` — this is a hysteresis/anti-jitter gate. `ThreshAbsLow/High` are set by **task546 _Set Thresholds_**, not task570.
-  - **Main-loop flag:** `MainLoop != On` — fires when the main loop is not already marked running (re-entrancy guard). ⚠️ Verify polarity in S9.
-- ⚠️ The exact And2/Or2 grouping is **flagged unresolved** (INDEX). The reading above matches design intent; S4/S9 must confirm against runtime behavior.
+  Three staged gates, evaluated in order:
+  1. **Accuracy-trust gate:** either the user trusts unreliable readings, or the reading must be accuracy>1 (Medium/High). Low-accuracy readings are dropped unless `TrustUnreliable=On`.
+  2. **Absolute-threshold dead-band:** the profile only re-fires when lux has moved **outside** the absolute band `[ThreshAbsLow, ThreshAbsHigh]` — this is a hysteresis/anti-jitter gate. `ThreshAbsLow/High` are set by **task546 _Set Thresholds_**, not task570.
+  3. **Main-loop mutex:** `MainLoop != On` — owner-confirmed polarity: re-entrancy/mutex guard, skip while the main loop is already running.
 
 ## prof753 "Hibernate (Display Off)" → task585
 - **Context:** Event **Display Off** (code 210). No gate. **Pri 3.**
@@ -77,18 +78,20 @@ Extraction notes:
 - Periodically reposts the foreground/running notification (task584) while active and not overridden.
 
 ## prof758 "Dynamic Scale Engine" → task90
-- **Context:** Time/periodic (code 165).
-- **Gate** (conditions c0..c13, bool sequence `[And, Or, And, Or, And2, And, Or, And, Or, And, Or, And, Or]` — multi-window time test):
-  - `%AAB_MorningStart < %TIMES % 86400` / `%AAB_MorningEnd > %TIMES % 86400` (within morning ramp window, with ±86400 wrap variants)
-  - `%AAB_EveningStart < … - 86400` / `%AAB_EveningEnd > …` (evening ramp window, with wrap variants)
-  - `%AAB_SunLastDate != %DATE` (recompute once per day)
-  - `%AAB_ScalingUse = true` (dynamic scaling enabled)
-- i.e. fires task90 (Dynamic Scale V13) when scaling is enabled AND now is inside a dawn/dusk ramp window (with day-wrap handling) OR the sun-times are stale for today. ⚠️ Exact And2 grouping flagged unresolved; window math owned by S2 (task090 doc) + S6.
+- **Context:** Time (con0, repeat every 2 min) + State (con1, code 165) carrying the gate.
+- **Gate** (c0..c13; bool sequence corrected in S3.5 — S1's `[…And2 in 5th position…]` was an artifact of the XML's ALPHABETICAL child ordering (D-021). Numerically re-sorted it is twelve plain joins, then one final `And2`: `[And, Or, And, Or, And, Or, And, Or, And, Or, And, Or, And2]`):
+  - c0∧c1: `MorningStart < %TIMES%86400 < MorningEnd` · c2∧c3: same window at `+86400` · c4∧c5: same at `−86400` (day-wrap variants)
+  - c6∧c7: `EveningStart < %TIMES%86400 < EveningEnd` · c8∧c9: at `+86400` · c10∧c11: at `−86400`
+  - c12: `%AAB_SunLastDate != %DATE` (sun data stale for today) · c13: `%AAB_ScalingUse = true`
+- **Reading (validated D-021 rule):**
+  `((c0∧c1) ∨ (c2∧c3) ∨ (c4∧c5) ∨ (c6∧c7) ∨ (c8∧c9) ∨ (c10∧c11) ∨ c12) AND (ScalingUse = true)`
+  — fires task90 (Dynamic Scale V13) when circadian scaling is enabled AND (now is inside a dawn/dusk ramp window, with ±1-day wrap variants, OR sun times need recomputing today). Window math owned by S2 (task090 doc) + S6.
 
 ## prof759 "Proximity Detection" → task545 (enter & exit)
 - **Context:** State **Proximity** (code 125, arg0=1). **Pri 4.**
-- Both enter and exit run task545 (proximity handling — e.g. pause/ignore sensor while phone is to ear/in pocket). task545 is not in S1's transcription list; S2/S9 should note it.
+- Enter and exit both run **task545 "Detect Proximity"** (XML L16424; transcribed S3.5 → `tasks/task545_detect-proximity.md`): `If %caller1 ~ *enter* → %AAB_Proximity = near; Else-If %caller1 ~ *exit* → %AAB_Proximity = far`.
+- **It does NOT pause the pipeline** (owner-verified, D-022): `near` only *damps* smoothing — task544 act28–29 sets `LuxAlpha = lux_results2 × 0.1`, so brightness reacts an order of magnitude slower while the phone is at the ear / in a pocket.
 
 ## prof769 "Panic (Reset)" → task528
-- **Context:** Event (code 2083, panic trigger — likely a Tasker shortcut/long-press hook; two arg0 entries). **Pri 15** (highest — beats everything).
-- Fires task528 (Panic Button) → restore sane brightness, clear all runtime state, disengage dimming. Emergency escape hatch (Gate-1 / S9 notification panic-reset action).
+- **Contexts (all must hold; XML L722–743, verified S3.5/D-022):** Event **2083** (significant-motion/shake trigger, no args) **+** State **120 arg0=3** (Orientation: *upside down*) **+** State **123 arg0=1** (same state family as prof754; label inferred — display-active). **Pri 15** (highest — beats everything).
+- Owner-verified semantics: emergency escape hatch when the screen is black due to misconfiguration — **flip the phone upside down and shake**. task528 (Panic Button) sets brightness to max, disables the event listeners/profiles, and sets `%AAB_Service = Off` (full stop). (Gate-1 / S9 notification panic-reset action.)

--- a/docs/rebuild/extraction/scenes/debug.md
+++ b/docs/rebuild/extraction/scenes/debug.md
@@ -25,7 +25,8 @@ Active Rule, Loaded Profile, Last Update, Last Animation.
 ### JS → Tasker calls embedded in the WebElement HTML
 - `performTask('_CalibratePowerDraw', 10)` — "Screen Power Measurement" calibration tool
   (steps brightness, measures mA, generates Power Curve). Experimental diagnostic.
-- `performTask('_SetDebugLevel', 10, val)` — set debug verbosity level.
+- `performTask('_SetDebugLevel', 10, val)` — set the debug *category* (10 named levels from the
+  selector options at XML L2773–2782, e.g. "7 - Graph Metrics" — see features_spec §4, D-023).
 
 ## Disposition
 

--- a/docs/rebuild/extraction/scenes/superdimming_settings.md
+++ b/docs/rebuild/extraction/scenes/superdimming_settings.md
@@ -50,7 +50,7 @@
 | elements23 | abs_and_rel_super_dimming_effect | TextElement | displays `%AAB_DimmingCurrent`, `%AAB_DimmingDS`, `%AAB_CurrentBright` | — | longclick=514 | Live readout: current super-dimming strength (rel/abs) + brightness; longtap action |
 | elements1 | rectangle_10 | RectElement | — | — | — | Decorative card bg for circadian/graph row (y=2034) |
 | elements9 | draw_graph4_drop_shadow | TextElement | static "Draw Circadian Graph" | — | — | Drop-shadow layer behind "Draw Circadian Graph" |
-| elements10 | draw_graph4 | TextElement | static "Draw Circadian Graph" | — | click=517 | Button: open circadian graph (`_CalibratePowerDraw`/graph) |
+| elements10 | draw_graph4 | TextElement | static "Draw Circadian Graph" | — | click=517 | Button: opens **AAB Circadian Dimming Graph** — task517 warns if `%aab_scaletransitionfactor>0.5`, clears `%AAB_SunLastDate`, runs task90 + task705 `_GenerateCircadianDimmingGraph`, resizes (task620), hides this scene. Shown only when `%AAB_ScalingUse` is enabled (owner). S3.5 fix — the earlier `_CalibratePowerDraw` gloss was wrong (D-026) |
 | elements20 | draw_graph5_drop_shadow | TextElement | static "Draw Dimming Graph" | — | — | Drop-shadow layer behind "Draw Dimming Graph" |
 | elements21 | draw_graph5 | TextElement | static "Draw Dimming Graph" | — | click=513 | Button: open dimming graph |
 | elements5 | rectangle_9 | RectElement | — | — | — | Decorative card bg for bottom button bar (y=1234) |

--- a/docs/rebuild/extraction/tasks/anonymous_handlers.md
+++ b/docs/rebuild/extraction/tasks/anonymous_handlers.md
@@ -1,0 +1,191 @@
+# anonymous_handlers.md — census of all 168 unnamed (anonymous) tasks (S3.5)
+
+**Provenance:** S3.5 owner-review errata. The owner flagged that `tasks/` only covers *named*
+tasks; the XML holds **276 tasks, of which 168 are anonymous** scene-element handlers
+(`clickTask`, `checkchangeTask`, `valueselectedTask`, `keyTask`, …). Every one of the 168 is
+referenced from exactly one scene (none are dead). 34 of them are `keyTask` handlers on scene
+`PropertiesElement`s — i.e. **hardware-/back-key behavior** — which S2's element dispositions
+dropped as "scene chrome"; S12 must re-derive per-screen back behavior from them.
+
+**Method (regenerable):** mechanical decode — task id + XML line from `<Task sr=>` blocks
+lacking `<nme>`; wiring from `<*Task>ID</*Task>` refs inside `<Scene>` blocks; per action:
+code → name (INDEX.md legend + best-effort Tasker labels — treat code numbers + args as ground
+truth, labels outside the INDEX-verified set as advisory), first condition for If/Else, first
+`arg0` (truncated, entity-decoded). Action chains are truncated at ~220 chars.
+
+**How to consume (S12/S13 precondition):** every row must end up either *ported* (wired into
+the Compose screen that absorbs its scene, per `screen_map.md`) or *dropped(reason)*. Most rows
+are 1–3-action glue (set var / perform named task / scene nav); deep-dive only the branching
+ones (validation guards, e.g. task384/386/395/403, task517) during the owning segment. Use
+XML_RECIPES R2 (extract task by id) for the full block.
+
+| Task | XML | Wired from (scene · element·event) | Actions |
+|---|---|---|---|
+| task383 | L11185 | AAB Brightness Settings · elements22·longclick | Flash(Current light sensor reading after smoothing …) |
+| task384 | L11210 | AAB Brightness Graph · elements3·click | If[%aab_form2a < 0]; Flash(⚠️ Invalid brightness settings. Negative valu…); Stop; Else; Perform Task(_SaveButtonGeneral); End If |
+| task386 | L11278 | AAB Brightness Settings · elements24·click | If[%aab_form2a < 0]; Flash(⚠️ Invalid brightness settings. Can't be appl…); Stop; Else; Perform Task(_SaveButtonGeneral); End If |
+| task390 | L11364 | AAB Misc Settings · elements6·valueselected | Variable Set(%aab_maxbright) |
+| task391 | L11380 | AAB Brightness Settings · elements26·click | Perform Task(_ExitButton) |
+| task395 | L11402 | AAB Misc Settings · elements4·valueselected | Variable Set(%aab_minbright); If[%new_val < 10]; Flash(Caution: Low brightness may be unreadable on …); Variable Set(%warn); End If |
+| task396 | L11466 | AAB Brightness Settings · elements28·click | Variable Clear(%AAB_SetupComplete); Variable Set(%reset); Perform Task(Initialize AAB Defaults); Variable Clear(%reset); Variable Set(%AAB_SetupComplete); Multiple Variables Set; Destroy Scene(AAB Brightness Settings); … |
+| task397 | L11566 | AAB Brightness Settings · elements29·checkchange | Perform Task(_QSToggleAABService V2) |
+| task402 | L11648 | AAB Brightness Settings · elements30·checkchange | Perform Task(_QSToggleAABService V2) |
+| task403 | L11670 | AAB Misc Settings · elements13·click | If[%aab_minwait > %aab_maxwait]; Flash(⚠️ Invalid wait time settings. Can't be appli…); Stop; Else; Perform Task(_SaveButtonMisc); End If |
+| task405 | L11732 | AAB Misc Settings · elements33·longclick | Flash(A global multiplier for the entire brightness…) |
+| task406 | L11757 | AAB Reactivity Graph · elements3·click | Perform Task(_SaveButtonReactivity) |
+| task407 | L11779 | AAB Misc Settings · elements10·valueselected | Variable Set(%aab_scale) |
+| task409 | L11795 | AAB Misc Settings · elements9·valueselected | Variable Set(%aab_offset) |
+| task411 | L11811 | AAB Reactivity Graph · elements5·click | Multiple Variables Set; Perform Task(_AdaptiveBrightnessSceneSize V4); Perform Task(_LoadedReactivityToggle); Perform Task(_LoadedOverrideToggle); Destroy Scene(AAB Reactivity Graph) |
+| task412 | L11888 | AAB Brightness Graph · elements6·click | If[%suggest = true]; Variable Clear(%suggest*); Destroy Scene(AAB Brightness Settings); Perform Task(Advanced Auto Brightness); Destroy Scene(AAB Brightness Graph); Else; Perform Task(Advanced Auto Brightness); Destroy … |
+| task417 | L11961 | AAB Misc Settings · elements14·click | Perform Task(_ExitButton) |
+| task421 | L11983 | AAB Superdimming Settings · elements24·longclick | If[%AAB_DimmingEnabled = true]; Flash(This is the screen brightness below which sup…); Else[%AAB_PWMSensitive = true]; Flash(This is the lowest hardware screen brightness…); End If |
+| task462 | L12855 | AAB Debug Scene · elements1·click | Perform Task(_MenuScene); Wait; Destroy Scene(AAB Debug Scene) |
+| task465 | L12889 | AAB Superdimming Settings · elements3·longclick | Flash(Controls the maximum super dimming strength. …) |
+| task466 | L12914 | AAB Superdimming Settings · elements7·click | Perform Task(_SaveButtonDimming); Perform Task(_DimmingApplyToggle) |
+| task473 | L12952 | AAB Reactivity Settings · elements4·click | Perform Task(_GenerateReactivityGraph (Java)); Multiple Variables Set; Perform Task(_AdaptiveBrightnessSceneSize V4); Hide Scene(AAB Reactivity Settings) |
+| task481 | L13013 | AAB Superdimming Settings · elements8·click | Perform Task(_ExitButton) |
+| task490 | L13035 | AAB Superdimming Settings · elements8·longclick | Perform Task(_ExitButton) |
+| task492 | L13056 | AAB Superdimming Settings · elements27·click | Variable Clear(%AAB_Privilege); Perform Task(_PrivilegeDetection V5 (Java)) |
+| task493 | L13085 | AAB Reactivity Settings · elements11·longclick | Flash(Point where the logic switches from zone 1 cu…) |
+| task500 | L13110 | AAB Superdimming Settings · elements12·click | Variable Clear(%AAB_SetupComplete); Variable Set(%reset); Perform Task(Initialize AAB Defaults); Variable Clear(%reset); Variable Set(%AAB_SetupComplete); Multiple Variables Set; Perform Task(_SuperDimmingScene) |
+| task505 | L13202 | AAB Superdimming Settings · elements13·longclick | Variable Set(%min); Variable Set(%max); If[%max > 65]; Variable Set(%max); End If; Flash(Controls how wide the scale shifts over the d…) |
+| task506 | L13270 | AAB Superdimming Settings · elements14·longclick | Flash(Controls how gradual the super dimming kicks …) |
+| task508 | L13295 | AAB Superdimming Settings · elements15·valueselected | If[%new_val < 0.00001]; Stop; End If; Variable Set(%aab_dimmingexponent) |
+| task509 | L13329 | AAB Superdimming Settings · elements16·checkchange | Perform Task(_DimmingUIToggle); Perform Task(_DimmingApplyToggle); If[%AAB_Privilege = None]; Flash(⚠️ Unprivileged super dimming will use a semi…); End If |
+| task510 | L13405 | AAB Superdimming Settings · elements17·longclick | Flash(Enables or disables the entire experimental c…) |
+| task511 | L13430 | AAB Superdimming Settings · elements18·checkchange | Perform Task(_DimmingUIToggle); Perform Task(_DimmingApplyToggle); If[%AAB_Privilege = None]; Flash(⚠️ Unprivileged super dimming will use a semi…); End If |
+| task513 | L13567 | AAB Superdimming Settings · elements21·click | If[%aab_dimmingthreshold < %aab_minbright]; Flash(⚠️ Threshold is set below minimum brightness!…); Stop; End If; Perform Task(_GenerateDimmingCurveGraph (Java)); Multiple Variables Set; Perform Task(_AdaptiveBrightnessS… |
+| task514 | L13665 | AAB Superdimming Settings · elements23·longclick | Flash(Displays the current (un)compressed scale fac…) |
+| task515 | L13690 | AAB Dimming Graph · elements3·click | Perform Task(_SaveButtonDimming) |
+| task516 | L13712 | AAB Dimming Graph · elements5·click | Show Scene(AAB Superdimming Settings); Perform Task(_LoadedDimmingToggle); Wait; Destroy Scene(AAB Dimming Graph) |
+| task517 | L13761 | AAB Superdimming Settings · elements10·click | If[%aab_scaletransitionfactor > 0.5]; Flash(⚠️ Graph might be non-sensical due to scale t…); End If; Flash(Please be patient. Generating the graph might…); Variable Clear(%AAB_SunLastDate); Perform Task(Dynamic Scale V1… |
+| task519 | L13896 | AAB Reactivity Settings · elements31·longclick | Flash(Disable this if you get frequent false positi…) |
+| task520 | L13921 | AAB Circadian Dimming Graph · elements3·click | Perform Task(_SaveButtonDimming) |
+| task521 | L13943 | AAB Circadian Dimming Graph · elements5·click | Show Scene(AAB Superdimming Settings); Perform Task(_LoadedDimmingToggle); Wait; Destroy Scene(AAB Circadian Dimming Graph) |
+| task522 | L13992 | AAB Superdimming Settings · elements28·valueselected | If[%new_val > 100]; Stop; End If; Variable Set(%aab_dimspread) |
+| task523 | L14032 | AAB Superdimming Settings · elements28·focuschange | If[%focused = false]; If[%new_val > 100]; Flash(⚠️ Dimming spread setting invalid! Has to be …); End If; End If |
+| task525 | L14740 | AAB Reactivity Settings · elements33·checkchange | Perform Task(_OverrideToggle) |
+| task526 | L14762 | AAB Reactivity Settings · elements32·checkchange | Perform Task(_OverrideToggle) |
+| task527 | L14784 | AAB Superdimming Settings · elements26·longclick | Perform Task(_SuperDimmingLongTap) |
+| task529 | L14939 | AAB Superdimming Settings · elements32·longclick | Flash(Enables or disables the software dimming feat…) |
+| task530 | L14964 | AAB Superdimming Settings · elements31·valueselected | If[%new_val > 0.1999]; Variable Set(%aab_pwmexp); Else; End If |
+| task531 | L15002 | AAB Superdimming Settings · elements36·valueselected | If[%new_val < %AAB_MinBright]; Stop; End If; Variable Set(%aab_dimmingthreshold) |
+| task532 | L15042 | AAB Power Draw Graph · elements3·click | Show Scene(AAB Debug Scene); If[%err isSet]; Destroy Scene(AAB Debug Scene); Show Scene(AAB Debug Scene); End If; Destroy Scene(AAB Power Draw Graph) |
+| task533 | L15105 | AAB Superdimming Settings · elements34·checkchange | Perform Task(_PWMToggle); Wait; Perform Task(_LoadedPWMToggle) |
+| task534 | L15151 | AAB Superdimming Settings · elements33·checkchange | Perform Task(_PWMToggle); Wait; Perform Task(_LoadedPWMToggle) |
+| task536 | L15261 | AAB Misc Settings · elements5·longclick | Flash(Sets the highest brightness level the screen …) |
+| task537 | L15286 | AAB Reactivity Settings · elements22·click | Perform Task(_ExitButton) |
+| task538 | L15308 | AAB Misc Settings · elements14·longclick | Perform Task(_ExitButton) |
+| task539 | L15329 | AAB Experiment Settings · elements15·valueselected | Variable Set(%aab_scaletransitionfactor) |
+| task550 | L17293 | AAB Power Draw Graph · props·key | Show Scene(AAB Debug Scene); Wait; Destroy Scene(AAB Power Draw Graph) |
+| task568 | L20886 | AAB Superdimming Settings · props·key | Destroy Scene(AAB Superdimming Settings) |
+| task590 | L24045 | AAB Alpha Graph · props·key | Show Scene(AAB Misc Settings); Wait; Destroy Scene(AAB Alpha Graph) |
+| task591 | L24077 | AAB Circadian Dimming Graph · props·key | Show Scene(AAB Superdimming Settings); Perform Task(_LoadedDimmingToggle); Wait; Destroy Scene(AAB Circadian Dimming Graph) |
+| task593 | L24429 | AAB Reactivity Settings · props·key | Destroy Scene(AAB Reactivity Settings) |
+| task594 | L24439 | AAB Taper Graph · props·key | Show Scene(AAB Experiment Settings); Wait; Destroy Scene(AAB Taper Graph) |
+| task595 | L24472 | AAB User Guide · props·key | Destroy Scene(AAB User Guide); Wait; Show Scene(AAB Menu) |
+| task596 | L24504 | AAB About · props·key | Show Scene(AAB Menu); Wait; Destroy Scene(AAB About) |
+| task597 | L24535 | AAB Experiment Settings · props·key | Destroy Scene(AAB Experiment Settings) |
+| task598 | L24545 | AAB Misc Settings · props·key | Destroy Scene(AAB Misc Settings) |
+| task599 | L24555 | AAB Reactivity Graph · props·key | Show Scene(AAB Reactivity Settings); Wait; Destroy Scene(AAB Reactivity Graph) |
+| task600 | L24587 | AAB Debug Scene · props·key | Show Scene(AAB Menu); Wait; Destroy Scene(AAB Debug Scene) |
+| task602 | L24792 | AAB Brightness Settings · props·key | Destroy Scene(AAB Brightness Settings) |
+| task603 | L24802 | AAB Experiment Graph · props·key | Show Scene(AAB Experiment Settings); Perform Task(_LoadedExperimentTogglesV2); Wait; Destroy Scene(AAB Experiment Graph) |
+| task604 | L24850 | AAB Chart.Js License · props·key | Show Scene(AAB Menu); Wait; Destroy Scene(AAB Chart.Js License) |
+| task605 | L24882 | AAB Dimming Graph · props·key | Show Scene(AAB Superdimming Settings); Wait; Destroy Scene(AAB Dimming Graph) |
+| task606 | L24914 | AAB Menu · props·key | Perform Task(_KeyEventBackMenu) |
+| task607 | L24936 | AAB Superdimming Settings · elements29·focuschange | If[%focused = false]; Rotate Image(AAB Superdimming Settings); Stop; If[%new_val > 65]; Flash(⚠️ Dimming strength will be clamped to minimu…); End If; End If |
+| task608 | L25017 | AAB Superdimming Settings · elements29·valueselected | Variable Set(%aab_dimmingstrength) |
+| task609 | L25033 | AAB Superdimming Settings · elements15·focuschange | If[%focused = false]; If[%new_val < 0.00001]; Flash(⚠️ Exponent cannot be set to 0 or lower!); End If; End If |
+| task610 | L25084 | AAB Superdimming Settings · elements36·focuschange | If[%focused = false]; If[%new_val < %AAB_MinBright]; Flash(⚠️ Dimming threshold cannot be set outside br…); End If; End If |
+| task611 | L25141 | AAB Superdimming Settings · elements31·focuschange | If[%focused = false]; If[%new_val < 0.2]; Flash(⚠️ Not set!…); End If; End If |
+| task612 | L25199 | AAB Misc Settings · elements28·focuschange | If[%focused = false]; If[%new_val < 0.0001]; Flash(Delta factor cannot be 0 or lower! Field not …); End If; End If |
+| task613 | L25250 | AAB Brightness Settings · elements7·focuschange | If[%focused = false]; If[%new_val isSet]; Perform Task(_UpdateBrightnessFormulae); Perform Task(_UpdateStaticSceneElements); Perform Task(_RedInvalidFormulae); End If; End If |
+| task614 | L25330 | AAB Brightness Settings · elements20·focuschange | If[%focused = false]; If[%new_val isSet]; Perform Task(_UpdateBrightnessFormulae); Perform Task(_UpdateStaticSceneElements); Perform Task(_RedInvalidFormulae); End If; If[%aab_zone1end < %aab_form2c]; Flash(Zone 2 Offse… |
+| task615 | L25448 | AAB Brightness Settings · elements12·focuschange | If[%focused = false]; If[%new_val isSet]; Perform Task(_UpdateBrightnessFormulae); Perform Task(_UpdateStaticSceneElements); Perform Task(_RedInvalidFormulae); End If; End If |
+| task616 | L25528 | AAB Brightness Settings · elements14·focuschange | If[%focused = false]; If[%new_val > %aab_zone1end]; End If; Flash(Zone 2 Offset cannot exceed Zone 1 End!); Element Visibility(AAB Brightness Settings); Else; Element Visibility(AAB Brightness Settings); Perform Task(_U… |
+| task617 | L25652 | AAB Brightness Settings · elements19·focuschange | If[%focused = false]; If[%new_val < %aab_zone1end]; Flash(Zone 2 End cannot be smaller than Zone 1 End!); Else; Perform Task(_UpdateBrightnessFormulae); Perform Task(_UpdateStaticSceneElements); Perform Task(_RedInvalid… |
+| task621 | L26607 | AAB Brightness Graph · props·key | If[%suggest = true]; Variable Clear(%suggest*); Perform Task(Advanced Auto Brightness); Destroy Scene(AAB Brightness Graph); Else; Multiple Variables Set; Perform Task(_AdaptiveBrightnessSceneSize V4); Perform Task(_Loa… |
+| task632 | L28716 | AAB Profile · props·key | Show Scene(AAB Menu); Wait; Destroy Scene(AAB Profile) |
+| task651 | L32230 | AAB Brightness Graph · elements7·click | Perform Task(_SuggestCurveParameters V24 (Hybrid)); Wait; Destroy Scene(AAB Brightness Graph) |
+| task658 | L33306 | AAB Experiment Settings · elements3·longclick | Flash(Controls how wide the scale shifts over the d…) |
+| task660 | L33366 | AAB Experiment Settings · elements16·valueselected | Variable Set(%aab_scalesteepness) |
+| task662 | L33892 | AAB Experiment Settings · elements14·longclick | Flash(Controls the sharpness of the transition curv…) |
+| task664 | L34471 | AAB Experiment Settings · elements4·valueselected | Variable Set(%aab_scalespread) |
+| task665 | L34487 | AAB Experiment Settings · elements7·click | If[%aab_scalespread isNotSet]; Flash(⚠️ One or more values haven't been set. Can't…); Stop; Else; Perform Task(_SaveButtonExperiment); End If |
+| task666 | L34561 | AAB Experiment Settings · elements8·click | Perform Task(_ExitButton) |
+| task667 | L34583 | AAB Experiment Settings · elements8·longclick | Perform Task(_ExitButton) |
+| task669 | L34604 | AAB Experiment Graph · elements3·click | Perform Task(_SaveButtonExperiment) |
+| task670 | L34626 | AAB Experiment Settings · elements35·longclick | Flash(Select the date and/or location for the sunri…) |
+| task671 | L34651 | AAB Experiment Graph · elements5·click | Show Scene(AAB Experiment Settings); Perform Task(_LoadedExperimentTogglesV2); Wait; Destroy Scene(AAB Experiment Graph) |
+| task672 | L34700 | AAB Experiment Settings · elements18·longclick | Flash(Enables or disables the entire experimental c…) |
+| task674 | L34725 | AAB Experiment Settings · elements10·click | If[%aab_scaletransitionfactor > 0.5]; Flash(⚠️ Graph might be non-sensical due to scale t…); End If; Flash(Please be patient. Generating the graph might…); Variable Clear(%AAB_SunLastDate); Perform Task(Dynamic Scale V1… |
+| task675 | L34860 | AAB Experiment Settings · elements12·click | Variable Clear(%AAB_SetupComplete); Variable Set(%reset); Perform Task(Initialize AAB Defaults); Variable Clear(%reset); Variable Set(%AAB_SetupComplete); Multiple Variables Set; Perform Task(_ExperimentScene) |
+| task676 | L34953 | AAB Experiment Settings · elements19·checkchange | Perform Task(_ExperimentUIToggle) |
+| task677 | L34975 | AAB Experiment Settings · elements17·checkchange | Perform Task(_ExperimentUIToggle) |
+| task678 | L34997 | AAB Experiment Settings · elements13·longclick | Flash(Adjusts the duration of the transition betwee…) |
+| task679 | L35022 | AAB Taper Graph · elements3·click | Perform Task(_SaveButtonExperiment) |
+| task680 | L35044 | AAB Taper Graph · elements5·click | Show Scene(AAB Experiment Settings); Perform Task(_LoadedExperimentTogglesV2); Wait; Destroy Scene(AAB Taper Graph) |
+| task681 | L35093 | AAB Experiment Settings · elements38·click | Element Value(AAB Experiment Settings); Element Value(AAB Experiment Settings) |
+| task682 | L35116 | AAB Misc Settings · elements34·longclick | Flash(Use notifications to keep the service alive a…) |
+| task683 | L35141 | AAB Experiment Settings · elements36·click | Element Value(AAB Experiment Settings); Element Value(AAB Experiment Settings) |
+| task684 | L35163 | AAB Misc Settings · elements31·longclick | Flash(Current throttle is a time based gatekeeper f……) |
+| task685 | L35190 | AAB About · elements1·click | Perform Task(_MenuScene); Wait; Destroy Scene(AAB About) |
+| task686 | L35224 | AAB Experiment Settings · elements23·click | Flash(Please be patient. Generating the graph might…); Perform Task(_GenerateCompressionGraph (Java)); Multiple Variables Set; Perform Task(_AdaptiveBrightnessSceneSize V4); Hide Scene(AAB Experiment Settings) |
+| task687 | L35304 | AAB Experiment Settings · elements25·longclick | Flash(Sets the brightness level (%AAB_MinBright-%AA…) |
+| task688 | L35329 | AAB Experiment Settings · elements31·longclick | If[%AAB_Package = net.dinglisch.android.ta…]; Flash(Use a quick settings tile set to position 3 (…); Else; Flash(This only works for Tasker. It does nothing f…); End If |
+| task689 | L35389 | AAB Experiment Settings · elements26·valueselected | If[%aab_scaletapermidpoint < %AAB_MaxBright]; Variable Set(%aab_scaletapermidpoint); Else; Flash(⚠️ Taper midpoint cannot exceed current maxim…); End If |
+| task690 | L35440 | AAB Experiment Settings · elements27·longclick | Flash(Controls the slope of the dynamic range compr…) |
+| task691 | L35465 | AAB Experiment Settings · elements28·valueselected | Variable Set(%aab_scaletapersteepness) |
+| task693 | L35624 | AAB Misc Settings · elements37·click | Perform Task(_NotifyToggle) |
+| task694 | L35646 | AAB Experiment Settings · elements30·longclick | Flash(Displays the current (un)compressed scale fac…) |
+| task695 | L35671 | AAB Misc Settings · elements35·checkchange | Perform Task(_NotifyToggle) |
+| task697 | L35927 | AAB Experiment Settings · elements32·checkchange | Perform Task(_QSExperimentUIToggle) |
+| task699 | L36452 | AAB Experiment Settings · elements33·checkchange | Perform Task(_QSExperimentUIToggle) |
+| task701 | L36713 | AAB Reactivity Settings · elements13·valueselected | Variable Set(%aab_threshdark_c); Variable Set(%aab_threshdark) |
+| task702 | L36739 | AAB Superdimming Settings · elements30·longclick | Flash(Gamma-like exponent. Controls the shape of th……) |
+| task704 | L37156 | AAB Reactivity Settings · elements14·valueselected | Variable Set(%aab_threshdim_c); Variable Set(%aab_threshdim) |
+| task708 | L38257 | AAB Reactivity Settings · elements15·valueselected | Variable Set(%aab_threshbright_c); Variable Set(%aab_threshbright) |
+| task709 | L38283 | AAB Reactivity Settings · elements16·valueselected | Variable Set(%aab_threshsteepness) |
+| task710 | L38299 | AAB Reactivity Settings · elements20·click | Perform Task(_SaveButtonReactivity); Multiple Variables Set |
+| task711 | L38348 | AAB Reactivity Settings · elements21·longclick | Flash(Brightness is only changed when the change in…) |
+| task712 | L38373 | AAB Reactivity Settings · elements10·longclick | Variable Set(%aab_10xthreshmidpoint); Flash(The log-transformed lux level where the syste……) |
+| task713 | L38410 | AAB Reactivity Settings · elements23·valueselected | Variable Set(%aab_threshmidpoint) |
+| task714 | L38426 | AAB Misc Settings · elements20·valueselected | Variable Set(%aab_animsteps); Variable Set(%aab_throttle); If[%aab_throttle < 1001]; Variable Set(%aab_throttle); End If |
+| task715 | L38475 | AAB Misc Settings · elements22·valueselected | If[%aab_minwait < %aab_maxwait]; Variable Set(%aab_minwait); Else; Wait; Variable Set(%aab_maxwait); Flash(Minimum wait cannot exceed maximum wait!); c50(AAB Misc Settings); End If |
+| task716 | L38552 | AAB Misc Settings · elements23·valueselected | If[%aab_maxwait > %aab_minwait]; Variable Set(%aab_maxwait); Variable Set(%aab_throttle); End If; Else; Wait; Variable Set(%aab_minwait); Flash(Maximum wait cannot be lower than minimum wai…); c50(AAB Misc Settings); En… |
+| task717 | L38662 | AAB User Guide · elements1·click | Perform Task(_MenuScene); Wait; Destroy Scene(AAB User Guide) |
+| task718 | L38696 | AAB Chart.Js License · elements1·click | Perform Task(_MenuScene); Wait; Destroy Scene(AAB Chart.Js License) |
+| task719 | L38730 | AAB Reactivity Settings · elements6·longclick | Flash(The reactivity level in complete darkness. A …) |
+| task720 | L38755 | AAB Reactivity Settings · elements7·longclick | Flash(The baseline reactivity for most situations. …) |
+| task721 | L38780 | AAB Reactivity Settings · elements8·longclick | Flash(The baseline reactivity for bright, outdoor l…) |
+| task722 | L38805 | AAB Reactivity Settings · elements9·longclick | Flash(Controls how quickly the reactivity changes a…) |
+| task723 | L38830 | AAB Misc Settings · elements3·longclick | Flash(Sets the lowest brightness level the screen w…) |
+| task724 | L38855 | AAB Brightness Settings · elements5·click | Perform Task(_UpdateBrightnessFormulae); Perform Task(_UpdateStaticSceneElements); Variable Set(%array_size); If[%suggest = true]; Element Value(AAB Brightness Graph); Element Value(AAB Brightness Graph); Else[%array_si… |
+| task725 | L39090 | AAB Brightness Settings · elements6·longclick | Flash(Controls how quickly brightness rises in dim …) |
+| task726 | L39115 | AAB Misc Settings · elements16·longclick | Flash(The number of steps in a brightness change an…) |
+| task727 | L39140 | AAB Misc Settings · elements19·longclick | Flash(The shortest time (in milliseconds) between a…) |
+| task728 | L39165 | AAB Misc Settings · elements18·longclick | Flash(The longest time (in milliseconds) between an…) |
+| task729 | L39190 | AAB Reactivity Settings · elements27·longclick | Flash(Enable this ONLY if auto-brightness seems unr…) |
+| task730 | L39215 | AAB Misc Settings · elements8·longclick | Flash(A global multiplier for the entire brightness…) |
+| task731 | L39240 | AAB Reactivity Settings · elements29·checkchange | Perform Task(_ReactivityToggle) |
+| task732 | L39262 | AAB Misc Settings · elements7·longclick | Flash(A simple brightness boost or cut. This value …) |
+| task733 | L39287 | AAB Reactivity Settings · elements28·checkchange | Perform Task(_ReactivityToggle) |
+| task734 | L39309 | AAB Brightness Settings · elements7·valueselected | Variable Set(%aab_form1a) |
+| task735 | L39325 | AAB Reactivity Settings · elements25·click | Variable Clear(%AAB_SetupComplete); Variable Set(%reset); Perform Task(Initialize AAB Defaults); Variable Clear(%reset); Variable Set(%AAB_SetupComplete); Multiple Variables Set; Destroy Scene(AAB Reactivity Settings); … |
+| task736 | L39422 | AAB Brightness Settings · elements9·longclick | Flash(Hinge point to enable smooth transition from …) |
+| task737 | L39447 | AAB Brightness Settings · elements11·longclick | Flash(Higher values give a major boost in medium li…) |
+| task738 | L39472 | AAB Misc Settings · elements30·click | Variable Clear(%AAB_SetupComplete); Variable Set(%reset); Perform Task(Initialize AAB Defaults); Variable Clear(%reset); Variable Set(%AAB_SetupComplete); Multiple Variables Set; Perform Task(_MiscScene) |
+| task739 | L39570 | AAB Brightness Settings · elements12·valueselected | If[%new_val isSet]; Variable Set(%aab_form2b); End If |
+| task740 | L39599 | AAB Misc Settings · elements26·longclick | Flash(Controls how much to smooth out sensor readin…) |
+| task741 | L39624 | AAB Brightness Settings · elements13·longclick | Flash(Subtle but powerful "offset" for the midrange…) |
+| task742 | L39649 | AAB Misc Settings · elements28·valueselected | If[%new_val < 0.0001]; Stop; Else; Variable Set(%aab_deltafactor); End If |
+| task743 | L39686 | AAB Misc Settings · elements29·click | Perform Task(_GenerateAlphaGraph (Java)); Multiple Variables Set; Perform Task(_AdaptiveBrightnessSceneSize V4); Hide Scene(AAB Misc Settings) |
+| task744 | L39747 | AAB Brightness Settings · elements14·valueselected | Variable Set(%aab_form2c); Variable Set(%aab_form3a) |
+| task746 | L39773 | AAB Alpha Graph · elements3·click | Perform Task(_SaveButtonMisc) |
+| task747 | L39795 | AAB Brightness Settings · elements15·longclick | Flash(Sets the lux level where 'dim light' ends and…) |
+| task748 | L39820 | AAB Alpha Graph · elements5·click | Multiple Variables Set; Perform Task(_AdaptiveBrightnessSceneSize V4); Perform Task(_LoadedMiscAuto); Destroy Scene(AAB Alpha Graph) |
+| task749 | L39880 | AAB Brightness Settings · elements16·longclick | Flash(Hinge point to enable smooth transition from …) |
+| task750 | L39905 | AAB Brightness Settings · elements18·longclick | Flash(Sets the lux level where 'indoor light' ends …) |
+| task751 | L39930 | AAB Brightness Settings · elements19·valueselected | If[%new_val isSet]; Variable Set(%aab_zone2end); End If |
+| task752 | L39959 | AAB Brightness Settings · elements20·valueselected | If[%new_val isSet]; Variable Set(%aab_form2d); Variable Set(%aab_zone1end); End If; If[%aab_zone1end < %aab_form2c]; Variable Set(%aab_form2c); Element Visibility(AAB Brightness Settings); Perform Task(_RedInvalidFormul… |

--- a/docs/rebuild/extraction/tasks/task545_detect-proximity.md
+++ b/docs/rebuild/extraction/tasks/task545_detect-proximity.md
@@ -1,0 +1,17 @@
+# task545 "Detect Proximity" (XML L16424–16473) — S3.5
+
+Enter & exit task of prof759 (State **Proximity**, code 125, arg0=1). Task pri 6.
+Owner-verified S3.5 (D-022).
+
+| Act | Code | Action |
+|---|---|---|
+| act0 | 37 If | `%caller1 ~ *enter*` |
+| act1 | 547 Variable Set | `%AAB_Proximity = near` |
+| act2 | 43 Else-If | `%caller1 ~ *exit*` |
+| act3 | 547 Variable Set | `%AAB_Proximity = far` |
+| act4 | 38 End If | — |
+
+Consumed in task544 act28–29: `if %AAB_Proximity = near → LuxAlpha = lux_results2 × 0.1`
+(reaction damping while the phone is at the ear / in a pocket). It does **NOT** pause the
+pipeline. Port target: S9 proximity sensor listener → pipeline state flag feeding the
+engine's alpha damping.

--- a/docs/rebuild/screen_map.md
+++ b/docs/rebuild/screen_map.md
@@ -14,8 +14,8 @@ rects and `PropertiesElement` scene-chrome are dropped (replaced by the M3 Scaff
 | **Dashboard** | Menu (nav), Misc Settings (global toggles, service switch) | — |
 | **Curve & Brightness** | Brightness Settings, Brightness Graph | BrightnessCurveChart |
 | **Reactivity** | Reactivity Settings, Reactivity Graph, Alpha Graph | ReactivityChart |
-| **Animation & Dimming** | Superdimming Settings, Dimming Graph, Color Filter | DimmingChart |
-| **Dynamic Scale** | Experiment Settings, Experiment Graph, Circadian Dimming Graph, Taper Graph | ExperimentChart, CircadianChart, TaperChart |
+| **Animation & Dimming** | Superdimming Settings, Dimming Graph, Circadian Dimming Graph, Color Filter | DimmingChart, CircadianChart |
+| **Dynamic Scale** | Experiment Settings, Experiment Graph, Taper Graph | ExperimentChart, TaperChart |
 | **Contexts** | (rules surfaced from contexts_spec — no dedicated Tasker scene; editor lives in AAB Profile) | — |
 | **Tools** | Debug Scene, Power Draw Graph, (wizard from Brightness Graph 'Suggest', calibration from task524) | PowerDrawChart |
 | **Profiles & Import/Export** | AAB Profile (profile manager + context-rule editor) | — |
@@ -452,22 +452,30 @@ Every Chart.js WebElement maps to a named Compose-Canvas chart (built S12/S13). 
 | background#5 | Rect | dropped(decorative/background rect) |
 | props | Properties | merged-into Dynamic Scale |
 
-### AAB Circadian Dimming Graph  ·  `circadian_dimming_graph`  ·  XML L2388–2551  ·  12 elements  → Dynamic Scale
+### AAB Circadian Dimming Graph  ·  `circadian_dimming_graph`  ·  XML L2388–2551  ·  12 elements  → Animation & Dimming
+
+> **S3.5 (owner, D-026): re-homed Dynamic Scale → Animation & Dimming.** In Tasker this graph is opened
+> from **Superdimming Settings** (`draw_graph4` button, handler task517: warning toast if
+> `%aab_scaletransitionfactor>0.5`, clears `%AAB_SunLastDate`, runs task90 + task705, hides Superdimming
+> Settings), and the button is shown only when circadian scaling (`%AAB_ScalingUse`) is enabled — keep
+> that conditional visibility. This also resolves the contradiction with `_disp_group4.md`, which already
+> said Animation & Dimming. (Distinct from the Experiment Graph / task549 / Graph4 — that one stays in
+> Dynamic Scale.)
 
 | Element | Type | Disposition |
 |---|---|---|
-| elements0 | Web | merged-into Dynamic Scale |
-| elements1 | Web | merged-into Dynamic Scale |
+| elements0 | Web | merged-into Animation & Dimming |
+| elements1 | Web | merged-into Animation & Dimming |
 | background#1 | Rect | dropped(decorative/background rect) |
-| elements2 | Text | merged-into Dynamic Scale |
+| elements2 | Text | merged-into Animation & Dimming |
 | background#2 | Rect | dropped(decorative/background rect) |
-| elements3 | Text | merged-into Dynamic Scale |
+| elements3 | Text | merged-into Animation & Dimming |
 | background#3 | Rect | dropped(decorative/background rect) |
-| elements4 | Text | merged-into Dynamic Scale |
+| elements4 | Text | merged-into Animation & Dimming |
 | background#4 | Rect | dropped(decorative/background rect) |
-| elements5 | Text | merged-into Dynamic Scale |
+| elements5 | Text | merged-into Animation & Dimming |
 | background#5 | Rect | dropped(decorative/background rect) |
-| props | Properties | merged-into Dynamic Scale |
+| props | Properties | merged-into Animation & Dimming |
 
 ### AAB Taper Graph  ·  `taper_graph`  ·  XML L8387–8550  ·  12 elements  → Dynamic Scale
 


### PR DESCRIPTION
## Summary

Owner-review corrections folded into extraction documentation and CLAUDE.md. All changes are docs-only; no source code or build artifacts modified.

## Key changes

- **ConditionList boolean semantics validated (D-021):** Plain `And`/`Or` bind tighter (inner groups, `And` > `Or` precedence); `And2`/`Or2` join those groups left-to-right. Resolves INDEX.md unresolved #1 and D-009. ⚠️ **Critical discovery:** ConditionList children are stored ALPHABETICALLY in XML (`bool10` < `bool2`), not numerically — S1's prof758 transcription was scrambled by this (fixed in profiles.md; recipe R4 updated).

- **task551 act0 branch logic resolved (D-018 leftover):** Corrected reading of the service ON/OFF toggle condition with validated And/Or precedence.

- **`%AAB_Debug` = 10 named info categories, not verbosity levels (D-023):** Updated features_spec.md with authoritative table from the Debug scene selector (XML L2773–2782). Levels are discrete toast categories (equality-matched), not monotonic severity tiers.

- **168 anonymous task census added (D-026):** New file `extraction/tasks/anonymous_handlers.md` documents all unnamed scene-element handlers (clickTask, checkchangeTask, keyTask, etc.) with their wiring, actions, and consumption guidance for S12/S13 porting.

- **task545 "Detect Proximity" documented (D-022):** New file `extraction/tasks/task545_detect-proximity.md` clarifies prof759 behavior: sets `%AAB_Proximity` near/far → damps LuxAlpha ×0.1 in the pipeline, does NOT pause.

- **prof769 panic context clarified (D-022):** Corrected to Event 2083 (shake/significant-motion) + State 120/3 (upside-down) + State 123/1.

- **Action codes corrected (D-025):** Code 590 = Variable Split (was mislabeled "Array Push"), code 105 = Set Clipboard. `%AAB_Test` = curve-wizard diagnostics report → clipboard (user-facing).

- **Non-`%AAB_` globals census added (D-025):** Identified four bare runtime globals (`%SmoothedLux`, `%AutoBrightRunning`, `%LastAAB`, `%LuxAlpha`) missed by S1's scope.

- **Circadian Dimming Graph re-homed (D-026):** Moved from Dynamic Scale to Animation & Dimming screen per owner clarification; updated screen_map.md and disposition notes.

- **Privilege detection deviation documented (D-024):** Noted that task563 reads Tasker pref `adbwp` (ADB port) — a sanctioned deviation; S12 rebuild must NOT read Tasker prefs and drops ADB-WiFi probing (elevated-tier truth = `checkPermission(WRITE_SECURE_SETTINGS)`).

- **CLAUDE.md updated:** Branch naming clarified (per-session `claude/*` branches by design; owner merges each segment to main via PR). S3.5 corrections summarized for future sessions.

- **STATE.md updated:** Added S3.5 errata row with D-020…D-026 ledger entries.

## Notable details

- All 168 anonymous tasks are referenced from exactly one scene (no dead code); 34 are `keyTask` handlers on PropertiesElements (back-key behavior) that S2 dropped as "scene chrome" — S12 must re-derive per-screen back behavior from them.
- ConditionList alphabetical-ordering trap is a critical extraction hazard for future sessions; recipe R4 now flags it.
- `%AAB_MaxSteps` confirmed as legacy/unused (never assigned a default); marked LEGACY in defaults_audit.md.

https://claude.ai/code/session_01UmuTRGY61vKbm36ETjyKF9