### PR TITLE
S3.6: Plan hardening from peer review (D-027)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ dimming. Shizuku is used only in the grant flow, never as a runtime binder depen
   not stale — but it has zero action-level or scene detail; treat as reference only.
 - Salvage KEEP list: `domain/.../brightness/BrightnessEngine.kt` (+tests),
   `app/.../settings/AabSettings.kt`, `TaskerLegacyProfileSerializer.kt`, SettingsStore/
-  AppDataStores, module split, runtime scaffolding shapes. DISCARD list (deleted by S3/S9):
+  AppDataStores, module split, runtime scaffolding shapes. DISCARD list (deleted by S3/S9b):
   toy `BrightnessPolicyEngine` + `EvaluateAndApplyBrightnessUseCase` + `Ports.kt`, everything
   in `data/`, `platform/SystemAdapters.kt` fakes, `WebViewGraphFallback`,
   `PermissionOnboardingStateMachine`.
@@ -92,6 +92,14 @@ dimming. Shizuku is used only in the grant flow, never as a runtime binder depen
   task545 sets %AAB_Proximity near/far → damps LuxAlpha ×0.1, never pauses. prof769 panic =
   upside-down + shake. 168/276 tasks are anonymous scene handlers → see
   extraction/tasks/anonymous_handlers.md. Never read Tasker prefs (adbwp) in the rebuild.
+- S3.6 peer-review adoptions (D-027): S9 split into S9a (pipeline core + service) and S9b
+  (dimming wiring, tile, boot receiver, legacy rip-out) — Gate 1 after S9b. Runtime concurrency
+  model is BINDING: single pipeline coroutine, one event runs to completion (incl. animation),
+  events arriving mid-cycle are DROPPED not queued (prof760's %AAB_MainLoop clause is Tasker's
+  re-entry mutex, D-021). Profile gates = hardcoded Kotlin booleans with provenance + a
+  truth-table test; no generic ConditionList evaluator. S8 preconditions now include S2.
+  S4 has an explicit code-547 maths transcription protocol (cross-validate task661 vs task663;
+  disagreements → parity_gaps.md, never guess). S12 starts with an anonymous-handler triage.
 
 ## Coding conventions
 

--- a/docs/rebuild/RUNBOOK.md
+++ b/docs/rebuild/RUNBOOK.md
@@ -12,13 +12,15 @@ Models are Opus / Sonnet / Haiku at reasoning effort low / medium / high. Where 
 
 ```
 S0 ─┬─ S1 ─┬──────────── S4 ── S5 ─┬─ S6 ─────┐
-    ├─ S2 ─┤(S2 feeds S6,S10,S12+) ├─ S7 ─────┼─ S9 ─┬─ S10 ─┬─ S12 ── S13 ── S14
-    └─ S3 ─┴─(gates all builds)────┴─ S8 ─────┘GATE1 └─ S11 ─┘ GATE2          GATE3
+    ├─ S2 ─┤(S2 feeds S6,S8,S10,S12+) S7 ─────┼─ S9a ── S9b ─┬─ S10 ─┬─ S12 ── S13 ── S14
+    └─ S3 ─┴─(gates all builds)────┴─ S8 ─────┘        GATE1 └─ S11 ─┘ GATE2          GATE3
 ```
 
 Parallel windows (disjoint files; if raced, `git pull --rebase` before push):
-**A:** S1 ∥ S2 ∥ S3 · **B:** S6 ∥ S7 ∥ S8 (after S5; S6 also needs S2) · **C:** S10 ∥ S11 (after S9).
-Serial spine: S0 → A → S4 → S5 → B → S9 → C → S12 → S13 → S14.
+**A:** S1 ∥ S2 ∥ S3 · **B:** S6 ∥ S7 ∥ S8 (after S5; S6 and S8 also need S2) ·
+**C:** S10 ∥ S11 (after S9b).
+Serial spine: S0 → A → S4 → S5 → B → S9a → S9b → C → S12 → S13 → S14.
+(S9 was split into S9a/S9b in S3.6 — see D-027.)
 
 ## Global failure protocol
 
@@ -196,10 +198,10 @@ compose BOM, minimal res/ (kills the `R.mipmap.ic_launcher` blocker), correct ma
 9. `:platform` → `com.android.library` (namespace `com.tideo.autobrightness.platform`,
    minSdk 31, compileSdk 35, Robolectric-ready: `testOptions.unitTests
    { isIncludeAndroidResources = true; isReturnDefaultValues = true }`). Keep
-   `SystemAdapters.kt` compiling as-is (deleted in S9, not now).
+   `SystemAdapters.kt` compiling as-is (deleted in S9b, not now).
 10. Retire `:data`: `grep -rn "autobrightness.data" app domain platform` — if (expected) zero
    references: remove from `settings.gradle.kts`, `git rm -r data/`. If referenced: record in
-   STATE.md and defer deletion to S9.
+   STATE.md and defer deletion to S9b.
 11. Lint baseline: `./gradlew :app:lintDebug` → commit `app/lint-baseline.xml`
     (`lint { baseline = file("lint-baseline.xml") }`). Policy: baseline never grows.
 12. STATE.md (record exact final version matrix) + checklist untouched (no parity rows here) +
@@ -252,6 +254,16 @@ continuity math), `pipeline_spec.md`, `defaults_audit.md`;
 
 **Non-goals:** Do NOT fix `BrightnessEngine` (S5's job). No circadian/wizard (S6). No app/
 platform changes. No gradle changes beyond (if needed) a test-resources stanza.
+
+**Expression transcription protocol (code-547 maths — task661 curve math, task659 continuity;
+D-002/D-027):** Java blocks get verbatim decode, but Variable Set maths expressions need their
+own discipline: (a) start from the verbatim expression in the extraction doc; (b) write the
+parse tree you inferred into the function's provenance comment (note operator precedence/
+associativity assumptions explicitly); (c) cross-validate the task661 transcription against
+task663's plot-side Java copy of the same 3-zone formula (CLAUDE.md ledger) by running both
+over the golden lux grid; (d) if 661 and 663 disagree on any row, record both values in
+`parity_gaps.md` and re-derive from the XML via recipes — NEVER pick one by guessing. This is
+the highest-risk transcription in the program: a divergence here is wrong brightness everywhere.
 
 **Steps:** transcribe block-by-block with the original Java in a side comment where subtle;
 sanity-test each reference function against hand-computed values from XML comments/Flash
@@ -380,9 +392,9 @@ as interface + impl + Robolectric/fake test):
   `context/WifiInfoReader.kt` (`ConnectivityManager.registerNetworkCallback` with
   `FLAG_INCLUDE_LOCATION_INFO`, read `transportInfo as WifiInfo` SSID; document
   FINE_LOCATION requirement).
-- Mark `SystemAdapters.kt` classes `@Deprecated("S9 removes")` (toy loop still uses them).
+- Mark `SystemAdapters.kt` classes `@Deprecated("S9b removes")` (toy loop still uses them).
 
-**Non-goals:** No service/runtime rewiring (S9), no UI, no context POLICY (S10 — you build
+**Non-goals:** No service/runtime rewiring (S9a/S9b), no UI, no context POLICY (S10 — you build
 readers only), no deletion of fakes.
 
 **Acceptance:** `./gradlew :platform:test :app:assembleDebug` green. Robolectric coverage:
@@ -398,8 +410,9 @@ sensor source covered by a fake-driven flow test (Robolectric sensors are limite
 
 ## S8 — Settings schema v2, persistence, import/export
 
-**Model:** Sonnet / medium · **Size:** medium · **Preconditions:** S1 DONE, S5 DONE.
-Parallel window B.
+**Model:** Sonnet / medium · **Size:** medium · **Preconditions:** S1 DONE, S2 DONE
+(features_spec.md carries the 583/707 validation rules + 592/637/622 import/export semantics),
+S5 DONE. Parallel window B.
 
 **Objective:** Close every settings-schema gap, version the schema with migration, make
 import/export + default profiles real, expose validation for the UI.
@@ -425,18 +438,33 @@ round-trip + validator tests; pushed.
 
 ---
 
-## S9 — Runtime integration: the real pipeline service (+ legacy rip-out)
+## S9a — Runtime core: the real pipeline service
 
 **Model:** Sonnet / high (Opus / medium if budget allows — cheapest insurance before Gate 1)
-· **Size:** large · **Preconditions:** S5, S6, S7, S8 all DONE.
+· **Size:** large · **Preconditions:** S5, S6, S7, S8 all DONE. (Split from the original S9
+per D-027 so the parity-critical core can land/block independently of features+cleanup.)
 
 **Objective:** Rebuild the runtime as the sensor-event-driven Tasker pipeline with animated
-writes, override detect/resume, hibernate, throttle, panic, boot start, QS tile, actionable
-notification; delete every legacy fake.
+writes, override detect/resume, hibernate, throttle, panic, actionable notification.
 
 **Inputs:** `pipeline_spec.md` (THE spec), extraction docs for 554/544/535/661/548/543/696/
-698/700/618/585/566/567/569/561/528/551/584, all S7 adapters, S8 mapper, existing
-`app/.../runtime/*`.
+698/700/618/585/566/567/569/561/528/584, `extraction/profiles.md` (D-021 grouping), all S7
+adapters, S8 mapper, existing `app/.../runtime/*`.
+
+**Concurrency model (BINDING, D-027):** the pipeline is serialized — a single pipeline
+coroutine processes one event to completion (including its animation frames) before looking at
+the next. Sensor events arriving mid-cycle are **DROPPED, not queued** — this is exactly what
+prof760's `%AAB_MainLoop != On` clause does in Tasker (a re-entry mutex, D-021): the profile
+simply doesn't fire while a cycle runs. Implement as a busy-gate (e.g. `Channel` with
+drop-when-busy `trySend`, or an atomic in-cycle flag); the MainLoop flag maps to it 1:1. All
+runtime state (smoothedLux, lastRawLux, thresholds, cycleTime…) lives in one state holder
+written ONLY from the pipeline coroutine; other coroutines (UI, notification) read via
+StateFlow snapshots. No state writes from observer/animation callbacks — they signal the
+pipeline coroutine instead.
+
+**Profile-gate strategy (D-027):** HARDCODE each profile's ConditionList as a Kotlin boolean
+expression with a provenance comment showing the D-021 parenthesization — do NOT build a
+generic ConditionList evaluator (we port fixed profiles, not a Tasker runtime).
 
 **Deliverables:**
 1. `app/.../runtime/BrightnessPipelineController.kt` — owns Tasker runtime state (smoothedLux,
@@ -453,20 +481,52 @@ notification; delete every legacy fake.
    actions Pause/Resume/Disable + panic-reset (528: restore sane brightness, clear state);
    SCREEN_OFF → hibernate (sensor unregister, state reset per 585), SCREEN_ON → reinit
    (throttle reset 566 + initial brightness 618 via domain `InitialBrightness`).
-5. Super dimming: below threshold engage `SecureDimmingController` (math from domain
-   `SoftwareDimming`) when tier ELEVATED; clean disengage path (645–654 semantics).
-6. `runtime/BrightnessTileService.kt` — `TileService` toggling the service; manifest entry
+5. Gate truth-table unit test (D-027): construct the prof760 AND prof758 condition expressions
+   exactly per D-021 grouping and assert true/false for every branch of each clause — a
+   mis-parenthesized gate silently suppresses sensor events and no other test catches it.
+6. Robolectric/unit tests: service start → foreground notification posted; SCREEN_OFF/ON
+   hibernate/reinit (sensor flow subscription state); observer event → paused state; pipeline
+   controller unit-tested with fake adapters end-to-end (lux sequence → expected write
+   sequence from goldens); mid-cycle event is dropped (concurrency model assertion).
+
+**Non-goals:** Super dimming wiring, QS tile, boot receiver, legacy rip-out (ALL S9b).
+Context-override policy (S10), UI screens (S11/S12), onboarding flow (S11).
+
+**Acceptance:** `./gradlew :app:assembleDebug :app:testDebugUnitTest :domain:test
+:platform:test :app:lintDebug` green (legacy fakes still present — S9b deletes them); pushed.
+
+**Failure notes:** `ForegroundServiceTypeException` on start → re-check manifest property +
+type flag pairing. If blocked, S9b can still NOT proceed (it deletes code S9a's graph replaces)
+— log BLOCKED and recommend escalation.
+
+---
+
+## S9b — Runtime features + legacy rip-out
+
+**Model:** Sonnet / high · **Size:** medium · **Preconditions:** S9a DONE. Same window —
+ideally the immediately following session.
+
+**Objective:** Finish the runtime surface (super dimming, QS tile, boot start) and delete
+every legacy fake, then declare Gate 1.
+
+**Inputs:** extraction docs 645–654/700 (dimming), 551 (tile), `features_spec.md`;
+S9a runtime; `AppModule.kt`.
+
+**Deliverables:**
+1. Super dimming: below threshold engage `SecureDimmingController` (math from domain
+   `SoftwareDimming`) when tier ELEVATED; clean disengage path (645–654 semantics); wired
+   into the S9a pipeline cycle (writes happen from the pipeline coroutine — see S9a
+   concurrency model).
+2. `runtime/BrightnessTileService.kt` — `TileService` toggling the service; manifest entry
    with `android.permission.BIND_QUICK_SETTINGS_TILE` + icon.
-7. `BootCompletedReceiver` — start service if enabled (specialUse FGS is boot-eligible;
+3. `BootCompletedReceiver` — start service if enabled (specialUse FGS is boot-eligible;
    if start fails log + post notification prompting open).
-8. RIP-OUT: delete `domain/BrightnessPolicyEngine.kt`, `domain/EvaluateAndApplyBrightnessUseCase.kt`,
+4. RIP-OUT: delete `domain/BrightnessPolicyEngine.kt`, `domain/EvaluateAndApplyBrightnessUseCase.kt`,
    `domain/Ports.kt`, `platform/SystemAdapters.kt`, `app/ui/graph/WebViewGraphFallback.kt`,
    `app/onboarding/PermissionOnboardingStateMachine.kt`, leftover `data/` references; rewrite
    `AppModule.kt` composing the real graph; keep `ServiceHealthStore` telemetry.
-9. Robolectric tests: service start → foreground notification posted; SCREEN_OFF/ON
-   hibernate/reinit (sensor flow subscription state); observer event → paused state;
-   tile instantiation; pipeline controller unit-tested with fake adapters end-to-end
-   (lux sequence → expected write sequence from goldens).
+5. Robolectric tests: tile instantiation; boot receiver → service start intent; dimming
+   engage/disengage tier-gated.
 
 **Non-goals:** Context-override policy (S10), UI screens (S11/S12), onboarding flow (S11).
 
@@ -475,15 +535,15 @@ notification; delete every legacy fake.
 EvaluateAndApplyBrightnessUseCase" app domain platform` → empty; STATE.md row notes "GATE 1
 READY"; pushed. → **HUMAN GATE 1** (checklist below).
 
-**Failure notes:** `ForegroundServiceTypeException` on start → re-check manifest property +
-type flag pairing; Robolectric TileService gaps → downgrade to instantiation-only test +
-STATE.md note.
+**Failure notes:** Robolectric TileService gaps → downgrade to instantiation-only test +
+STATE.md note. If rip-out breaks compilation in ways out of scope, prefer reverting the
+specific deletion and logging PARTIAL over leaving the branch red.
 
 ---
 
 ## S10 — Context override engine
 
-**Model:** Sonnet / medium · **Size:** medium · **Preconditions:** S2, S7, S9 DONE.
+**Model:** Sonnet / medium · **Size:** medium · **Preconditions:** S2, S7, S9a+S9b DONE.
 Parallel window C (with S11).
 
 **Objective:** Port the context system: per-app / WiFi / battery / time / location overrides
@@ -510,7 +570,7 @@ resolver test matrix matches spec table 1:1; pushed.
 
 ## S11 — UI shell, onboarding/privileges, dashboard
 
-**Model:** Sonnet / medium · **Size:** large · **Preconditions:** S7, S8, S9 DONE.
+**Model:** Sonnet / medium · **Size:** large · **Preconditions:** S7, S8, S9a+S9b DONE.
 Parallel window C (with S10 — disjoint packages; rebase before push).
 
 **Objective:** Compose M3 navigation shell (screen set per `screen_map.md`), privilege
@@ -533,9 +593,13 @@ usage-access step shown only when app rules exist (deep-link `ACTION_USAGE_ACCES
 (pipeline flows), service master switch (start/stop FGS), pause/resume, active context line,
 tier badge → onboarding, service health (last sensor event, degraded flags); M3 dynamic color
 + DayNight; first-run routing → onboarding when tier == NONE.
+Also revisit D-019's XML theme workaround (`android:Theme.Material.Light.NoActionBar`):
+Compose M3 generates its own theming and needs no Material XML parent — evaluate simplifying
+`values/themes.xml` to a minimal/no-op parent (watch the pre-Compose window background +
+status-bar look); record the outcome in STATE.md either way (D-027g).
 
 **Non-goals:** Parameter screens, charts, tools, context CRUD (all S12/S13). Notification
-styling (S9 owns it).
+styling (S9a owns it).
 
 **Acceptance:** `./gradlew :app:assembleDebug :app:lintDebug :app:testDebugUnitTest` green;
 Robolectric compose smoke test: launch → Dashboard renders, each route navigates; pushed.
@@ -556,6 +620,16 @@ every row owned by your screens must end up ported or dropped(reason); includes 
 `keyTask` rows = per-scene back-key behavior**), S8 `SettingsValidator`, S6
 `CurveSuggestionEngine`, existing `LineGraph.kt` (extend or replace — your call, record it),
 `extraction/features_spec.md` (calibration/debug — debug selector uses the 10 verbatim labels, D-023).
+
+**Step 0 — handler triage (BEFORE any porting, D-027f):** sweep `anonymous_handlers.md` and
+add a disposition-class column committing each of the 168 rows to one of three buckets:
+(a) **trivial scene-chrome** (background-rect clicks, scene close/back `keyTask` rows) →
+bulk-drop with one shared reason; (b) **settings mutations** (toggle/write a single variable,
+EditText value-selected) → dropped(`absorbed-by-compose-state`) — Compose field state +
+debounced persist already covers them; (c) **complex** (multi-action handlers with branching/
+side effects) → enumerate explicitly; THESE are your 1:1 port list. Commit the triaged file
+before starting screens so a follow-up session can resume from it. S13 owns the chart-scene
+rows — mark them `deferred-S13`, don't port them.
 
 **Deliverables:** screens per screen_map: Curve & Brightness (min/max/offset/scale, zone ends,
 form params + LIVE derived form2A/form3A readout), Reactivity (thresholds incl. midpoint/
@@ -644,7 +718,7 @@ on; lint-baseline shrink pass (delete entries that no longer fire).
 
 ## Human gates (the user + their phone; findings go to STATE.md "Gate findings")
 
-**GATE 1 — core loop (after S9).** Install `app/build/outputs/apk/debug/app-debug.apk`.
+**GATE 1 — core loop (after S9b).** Install `app/build/outputs/apk/debug/app-debug.apk`.
 Grant notifications + WRITE_SETTINGS via onboarding-less path if S11 not done yet (Settings →
 Apps → Special access → Modify system settings). Enable service. Verify: cover light sensor →
 brightness animates DOWN smoothly (no jumps); shine light → animates UP; drag system slider
@@ -684,7 +758,7 @@ style segment scoped to the findings).
 | 1 | Extraction misreading | Opus on S1/S2/S4; verbatim dumps + line provenance; census reconciliation (40/18/20/125); "unresolved" over guessing | S1/S2 |
 | 2 | Rounding/tie divergence (Math.round ties, BigDecimal HALF_UP, string outputs) | Reference keeps Java semantics; explicit tie/boundary golden rows | S4/S5 |
 | 3 | Kotlin 2 / AGP migration friction | Pinned matrix; step-down-one-minor protocol; STATE log | S3 |
-| 4 | FGS specialUse / boot policy (API 34/35) | Manifest property + type flag pairing; Gate-1 reboot test; dataSync abandoned | S3/S9 |
+| 4 | FGS specialUse / boot policy (API 34/35) | Manifest property + type flag pairing; Gate-1 reboot test; dataSync abandoned | S3/S9a/S9b |
 | 5 | OEM brightness range ≠ 255 | config_screenBrightnessSettingMaximum lookup + normalization; Gate-1 sweep | S7 |
 | 6 | Shizuku integration complexity | One-time-grant design (no runtime binder); adb fallback always present; gateway faked in tests | S7/S11 |
 | 7 | Scene-consolidation feature loss | S2 450-element disposition matrix; Gate 2 walkthrough; S14 zero-pending | S2/S12/S14 |

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -13,6 +13,7 @@ next session does not know it.
 | S2 extraction B | 2026-06-11 | Opus/medium | DONE | (this commit) | task090_dynamic_scale.md (+solar answer), task038_curve_wizard.md, contexts_spec.md, features_spec.md, 20 scene docs + 4 _disp fragments, screen_map.md (450-element matrix → 9 M3 screens). Docs-only. Scene/context-profile/non-pipeline-cluster checklist cells annotated "S2 extracted". |
 | S3 toolchain | 2026-06-11 | Sonnet/medium | DONE | (see push) | Gradle 8.14.3 wrapper; D-007 fixed (pluginManagement); libs.versions.toml (Kotlin 2.0.21, AGP 8.7.3, compose-bom 2024.12.01); :platform → com.android.library; :data retired (git rm); res/ created; manifest updated (specialUse FGS + all permissions); lint-baseline.xml frozen. Pre-existing compile bugs fixed (D-019). :app:assembleDebug ✅ :platform:test ✅ :app:lintDebug ✅; :domain:test 4/5 pass (1 pre-existing parity failure — rapidLuxSpike, D-019, S4/S5 fix). |
 | S3.5 errata (owner review) | 2026-06-11 | Fable | DONE | (this commit) | Owner-review corrections folded into extraction docs + CLAUDE.md (D-020…D-026): branch policy settled; And2/Or2 rule validated + alphabetical-XML-ordering trap found (prof758 bool sequence fixed); prof759/769 semantics corrected; debug = 10 named categories; 590=Variable Split, 105=Set Clipboard; %AAB_Test = wizard report→clipboard; non-AAB globals censused; Circadian Dimming Graph re-homed; 168-anonymous-task census added (tasks/anonymous_handlers.md) + task545 doc. Docs-only — build untouched. |
+| S3.6 plan hardening (LLM peer review) | 2026-06-12 | Fable | DONE | (this commit) | 6 of 8 review findings adopted, 2 adopted-with-correction (D-027): S9→S9a+S9b split (Gate 1 after S9b; S10/S11 preconds updated); binding runtime concurrency model (drop-not-queue, MainLoop=mutex); S8 preconds += S2; S4 code-547 expression transcription protocol; hardcoded profile gates + truth-table test; S12 step-0 handler triage; S11 theme-workaround revisit. RUNBOOK + CLAUDE.md updated. Docs-only — build untouched. |
 
 Status values: DONE · PARTIAL · BLOCKED (see failure protocol in CLAUDE.md).
 
@@ -25,12 +26,16 @@ committed; version catalog at `gradle/libs.versions.toml`; :platform is now an A
 — engine parity bug per D-019, not a new regression). S4 is now unblocked.
 S3.5 (owner-review errata) applied on top: extraction docs corrected per D-020…D-026 — read those
 entries before trusting any pre-S3.5 reading of profile gates, debug levels, or action codes 590/105.
+S3.6 (peer-review plan hardening) applied: RUNBOOK restructured per D-027 — S9 is now S9a+S9b,
+runtime concurrency model is binding, S4/S8/S11/S12 briefs amended. No code changes.
 
 ## Next up
 
 - S4 (Opus/medium) — Tasker reference implementation + golden vectors. Preconditions: S1 DONE ✅, S3 DONE ✅.
+  Note the new code-547 expression transcription protocol in the brief (D-027b).
 - S5 (Sonnet/high) after S4.
-- S6 ∥ S7 ∥ S8 (parallel window B) after S5.
+- S6 ∥ S7 ∥ S8 (parallel window B) after S5. (S8 preconditions now formally include S2 — already DONE ✅.)
+- Then S9a → S9b (split per D-027) → Gate 1.
 
 ## Deviations & discoveries ledger
 
@@ -165,7 +170,33 @@ Seeded by the S0 audit (details in CLAUDE.md "Facts & corrections ledger"):
   superdimming_settings gloss fixed — old `_CalibratePowerDraw` gloss was wrong; _disp_group4 already
   agreed). (Affects S12, S13.)
 
-Append new entries as D-027, D-028, … with which segments they affect.
+- D-027: S3.6 PLAN HARDENING from external LLM peer review of the S0–S3.5 approach. Adopted:
+  (a) S8 preconditions now include S2 (its inputs always listed S2's features_spec.md; the DAG
+  just never enforced it — no schedule impact, S2 already DONE). (b) S4 brief gains an explicit
+  transcription protocol for code-547 maths expressions (verbatim → parse-tree note in provenance
+  comment → cross-validate task661 vs task663 over the golden lux grid → disagreements recorded
+  in parity_gaps.md, never resolved by guessing). (c) S9 SPLIT: S9a = pipeline controller +
+  AnimationRunner + OverrideMonitor + service rebuild + tests (parity-critical core); S9b =
+  super-dimming wiring + tile + boot receiver + legacy rip-out. Gate 1 moves after S9b (the
+  reviewer proposed gating after S9a, but Gate 1's reboot/tile/dimming checks need S9b
+  deliverables). S10/S11 preconditions → S9a+S9b. (d) BINDING concurrency model (CLAUDE.md +
+  S9a brief): single pipeline coroutine, one event runs to completion incl. animation frames;
+  events arriving mid-cycle are DROPPED, not queued — prof760's `%AAB_MainLoop != On` clause is
+  a re-entry mutex that SUPPRESSES events while a cycle runs. ⚠️ The reviewer claimed "Tasker
+  would queue it" — wrong: the gate drops; a queueing/conflating implementation would process
+  events Tasker never would. (e) Profile gates are HARDCODED Kotlin booleans with provenance
+  comments (no generic ConditionList evaluator) + a dedicated prof758/prof760 truth-table unit
+  test in S9a (per-branch true/false — a mis-parenthesized gate silently suppresses sensor
+  events). (f) S12 step-0 triage of anonymous_handlers.md into trivial-chrome / settings-mutation
+  / complex buckets, committed before screen work. (g) S11 revisits D-019's XML theme workaround
+  (Compose M3 needs no Material XML parent). REJECTED from the review: the Tasker
+  single-threaded/queueing claim (corrected in d — Tasker runs tasks concurrently by default;
+  this project's serialization comes from its own MainLoop mutex); the Tasker expression
+  type-coercion concerns as a distinct risk (expressions are already captured verbatim per S1,
+  and (b)'s 661-vs-663 cross-validation is the actual safeguard). (Affects S4, S8, S9a, S9b,
+  S10, S11, S12.)
+
+Append new entries as D-028, D-029, … with which segments they affect.
 
 ## Blockers
 


### PR DESCRIPTION
## Summary

Documentation-only update applying six peer-review findings to the rebuild plan. No code changes. Restructures S9 into two segments (S9a/S9b), formalizes runtime concurrency model, adds expression transcription protocol for S4, and clarifies preconditions and testing strategies.

## Key changes

- **S9 split (D-027c):** S9 → S9a (pipeline controller + service core + tests) + S9b (super dimming, QS tile, boot receiver, legacy rip-out). Gate 1 moves after S9b. S10/S11 preconditions updated to S9a+S9b.

- **Runtime concurrency model (D-027d):** Formalized BINDING model: single pipeline coroutine, events run to completion (including animation frames), mid-cycle arrivals are DROPPED not queued. prof760's `%AAB_MainLoop` clause is a re-entry mutex. Hardcoded profile gates as Kotlin booleans with provenance comments + dedicated truth-table unit test in S9a.

- **S4 code-547 transcription protocol (D-027b):** Explicit discipline for maths expressions: verbatim → parse-tree provenance comment → cross-validate task661 vs task663 over golden lux grid → record disagreements in parity_gaps.md (never guess).

- **S8 preconditions (D-027a):** Now formally include S2 (features_spec.md carries validation rules + import/export semantics). No schedule impact; S2 already DONE.

- **S12 handler triage (D-027f):** Step 0 before screen porting: triage anonymous_handlers.md into trivial-chrome / settings-mutation / complex buckets, commit before work.

- **S11 theme workaround revisit (D-027g):** Evaluate simplifying XML theme parent now that Compose M3 generates its own theming.

## Notable details

- Parallel window B now explicitly notes S8 needs S2 (features_spec.md).
- Serial spine updated: S0 → A → S4 → S5 → B → S9a → S9b → C → S12 → S13 → S14.
- S9a deliverables clarified: no super dimming, QS tile, or boot receiver (all S9b).
- S9a includes concurrency model documentation and gate truth-table test requirement.
- STATE.md updated with S3.6 entry and D-027 ledger (6 adopted, 2 adopted-with-correction, 2 rejected with rationale).

All changes are in RUNBOOK.md, STATE.md, and CLAUDE.md. Build untouched.

https://claude.ai/code/session_01Y45zuyg1V8crexDuPVWPu7