### PR TITLE
S9a: Implement brightness pipeline controller and runtime service

### DIFF
--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
@@ -3,72 +3,123 @@ package com.tideo.autobrightness.app.runtime
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.Service
+import android.content.BroadcastReceiver
+import android.content.Context
 import android.content.Intent
-import android.os.Build
+import android.content.IntentFilter
+import android.content.pm.ServiceInfo
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
-import com.tideo.autobrightness.app.AppModule
+import androidx.core.app.ServiceCompat
 import com.tideo.autobrightness.R
-import com.tideo.autobrightness.app.settings.SettingsStore
-import com.tideo.autobrightness.app.storage.serviceHealthDataStore
 import com.tideo.autobrightness.app.storage.settingsDataStore
+import com.tideo.autobrightness.platform.brightness.AndroidScreenBrightnessController
+import com.tideo.autobrightness.platform.observe.AndroidBrightnessObserver
+import com.tideo.autobrightness.platform.sensor.AndroidLightSensorSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
+/**
+ * Foreground service hosting the real [BrightnessPipelineController] (S9a runtime core).
+ *
+ * Replaces the toy poll loop: composes the live platform adapters, runs as a `specialUse`
+ * foreground service (continuous ambient-light monitoring), surfaces a live lux/target
+ * notification with Pause/Resume/Disable/Panic actions, and routes display ON/OFF to the
+ * pipeline's reinit/hibernate paths (prof761/task618 and prof753/task585).
+ */
 class AmbientMonitoringService : Service() {
-    private val scope = CoroutineScope(Dispatchers.Default + Job())
-    private lateinit var settingsStore: SettingsStore
-    private lateinit var healthStore: ServiceHealthStore
-    private val appModule = AppModule()
-    private var monitoringJob: Job? = null
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    private lateinit var controller: BrightnessPipelineController
+    private var notificationJob: Job? = null
+
+    // SCREEN_ON/OFF are runtime-only broadcasts (not deliverable to manifest receivers).
+    private val screenReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent?) {
+            when (intent?.action) {
+                Intent.ACTION_SCREEN_OFF -> controller.onScreenOff()
+                Intent.ACTION_SCREEN_ON -> controller.onScreenOn()
+            }
+        }
+    }
 
     override fun onCreate() {
         super.onCreate()
-        settingsStore = SettingsStore(applicationContext.settingsDataStore)
-        healthStore = ServiceHealthStore(applicationContext.serviceHealthDataStore)
         createNotificationChannel()
+
+        // ONE controller instance is shared between writer and observer so the suppress-echo
+        // marker is per-instance (D-034): the observer must see exactly the writer's last value.
+        val brightnessController = AndroidScreenBrightnessController(applicationContext)
+        controller = BrightnessPipelineController(
+            lightSensor = AndroidLightSensorSource(applicationContext),
+            brightness = brightnessController,
+            brightnessObserver = AndroidBrightnessObserver(applicationContext, brightnessController),
+            settingsProvider = { applicationContext.settingsDataStore.data.first() },
+            scope = scope,
+        )
+
+        registerReceiver(
+            screenReceiver,
+            IntentFilter().apply {
+                addAction(Intent.ACTION_SCREEN_ON)
+                addAction(Intent.ACTION_SCREEN_OFF)
+            },
+        )
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        startForeground(NOTIFICATION_ID, buildNotification())
-        if (monitoringJob?.isActive != true) {
-            monitoringJob = scope.launch {
-                monitorLoop()
+        ServiceCompat.startForeground(
+            this,
+            NOTIFICATION_ID,
+            buildNotification(NotificationModel()),
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
+        )
+
+        when (intent?.action) {
+            ACTION_PAUSE -> controller.pause()
+            ACTION_RESUME -> controller.resume()
+            ACTION_PANIC -> controller.panic()
+            ACTION_DISABLE -> {
+                scope.launch { disableAndStop() }
+                return START_NOT_STICKY
             }
+            else -> ensureRunning()
         }
         return START_STICKY
     }
 
-    private suspend fun monitorLoop() {
-        while (true) {
-            val settings = settingsStore.readSettings()
-            if (!settings.enabled) {
-                stopSelf()
-                return
-            }
-
-            val now = System.currentTimeMillis()
-            val result = appModule.evaluateAndApplyBrightnessUseCase.run()
-            if (result.sampledLux != null) {
-                healthStore.markSensorSampled(now)
-            }
-            if (result.applied) {
-                healthStore.markApplied(now)
-            } else {
-                healthStore.markDegraded("Continuous sensing paused: permissions or OS restrictions")
-            }
-
-            delay(SAMPLE_INTERVAL_MS)
+    private fun ensureRunning() {
+        controller.start()
+        if (notificationJob?.isActive == true) return
+        notificationJob = scope.launch {
+            controller.state
+                .map { NotificationModel(it.smoothedLux, it.targetBrightness, it.paused, it.serviceOn) }
+                .distinctUntilChanged()
+                .collect { model ->
+                    if (!model.serviceOn) return@collect
+                    getSystemService(NotificationManager::class.java)
+                        .notify(NOTIFICATION_ID, buildNotification(model))
+                }
         }
     }
 
+    private suspend fun disableAndStop() {
+        controller.stop()
+        // Persist the disable so boot/screen receivers do not restart the loop.
+        applicationContext.settingsDataStore.updateData { it.copy(serviceEnabled = false) }
+        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
+        stopSelf()
+    }
+
     private fun createNotificationChannel() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
         val manager = getSystemService(NotificationManager::class.java)
         val channel = NotificationChannel(
             CHANNEL_ID,
@@ -78,17 +129,52 @@ class AmbientMonitoringService : Service() {
         manager.createNotificationChannel(channel)
     }
 
-    private fun buildNotification(): Notification {
-        return NotificationCompat.Builder(this, CHANNEL_ID)
-            .setContentTitle("Auto Brightness active")
-            .setContentText("Monitoring ambient changes")
+    private data class NotificationModel(
+        val smoothedLux: Double? = null,
+        val targetBrightness: Int? = null,
+        val paused: Boolean = false,
+        val serviceOn: Boolean = true,
+    )
+
+    private fun buildNotification(model: NotificationModel): Notification {
+        val title = if (model.paused) "Auto Brightness paused" else "Auto Brightness active"
+        val text = when {
+            model.paused -> "Manual override active — tap Resume to continue"
+            model.smoothedLux != null && model.targetBrightness != null ->
+                "Lux ${model.smoothedLux.toInt()} → brightness ${model.targetBrightness}"
+            else -> "Monitoring ambient light"
+        }
+
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(title)
+            .setContentText(text)
             .setSmallIcon(R.drawable.ic_stat_brightness)
             .setOngoing(true)
-            .build()
+            .setOnlyAlertOnce(true)
+
+        if (model.paused) {
+            builder.addAction(0, "Resume", actionIntent(ACTION_RESUME))
+        } else {
+            builder.addAction(0, "Pause", actionIntent(ACTION_PAUSE))
+        }
+        builder.addAction(0, "Reset", actionIntent(ACTION_PANIC))
+        builder.addAction(0, "Disable", actionIntent(ACTION_DISABLE))
+        return builder.build()
+    }
+
+    private fun actionIntent(action: String): PendingIntent {
+        val intent = Intent(this, AmbientMonitoringService::class.java).setAction(action)
+        return PendingIntent.getService(
+            this,
+            action.hashCode(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
     }
 
     override fun onDestroy() {
-        monitoringJob?.cancel()
+        runCatching { unregisterReceiver(screenReceiver) }
+        controller.stop()
         scope.cancel()
         super.onDestroy()
     }
@@ -97,9 +183,12 @@ class AmbientMonitoringService : Service() {
 
     companion object {
         const val ACTION_START = "com.tideo.autobrightness.runtime.action.START"
+        const val ACTION_PAUSE = "com.tideo.autobrightness.runtime.action.PAUSE"
+        const val ACTION_RESUME = "com.tideo.autobrightness.runtime.action.RESUME"
+        const val ACTION_DISABLE = "com.tideo.autobrightness.runtime.action.DISABLE"
+        const val ACTION_PANIC = "com.tideo.autobrightness.runtime.action.PANIC"
         const val EXTRA_REASON = "reason"
         private const val CHANNEL_ID = "ambient_monitoring"
         private const val NOTIFICATION_ID = 1001
-        private const val SAMPLE_INTERVAL_MS = 15_000L
     }
 }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AnimationRunner.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AnimationRunner.kt
@@ -1,0 +1,71 @@
+package com.tideo.autobrightness.app.runtime
+
+import com.tideo.autobrightness.platform.brightness.ScreenBrightnessController
+import kotlinx.coroutines.delay
+
+/**
+ * Executes an animated brightness transition with per-frame read-back override detection.
+ *
+ * Tasker: task696 "Smooth Brightness Transition" (XML, java/task696_1) and the DC-like dimming
+ * variant task698. Steps `loops` times writing an intermediate brightness with `wait` ms between
+ * frames; before each frame it re-reads the system value and, if it drifted away from our last
+ * self-write while override detection is on, aborts and signals a manual override
+ * (→ prof755/task567). Our own writes are expected (suppress-echo); an unexpected external write
+ * is an override.
+ *
+ * Super-dimming (task698) writes are wired in S9b; this S9a runner handles the brightness-only
+ * path (task696). It is a plain suspend function with no Android dependencies beyond the
+ * ScreenBrightnessController interface, so it is unit-testable with a fake controller.
+ */
+class AnimationRunner(
+    private val controller: ScreenBrightnessController,
+    private val sleep: suspend (Long) -> Unit = { delay(it) },
+) {
+    enum class Result {
+        /** Animation finished; the final target is on screen. */
+        COMPLETED,
+
+        /** An external write was observed mid-animation — aborted, caller should pause. */
+        OVERRIDDEN,
+    }
+
+    /**
+     * Animate the system brightness from [from] to [to] over [steps] frames, [waitMs] apart.
+     *
+     * @param from    Brightness at the start of the transition (domain 0–255).
+     * @param to      Target brightness (domain 0–255).
+     * @param steps   Frame count (task543 %loops, ≥1).
+     * @param waitMs  Per-frame delay (task543 %wait).
+     * @param detectOverrides %AAB_DetectOverrides — when false, read-back checks are skipped.
+     * @return COMPLETED, or OVERRIDDEN if an external write was detected mid-animation.
+     */
+    suspend fun animate(
+        from: Int,
+        to: Int,
+        steps: Int,
+        waitMs: Long,
+        detectOverrides: Boolean,
+    ): Result {
+        val frames = steps.coerceAtLeast(1)
+        var lastWritten = from
+        for (i in 1..frames) {
+            // task696: re-read before writing the next frame; if the on-screen value is no longer
+            // our last self-write, an external app/user changed it → abort + override.
+            if (detectOverrides && i > 1) {
+                val observed = controller.read()
+                if (observed != lastWritten) return Result.OVERRIDDEN
+            }
+            // Linear interpolation; the final frame lands exactly on `to`.
+            val frame = if (i == frames) to else from + ((to - from) * i) / frames
+            controller.write(frame)
+            lastWritten = frame
+            if (waitMs > 0) sleep(waitMs)
+        }
+        // Final read-back: catch an override that landed during the last frame's wait.
+        if (detectOverrides) {
+            val observed = controller.read()
+            if (observed != lastWritten) return Result.OVERRIDDEN
+        }
+        return Result.COMPLETED
+    }
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineController.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineController.kt
@@ -1,0 +1,333 @@
+package com.tideo.autobrightness.app.runtime
+
+import com.tideo.autobrightness.app.settings.AabSettings
+import com.tideo.autobrightness.app.settings.toAnimationConfig
+import com.tideo.autobrightness.app.settings.toBrightnessCurveConfig
+import com.tideo.autobrightness.app.settings.toDynamicScalingConfig
+import com.tideo.autobrightness.app.settings.toThresholdConfig
+import com.tideo.autobrightness.domain.brightness.BrightnessEngine
+import com.tideo.autobrightness.domain.brightness.BrightnessPolicyInput
+import com.tideo.autobrightness.domain.brightness.OverrideRules
+import com.tideo.autobrightness.domain.brightness.PreviousState
+import com.tideo.autobrightness.domain.brightness.TimeContext
+import com.tideo.autobrightness.platform.brightness.ScreenBrightnessController
+import com.tideo.autobrightness.platform.observe.BrightnessObserver
+import com.tideo.autobrightness.platform.sensor.LightSensorSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * The runtime auto-brightness pipeline: the Kotlin rebuild of the Tasker sensor → brightness loop.
+ *
+ * Concurrency model (BINDING, D-027): the pipeline is serialized through a single consumer
+ * coroutine. One [PipelineEvent] runs to completion — including its animation frames — before the
+ * next is processed. Sensor ticks arriving while a cycle is in flight are **DROPPED, not queued**,
+ * exactly as prof760's `%AAB_MainLoop != On` clause drops them in Tasker (a re-entry mutex, D-021),
+ * implemented here as the [inCycle] busy flag. All durable runtime state lives in [state] and is
+ * written ONLY from the consumer coroutine; the sensor/observer collectors signal it via [events].
+ *
+ * Pipeline sources (pipeline_spec.md):
+ *   - prof760/task554 main loop      → [LightSensorSource] → gated → [PipelineEvent.SensorTick]
+ *   - prof755/task567 override detect → [OverrideMonitor]  → [PipelineEvent.OverrideDetected]
+ *   - lifecycle (screen on/off, pause/resume/panic) → events posted by the service
+ *
+ * The decision math is the golden-tested domain [BrightnessEngine]; this controller owns only the
+ * Tasker runtime state machine and the animated writes (via [AnimationRunner]).
+ */
+class BrightnessPipelineController(
+    private val lightSensor: LightSensorSource,
+    private val brightness: ScreenBrightnessController,
+    brightnessObserver: BrightnessObserver,
+    private val settingsProvider: suspend () -> AabSettings,
+    private val scope: CoroutineScope,
+    private val clock: () -> Long = System::currentTimeMillis,
+    private val animationRunner: AnimationRunner = AnimationRunner(brightness),
+) {
+    private val engine = BrightnessEngine()
+
+    private val _state = MutableStateFlow(PipelineState())
+    val state: StateFlow<PipelineState> = _state.asStateFlow()
+
+    // Fast-changing intra-cycle flags read by the observer coroutine; kept outside the immutable
+    // snapshot because they flip many times within a single cycle (mid-write / initial write).
+    @Volatile private var autoRunning = false
+    @Volatile private var initializing = false
+
+    // %AAB_MainLoop re-entry mutex: true while a sensor cycle is claimed or running.
+    private val inCycle = AtomicBoolean(false)
+
+    // Cached so the per-sample prof760 gate does not hit DataStore on every reading.
+    @Volatile private var cachedSettings: AabSettings? = null
+
+    private val events = Channel<PipelineEvent>(Channel.UNLIMITED)
+
+    private val overrideMonitor = OverrideMonitor(brightnessObserver) {
+        val s = _state.value
+        OverrideMonitor.GateState(
+            serviceOn = s.serviceOn,
+            autoRunning = autoRunning,
+            paused = s.paused,
+            initializing = initializing,
+            detectOverrides = cachedSettings?.detectOverrides ?: false,
+        )
+    }
+
+    private var consumerJob: Job? = null
+    private var sensorJob: Job? = null
+    private var overrideJob: Job? = null
+
+    /** Begin the pipeline: claim foreground state, start the consumer + sensor + observer flows. */
+    fun start() {
+        if (consumerJob != null) return
+        _state.update { it.copy(serviceOn = true) }
+        consumerJob = scope.launch {
+            cachedSettings = settingsProvider()
+            for (event in events) {
+                handle(event)
+            }
+        }
+        overrideJob = scope.launch {
+            overrideMonitor.overrides().collect { observed ->
+                events.trySend(PipelineEvent.OverrideDetected(observed))
+            }
+        }
+        startSensor()
+    }
+
+    /** Stop the pipeline entirely (service teardown). */
+    fun stop() {
+        _state.update { it.copy(serviceOn = false) }
+        sensorJob?.cancel(); sensorJob = null
+        overrideJob?.cancel(); overrideJob = null
+        consumerJob?.cancel(); consumerJob = null
+        inCycle.set(false)
+    }
+
+    // Lifecycle entry points — the service posts these; they run in consumer order.
+    fun onScreenOff() { events.trySend(PipelineEvent.ScreenOff) }
+    fun onScreenOn() { events.trySend(PipelineEvent.ScreenOn) }
+    fun pause() { events.trySend(PipelineEvent.Pause) }
+    fun resume() { events.trySend(PipelineEvent.Resume) }
+    fun panic() { events.trySend(PipelineEvent.Panic) }
+
+    private fun startSensor() {
+        if (sensorJob?.isActive == true) return
+        sensorJob = scope.launch {
+            lightSensor.samples().collect { sample -> onSensorSample(sample.lux.toDouble(), sample.accuracy) }
+        }
+    }
+
+    /**
+     * prof760 gate evaluation on the collector coroutine. Passing samples claim the [inCycle] mutex
+     * and enqueue a [PipelineEvent.SensorTick]; everything else is dropped here (never queued).
+     */
+    private fun onSensorSample(lux: Double, accuracy: Int) {
+        val settings = cachedSettings ?: return
+        if (!settings.serviceEnabled) return
+        val s = _state.value
+        val passes = ProfileGates.monitorAmbientLightGate(
+            trustUnreliable = settings.trustUnreliableSensor,
+            accuracy = accuracy,
+            lux = lux,
+            threshAbsLow = s.threshAbsLow ?: 0.0,
+            threshAbsHigh = s.threshAbsHigh ?: 0.0,
+            mainLoopOn = inCycle.get(),
+            thresholdsSeeded = s.threshAbsLow != null,
+        )
+        if (!passes) return
+        // Re-entry mutex: claim the cycle slot, or drop. Cleared when the cycle completes.
+        if (!inCycle.compareAndSet(false, true)) return
+        if (events.trySend(PipelineEvent.SensorTick(lux, accuracy)).isFailure) {
+            inCycle.set(false)
+        }
+    }
+
+    private suspend fun handle(event: PipelineEvent) {
+        when (event) {
+            is PipelineEvent.SensorTick -> {
+                try {
+                    runCycle(event.lux)
+                } finally {
+                    inCycle.set(false)
+                }
+            }
+            PipelineEvent.ScreenOff -> hibernate()
+            PipelineEvent.ScreenOn -> reinit()
+            PipelineEvent.Pause -> pauseInternal()
+            PipelineEvent.Resume -> resumeInternal()
+            PipelineEvent.Panic -> panicInternal()
+            is PipelineEvent.OverrideDetected -> handleOverride(event.observedBrightness)
+        }
+    }
+
+    /** task554 → task544 → task535 → task661: ingest a reading and animate to the new brightness. */
+    private suspend fun runCycle(rawLux: Double) {
+        val settings = settingsProvider().also { cachedSettings = it }
+        if (!settings.serviceEnabled || _state.value.paused) return
+
+        val now = clock()
+        val s = _state.value
+        // Throttle gate (task544 act2-9): drop ticks inside the throttle window.
+        s.lastAcceptedMs?.let { last ->
+            if (now - last < settings.throttleDefaultMs) return
+        }
+
+        val cycleStart = now
+        autoRunning = true
+        try {
+            val output = engine.evaluate(buildInput(rawLux, settings, s))
+            val from = brightness.read()
+            val target = output.targetBrightness
+
+            if (target != from) {
+                brightness.forceManualMode()
+                val result = animationRunner.animate(
+                    from = from,
+                    to = target,
+                    steps = output.animationSteps,
+                    waitMs = output.animationWaitMs,
+                    detectOverrides = settings.detectOverrides,
+                )
+                if (result == AnimationRunner.Result.OVERRIDDEN) {
+                    events.trySend(PipelineEvent.OverrideDetected(brightness.read()))
+                    return
+                }
+            }
+
+            val cycleTotal = (clock() - cycleStart).toDouble()
+            _state.update {
+                it.copy(
+                    smoothedLux = output.smoothedLux,
+                    lastRawLux = round3(rawLux),
+                    lastAcceptedMs = now,
+                    threshAbsLow = output.thresholdLow,
+                    threshAbsHigh = output.thresholdHigh,
+                    cycleTimeMs = cycleTotal,
+                    scaleDynamicCompress = output.scaleDynamicCompress,
+                    scalingUse = settings.scalingEnabled,
+                    lastAppliedBrightness = target,
+                    targetBrightness = target,
+                )
+            }
+        } finally {
+            autoRunning = false
+        }
+    }
+
+    private fun buildInput(rawLux: Double, settings: AabSettings, s: PipelineState): BrightnessPolicyInput {
+        // UTC seconds-of-day; real local time + solar ramp windows are wired with circadian in S9b/S12.
+        val secondsOfDay = ((clock() / 1000L) % 86_400L).toDouble()
+        val previous = if (s.smoothedLux != null && s.lastRawLux != null) {
+            PreviousState(smoothedLux = s.smoothedLux, lastRawLux = s.lastRawLux, cycleTimeMs = s.cycleTimeMs)
+        } else {
+            null
+        }
+        return BrightnessPolicyInput(
+            lux = rawLux,
+            time = TimeContext(secondsOfDay = secondsOfDay),
+            thresholds = settings.toThresholdConfig(),
+            curve = settings.toBrightnessCurveConfig(),
+            animation = settings.toAnimationConfig(),
+            dynamicScaling = settings.toDynamicScalingConfig(),
+            previous = previous,
+        )
+    }
+
+    /** task567 Manual Override: record the point and latch paused; the service posts the notification. */
+    private fun handleOverride(observed: Int) {
+        val s = _state.value
+        // task567 act8 re-check guard (mirrors the prof755 gate after the cycle-time wait).
+        if (!OverrideRules.shouldCommitPause(s.serviceOn, autoRunning, s.paused, initializing)) return
+        val history = OverrideRules.recordOverridePoint(
+            history = s.overrideHistory,
+            lux = s.smoothedLux ?: 0.0,
+            brightness = observed.toDouble(),
+            dynamicCompress = s.scaleDynamicCompress,
+            scalingUse = s.scalingUse,
+        )
+        brightness.clearSelfWriteMarker()
+        _state.update { it.copy(paused = true, overrideHistory = history) }
+    }
+
+    private fun pauseInternal() {
+        brightness.clearSelfWriteMarker()
+        _state.update { it.copy(paused = true) }
+    }
+
+    /** task569 Resume After Override: re-establish the initial brightness and clear the pause latch. */
+    private suspend fun resumeInternal() {
+        _state.update { it.copy(paused = false) }
+        setInitialBrightness(settingsProvider().also { cachedSettings = it })
+    }
+
+    /** prof761/task618 wake reinit: throttle resets to default (it is the setting), set initial brightness. */
+    private suspend fun reinit() {
+        val settings = settingsProvider().also { cachedSettings = it }
+        startSensor()
+        if (!_state.value.paused) setInitialBrightness(settings)
+    }
+
+    /** prof753/task585 hibernate: stop sensing and clear the runtime loop state. */
+    private fun hibernate() {
+        sensorJob?.cancel(); sensorJob = null
+        inCycle.set(false)
+        _state.update {
+            it.copy(
+                smoothedLux = null,
+                lastRawLux = null,
+                lastAcceptedMs = null,
+                threshAbsLow = null,
+                threshAbsHigh = null,
+                cycleTimeMs = null,
+            )
+        }
+    }
+
+    /** prof769/task528 panic: restore a sane brightness, clear state, full stop (%AAB_Service=Off). */
+    private fun panicInternal() {
+        brightness.forceManualMode()
+        brightness.write(PANIC_BRIGHTNESS) // task528: restore a sane (max) brightness
+        brightness.restoreMode()
+        sensorJob?.cancel(); sensorJob = null
+        inCycle.set(false)
+        _state.update {
+            PipelineState(serviceOn = false)
+        }
+    }
+
+    /** task618 block#1: set a starting brightness immediately (no smoothing loop) on wake/resume. */
+    private fun setInitialBrightness(settings: AabSettings) {
+        val s = _state.value
+        val lux = s.smoothedLux ?: s.lastRawLux ?: return
+        initializing = true
+        try {
+            // previous = null → engine's first-run path maps the reading straight to a target.
+            val output = engine.evaluate(buildInput(lux, settings, PipelineState()))
+            brightness.forceManualMode()
+            brightness.write(output.targetBrightness)
+            _state.update {
+                it.copy(
+                    lastAppliedBrightness = output.targetBrightness,
+                    targetBrightness = output.targetBrightness,
+                    lastAcceptedMs = clock(),
+                )
+            }
+        } finally {
+            initializing = false
+        }
+    }
+
+    // Tasker round3 idiom: Math.round(x*1000)/1000 (ties toward +∞).
+    private fun round3(value: Double): Double = Math.round(value * 1000.0) / 1000.0
+
+    private companion object {
+        const val PANIC_BRIGHTNESS = 255
+    }
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/OverrideMonitor.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/OverrideMonitor.kt
@@ -1,0 +1,45 @@
+package com.tideo.autobrightness.app.runtime
+
+import com.tideo.autobrightness.domain.brightness.OverrideRules
+import com.tideo.autobrightness.platform.observe.BrightnessObserver
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.mapNotNull
+
+/**
+ * Bridges the platform [BrightnessObserver] (prof755 ContentObserver) to the override
+ * detect/pause/resume decision in domain [OverrideRules] (task567 gate).
+ *
+ * The observer already filters self-writes via the ScreenBrightnessController suppress-echo hook
+ * (D-034), so this monitor only needs to apply the remaining prof755 gate clauses. Emitted values
+ * are observed brightness levels that should pause the pipeline; the controller turns each into a
+ * [PipelineEvent.OverrideDetected] (no state is written from the observer coroutine — D-027).
+ */
+class OverrideMonitor(
+    private val observer: BrightnessObserver,
+    private val gateProvider: () -> GateState,
+) {
+    /** Live snapshot of the prof755/task567 gate inputs at the moment a change is observed. */
+    data class GateState(
+        val serviceOn: Boolean,
+        val autoRunning: Boolean,
+        val paused: Boolean,
+        val initializing: Boolean,
+        val detectOverrides: Boolean,
+    )
+
+    /** Emits observed brightness values that qualify as manual overrides. */
+    fun overrides(): Flow<Int> = observer.externalChanges().mapNotNull { observed ->
+        val g = gateProvider()
+        val isOverride = OverrideRules.isManualOverride(
+            isServiceOn = g.serviceOn,
+            isAutoRunning = g.autoRunning,
+            isAlreadyPaused = g.paused,
+            isInitializing = g.initializing,
+            detectOverrides = g.detectOverrides,
+            observedValue = observed,
+            // The observer already suppressed our own writes; no further echo set needed here.
+            expectedValues = emptySet(),
+        )
+        if (isOverride) observed else null
+    }
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/PipelineState.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/PipelineState.kt
@@ -1,0 +1,61 @@
+package com.tideo.autobrightness.app.runtime
+
+/**
+ * The single Tasker-runtime state holder (pipeline_spec.md §5). All fields are written ONLY from
+ * the pipeline coroutine (BrightnessPipelineController); UI/notification read immutable snapshots
+ * via the controller's StateFlow (D-027 concurrency model).
+ *
+ * Maps the runtime (non-settings) `%AAB_*` variables that survive between sensor ticks.
+ */
+data class PipelineState(
+    /** %AAB_Service — master enable; false stops the loop. */
+    val serviceOn: Boolean = false,
+    /** true == paused by a manual override (%AAB_Manual_Override). */
+    val paused: Boolean = false,
+    /** %SmoothedLux — EMA-smoothed lux; null until the first reading seeds it. */
+    val smoothedLux: Double? = null,
+    /** %AAB_LastRawLux — last raw lux (round3). */
+    val lastRawLux: Double? = null,
+    /** %LastAAB — TIMEMS of the last accepted tick (throttle anchor); null until first accept. */
+    val lastAcceptedMs: Long? = null,
+    /** %AAB_ThreshAbsLow — absolute dead-band low (task546); null until seeded. */
+    val threshAbsLow: Double? = null,
+    /** %AAB_ThreshAbsHigh — absolute dead-band high (task546). */
+    val threshAbsHigh: Double? = null,
+    /** %AAB_CycleTime — measured duration of the last cycle, feeds task543's throttle. */
+    val cycleTimeMs: Double? = null,
+    /** %AAB_ScaleDynamicCompress — last taper effective scale (task561 de-compression input). */
+    val scaleDynamicCompress: Double = 1.0,
+    /** Last %AAB_ScalingUse seen (task561 gate). */
+    val scalingUse: Boolean = true,
+    /** Last brightness this pipeline applied (domain 0–255); null before the first write. */
+    val lastAppliedBrightness: Int? = null,
+    /** Last target the engine produced (for the notification "target" readout). */
+    val targetBrightness: Int? = null,
+    /** Recorded manual-override points (newest first), %AAB_Overrides (cap 50). */
+    val overrideHistory: List<Pair<Double, Double>> = emptyList(),
+)
+
+/** Events serialized through the single pipeline consumer (one runs to completion, D-027). */
+sealed interface PipelineEvent {
+    /** A gated light-sensor reading that passed prof760; carries raw lux + accuracy. */
+    data class SensorTick(val lux: Double, val accuracy: Int) : PipelineEvent
+
+    /** Display OFF → hibernate (prof753 / task585). */
+    data object ScreenOff : PipelineEvent
+
+    /** Display ON → reinit: throttle reset (task566) + initial brightness (task618). */
+    data object ScreenOn : PipelineEvent
+
+    /** User asked to pause auto-control. */
+    data object Pause : PipelineEvent
+
+    /** User tapped Resume (task569). */
+    data object Resume : PipelineEvent
+
+    /** Panic reset (prof769 / task528). */
+    data object Panic : PipelineEvent
+
+    /** An external brightness write was detected as a manual override (prof755 / task567). */
+    data class OverrideDetected(val observedBrightness: Int) : PipelineEvent
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/ProfileGates.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/ProfileGates.kt
@@ -1,0 +1,126 @@
+package com.tideo.autobrightness.app.runtime
+
+/**
+ * Hardcoded Kotlin transcriptions of the pipeline-profile `<ConditionList>` gates.
+ *
+ * Per D-027: we port a FIXED set of profiles, so each gate is a hand-written boolean expression
+ * with a provenance comment showing the D-021 parenthesization — NOT a generic ConditionList
+ * evaluator. A mis-parenthesized gate silently suppresses sensor events with no other test
+ * catching it, so [ProfileGatesTest] asserts every branch of each clause.
+ *
+ * ConditionList boolean semantics (owner-verified, D-021): plain `And`/`Or` bind tighter and form
+ * inner sub-expressions (`And` > `Or`); `And2`/`Or2` are the outer joins between those groups,
+ * evaluated left-to-right. Source: docs/rebuild/extraction/profiles.md.
+ */
+object ProfileGates {
+
+    /**
+     * prof760 "Monitor Ambient Light" gate (XML L318; profiles.md §prof760).
+     *
+     * Verbatim conditions c0..c5 with bool sequence `[Or2, And, And2, Or, And2]`:
+     *   c0 `%AAB_TrustUnreliable = On`     Or2
+     *   c1 `%AAB_TrustUnreliable = Off`    And
+     *   c2 `%as_accuracy > 1`              And2
+     *   c3 `%as_values1 < %AAB_ThreshAbsLow`   Or
+     *   c4 `%as_values1 > %AAB_ThreshAbsHigh`  And2
+     *   c5 `%AAB_MainLoop != On`           —
+     *
+     * Confirmed reading (D-021):
+     *   ((TrustUnreliable=On) OR (TrustUnreliable=Off AND as_accuracy>1))
+     *   AND ((as_values1 < ThreshAbsLow) OR (as_values1 > ThreshAbsHigh))
+     *   AND (MainLoop != On)
+     *
+     * Three staged gates: accuracy-trust, absolute-threshold dead-band, main-loop mutex.
+     *
+     * @param trustUnreliable %AAB_TrustUnreliable (true == "On").
+     * @param accuracy        %as_accuracy (1=Low, 2=Med, 3=High).
+     * @param lux             %as_values1 (raw sensor lux).
+     * @param threshAbsLow    %AAB_ThreshAbsLow (set by task546 _Set Thresholds_).
+     * @param threshAbsHigh   %AAB_ThreshAbsHigh.
+     * @param mainLoopOn      %AAB_MainLoop == "On" (a cycle is already running).
+     * @param thresholdsSeeded false on the very first reading, before task546 has ever run; the
+     *                          absolute dead-band sub-gate is bypassed so the first reading always
+     *                          enters the first-run init path (task544 act10-17).
+     */
+    fun monitorAmbientLightGate(
+        trustUnreliable: Boolean,
+        accuracy: Int,
+        lux: Double,
+        threshAbsLow: Double,
+        threshAbsHigh: Double,
+        mainLoopOn: Boolean,
+        thresholdsSeeded: Boolean,
+    ): Boolean {
+        // Gate 1 — accuracy trust: ((TrustUnreliable=On) OR (TrustUnreliable=Off AND accuracy>1))
+        val accuracyTrust = trustUnreliable || (!trustUnreliable && accuracy > 1)
+        // Gate 2 — absolute dead-band: ((lux < ThreshAbsLow) OR (lux > ThreshAbsHigh))
+        // Bypassed before the thresholds have ever been seeded (first run).
+        val deadBand = !thresholdsSeeded || lux < threshAbsLow || lux > threshAbsHigh
+        // Gate 3 — main-loop mutex: (MainLoop != On)
+        val mutex = !mainLoopOn
+        return accuracyTrust && deadBand && mutex
+    }
+
+    /**
+     * prof758 "Dynamic Scale Engine" gate (XML L195; profiles.md §prof758).
+     *
+     * Numerically re-sorted bool sequence (S3.5; alphabetical XML ordering corrected, D-021):
+     * twelve plain joins then one final `And2`:
+     *   [And, Or, And, Or, And, Or, And, Or, And, Or, And, Or, And2]
+     *
+     * Reading (D-021):
+     *   ((c0∧c1) ∨ (c2∧c3) ∨ (c4∧c5) ∨ (c6∧c7) ∨ (c8∧c9) ∨ (c10∧c11) ∨ c12) AND (ScalingUse=true)
+     * where each (c2k∧c2k+1) is a "now is inside a dawn/dusk ramp window" test, evaluated at the
+     * current day and at ±86400 s to cover windows that wrap midnight; c12 = sun data stale today.
+     *
+     * @param nowMod        %TIMES%86400 — seconds since local midnight.
+     * @param morningStart  %AAB_MorningStart (sec-of-day).
+     * @param morningEnd    %AAB_MorningEnd.
+     * @param eveningStart  %AAB_EveningStart.
+     * @param eveningEnd    %AAB_EveningEnd.
+     * @param sunDataStale  %AAB_SunLastDate != %DATE (today's sun times not yet computed).
+     * @param scalingUse    %AAB_ScalingUse.
+     */
+    fun dynamicScaleGate(
+        nowMod: Double,
+        morningStart: Double,
+        morningEnd: Double,
+        eveningStart: Double,
+        eveningEnd: Double,
+        sunDataStale: Boolean,
+        scalingUse: Boolean,
+    ): Boolean {
+        val inMorning = inWindowWithWrap(nowMod, morningStart, morningEnd)
+        val inEvening = inWindowWithWrap(nowMod, eveningStart, eveningEnd)
+        val inWindowOrStale = inMorning || inEvening || sunDataStale
+        return inWindowOrStale && scalingUse
+    }
+
+    /** start < now < end, also checking now±86400 so a window straddling midnight still matches. */
+    private fun inWindowWithWrap(now: Double, start: Double, end: Double): Boolean {
+        return inWindow(now, start, end) ||
+            inWindow(now + 86_400.0, start, end) ||
+            inWindow(now - 86_400.0, start, end)
+    }
+
+    private fun inWindow(now: Double, start: Double, end: Double): Boolean = now > start && now < end
+
+    /**
+     * prof755 "Allow Override" gate (XML L56; profiles.md §prof755).
+     *
+     * `Service=On AND AutoBrightRunning=0 AND Manual_Override!~true AND Initializing!~true
+     *  AND DetectOverrides!~Off` — treat an external brightness write as a manual override only
+     * when the service is on, our own pipeline is not mid-write, we are not already paused, not
+     * initializing, and override detection is enabled.
+     *
+     * The pure decision also lives in domain OverrideRules.isManualOverride (which adds the
+     * suppress-echo set); this mirror exists so the gate truth-table test covers prof755 too.
+     */
+    fun allowOverrideGate(
+        serviceOn: Boolean,
+        autoBrightRunning: Boolean,
+        manualOverride: Boolean,
+        initializing: Boolean,
+        detectOverrides: Boolean,
+    ): Boolean = serviceOn && !autoBrightRunning && !manualOverride && !initializing && detectOverrides
+}

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringServiceTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringServiceTest.kt
@@ -1,0 +1,36 @@
+package com.tideo.autobrightness.app.runtime
+
+import android.content.Intent
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import kotlin.test.assertNotNull
+
+@RunWith(RobolectricTestRunner::class)
+class AmbientMonitoringServiceTest {
+
+    @Test
+    fun onStartCommand_postsForegroundNotification() {
+        val controller = Robolectric.buildService(AmbientMonitoringService::class.java).create()
+        // ACTION_PAUSE keeps the heavy sensor/observer flows from starting while still exercising
+        // the foreground-notification path (posted unconditionally in onStartCommand).
+        val intent = Intent().setAction(AmbientMonitoringService.ACTION_PAUSE)
+        val service = controller.withIntent(intent).startCommand(0, 0).get()
+
+        val notification = shadowOf(service).lastForegroundNotification
+        assertNotNull(notification, "service should post a foreground notification")
+    }
+
+    @Test
+    fun lifecycle_createStartDestroy_doesNotThrow() {
+        val controller = Robolectric.buildService(AmbientMonitoringService::class.java).create()
+        controller
+            .withIntent(Intent().setAction(AmbientMonitoringService.ACTION_PAUSE))
+            .startCommand(0, 0)
+            .get()
+        // Tear down cleanly (unregisters the screen receiver, cancels the scope).
+        controller.destroy()
+    }
+}

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/AnimationRunnerTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/AnimationRunnerTest.kt
@@ -1,0 +1,64 @@
+package com.tideo.autobrightness.app.runtime
+
+import com.tideo.autobrightness.platform.brightness.ScreenBrightnessController
+import kotlinx.coroutines.test.runTest
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class AnimationRunnerTest {
+
+    private class FakeBrightness : ScreenBrightnessController {
+        val writes = mutableListOf<Int>()
+        var current = 0
+        var overrideRead: Int? = null
+        override fun read(): Int = overrideRead ?: current
+        override fun write(level: Int) { current = level; writes += level }
+        override fun forceManualMode() = Unit
+        override fun restoreMode() = Unit
+        override fun isSelfWrite(rawDeviceValue: Int): Boolean = rawDeviceValue == current
+        override fun clearSelfWriteMarker() = Unit
+    }
+
+    @Test
+    fun animate_completes_finalFrameLandsOnTarget() = runTest {
+        val fake = FakeBrightness()
+        val runner = AnimationRunner(fake, sleep = {})
+        val result = runner.animate(from = 0, to = 100, steps = 4, waitMs = 5, detectOverrides = false)
+        assertEquals(AnimationRunner.Result.COMPLETED, result)
+        assertEquals(4, fake.writes.size)
+        assertEquals(100, fake.writes.last())
+        // Monotonic non-decreasing toward the target.
+        assertTrue(fake.writes.zipWithNext().all { (a, b) -> b >= a })
+    }
+
+    @Test
+    fun animate_singleStep_writesOnlyTarget() = runTest {
+        val fake = FakeBrightness()
+        val runner = AnimationRunner(fake, sleep = {})
+        runner.animate(from = 200, to = 50, steps = 1, waitMs = 0, detectOverrides = false)
+        assertEquals(listOf(50), fake.writes)
+    }
+
+    @Test
+    fun animate_externalChangeMidAnimation_returnsOverridden() = runTest {
+        val fake = FakeBrightness()
+        val runner = AnimationRunner(fake, sleep = {
+            // Simulate an external write landing after the first frame.
+            if (fake.writes.size == 1) fake.overrideRead = 240
+        })
+        val result = runner.animate(from = 0, to = 100, steps = 5, waitMs = 5, detectOverrides = true)
+        assertEquals(AnimationRunner.Result.OVERRIDDEN, result)
+        // Aborted early — did not run all 5 frames.
+        assertTrue(fake.writes.size < 5)
+    }
+
+    @Test
+    fun animate_detectionOff_ignoresExternalChange() = runTest {
+        val fake = FakeBrightness()
+        val runner = AnimationRunner(fake, sleep = { fake.overrideRead = 240 })
+        val result = runner.animate(from = 0, to = 100, steps = 5, waitMs = 5, detectOverrides = false)
+        assertEquals(AnimationRunner.Result.COMPLETED, result)
+        assertEquals(5, fake.writes.size)
+    }
+}

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineControllerTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineControllerTest.kt
@@ -1,0 +1,185 @@
+package com.tideo.autobrightness.app.runtime
+
+import com.tideo.autobrightness.app.settings.AabSettings
+import com.tideo.autobrightness.platform.brightness.ScreenBrightnessController
+import com.tideo.autobrightness.platform.observe.BrightnessObserver
+import com.tideo.autobrightness.platform.sensor.LightSample
+import com.tideo.autobrightness.platform.sensor.LightSensorSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BrightnessPipelineControllerTest {
+
+    private class FakeSensor : LightSensorSource {
+        val flow = MutableSharedFlow<LightSample>(extraBufferCapacity = 16)
+        override fun samples(): Flow<LightSample> = flow
+    }
+
+    private class FakeObserver : BrightnessObserver {
+        val flow = MutableSharedFlow<Int>(extraBufferCapacity = 16)
+        override fun externalChanges(): Flow<Int> = flow
+    }
+
+    private class FakeBrightness : ScreenBrightnessController {
+        val writes = mutableListOf<Int>()
+        var current = 0
+        override fun read(): Int = current
+        override fun write(level: Int) { current = level; writes += level }
+        override fun forceManualMode() = Unit
+        override fun restoreMode() = Unit
+        override fun isSelfWrite(rawDeviceValue: Int): Boolean = rawDeviceValue == current
+        override fun clearSelfWriteMarker() = Unit
+    }
+
+    private fun sample(lux: Double, accuracy: Int = 3) = LightSample(lux.toFloat(), accuracy, 0L)
+
+    // trustUnreliable=true keeps the accuracy gate out of the way; detectOverrides=true for the
+    // override test; scaling off so the linear curve branch maps lux straight to brightness.
+    private val settings = AabSettings(
+        serviceEnabled = true,
+        detectOverrides = true,
+        trustUnreliableSensor = true,
+        scalingEnabled = false,
+    )
+
+    // Unconfined dispatcher so the sensor/observer collectors subscribe eagerly and emissions are
+    // delivered synchronously; animation delays still respect virtual time (advanceUntilIdle).
+    private fun TestScope.newController(
+        sensor: LightSensorSource = FakeSensor(),
+        brightness: ScreenBrightnessController = FakeBrightness(),
+        observer: BrightnessObserver = FakeObserver(),
+        clock: () -> Long,
+    ): Pair<BrightnessPipelineController, CoroutineScope> {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val controller = BrightnessPipelineController(
+            lightSensor = sensor,
+            brightness = brightness,
+            brightnessObserver = observer,
+            settingsProvider = { settings },
+            scope = scope,
+            clock = clock,
+        )
+        return controller to scope
+    }
+
+    @Test
+    fun firstRun_throttleDrop_acceptAfterWindow() = runTest {
+        val sensor = FakeSensor()
+        val brightness = FakeBrightness()
+        var nowMs = 1000L
+        val (controller, scope) = newController(sensor, brightness, clock = { nowMs })
+        controller.start()
+
+        // First run: no thresholds yet → reading is accepted and a brightness is written.
+        sensor.flow.emit(sample(lux = 10.0))
+        advanceUntilIdle()
+        assertTrue(brightness.writes.isNotEmpty(), "first run should write a brightness")
+        assertEquals(10.0, controller.state.value.lastRawLux)
+        assertEquals(1000L, controller.state.value.lastAcceptedMs)
+
+        // Within the throttle window (clock unchanged): a far-outside-band reading passes prof760
+        // but is dropped by the task544 throttle gate, leaving state unchanged.
+        sensor.flow.emit(sample(lux = 5000.0))
+        advanceUntilIdle()
+        assertEquals(10.0, controller.state.value.lastRawLux, "throttled tick must not update state")
+        assertEquals(1000L, controller.state.value.lastAcceptedMs)
+
+        // Past the throttle window: the reading is accepted.
+        nowMs += 2000L
+        sensor.flow.emit(sample(lux = 5000.0))
+        advanceUntilIdle()
+        assertEquals(5000.0, controller.state.value.lastRawLux)
+        assertEquals(3000L, controller.state.value.lastAcceptedMs)
+        scope.cancel()
+    }
+
+    @Test
+    fun midCycleSensorEvent_isDropped() = runTest {
+        val sensor = FakeSensor()
+        val brightness = FakeBrightness()
+        val (controller, scope) = newController(sensor, brightness, clock = { 1000L })
+        controller.start()
+
+        // Cycle 1 runs eagerly until it suspends inside the animation (per-frame delay).
+        sensor.flow.emit(sample(lux = 10.0))
+        assertTrue(brightness.writes.isNotEmpty(), "cycle should have begun writing")
+        assertNull(controller.state.value.lastRawLux, "cycle 1 not yet committed")
+
+        // A reading arriving mid-cycle is dropped by the %AAB_MainLoop mutex (not queued).
+        sensor.flow.emit(sample(lux = 5000.0))
+
+        advanceUntilIdle()
+        // Only cycle 1 committed; the mid-cycle reading never ran.
+        assertEquals(10.0, controller.state.value.lastRawLux)
+        scope.cancel()
+    }
+
+    @Test
+    fun externalOverride_pausesPipeline() = runTest {
+        val observer = FakeObserver()
+        val (controller, scope) = newController(observer = observer, clock = { 1000L })
+        controller.start()
+
+        observer.flow.emit(200)
+        advanceUntilIdle()
+
+        assertTrue(controller.state.value.paused, "external override should pause")
+        assertEquals(1, controller.state.value.overrideHistory.size)
+        scope.cancel()
+    }
+
+    @Test
+    fun resume_clearsPauseAndSetsInitialBrightness() = runTest {
+        val sensor = FakeSensor()
+        val observer = FakeObserver()
+        val brightness = FakeBrightness()
+        val (controller, scope) = newController(sensor, brightness, observer, clock = { 1000L })
+        controller.start()
+
+        // Establish a smoothedLux so setInitialBrightness has something to act on.
+        sensor.flow.emit(sample(lux = 50.0))
+        advanceUntilIdle()
+        assertNotNull(controller.state.value.smoothedLux)
+
+        observer.flow.emit(200)
+        advanceUntilIdle()
+        assertTrue(controller.state.value.paused)
+
+        val writesBefore = brightness.writes.size
+        controller.resume()
+        advanceUntilIdle()
+        assertTrue(!controller.state.value.paused, "resume should clear the pause latch")
+        assertTrue(brightness.writes.size > writesBefore, "resume should set an initial brightness")
+        scope.cancel()
+    }
+
+    @Test
+    fun screenOff_hibernatesRuntimeState() = runTest {
+        val sensor = FakeSensor()
+        val (controller, scope) = newController(sensor, clock = { 1000L })
+        controller.start()
+
+        sensor.flow.emit(sample(lux = 50.0))
+        advanceUntilIdle()
+        assertNotNull(controller.state.value.smoothedLux)
+
+        controller.onScreenOff()
+        advanceUntilIdle()
+        assertNull(controller.state.value.smoothedLux, "hibernate should clear smoothed lux")
+        assertNull(controller.state.value.threshAbsLow)
+        scope.cancel()
+    }
+}

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/ProfileGatesTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/ProfileGatesTest.kt
@@ -1,0 +1,135 @@
+package com.tideo.autobrightness.app.runtime
+
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+/**
+ * Gate truth-table test (S9a deliverable 5, D-027): asserts every branch of the prof760 and
+ * prof758 ConditionList transcriptions. A mis-parenthesized gate silently suppresses sensor
+ * events with no other test catching it, so each clause is exercised true AND false.
+ */
+class ProfileGatesTest {
+
+    // Convenience: a sample that passes all three prof760 sub-gates.
+    private fun monitor(
+        trustUnreliable: Boolean = false,
+        accuracy: Int = 3,
+        lux: Double = 5.0,
+        low: Double = 10.0,
+        high: Double = 100.0,
+        mainLoopOn: Boolean = false,
+        seeded: Boolean = true,
+    ) = ProfileGates.monitorAmbientLightGate(
+        trustUnreliable, accuracy, lux, low, high, mainLoopOn, seeded,
+    )
+
+    // --- prof760: accuracy-trust gate ---
+
+    @Test fun monitor_trustUnreliableOn_lowAccuracy_passesTrust() {
+        // ((TrustUnreliable=On) OR ...) — On short-circuits the accuracy requirement.
+        assertTrue(monitor(trustUnreliable = true, accuracy = 1))
+    }
+
+    @Test fun monitor_trustUnreliableOff_lowAccuracy_failsTrust() {
+        // (TrustUnreliable=Off AND accuracy>1) — accuracy 1 (Low) is rejected.
+        assertFalse(monitor(trustUnreliable = false, accuracy = 1))
+    }
+
+    @Test fun monitor_trustUnreliableOff_mediumAccuracy_passesTrust() {
+        assertTrue(monitor(trustUnreliable = false, accuracy = 2))
+    }
+
+    // --- prof760: absolute dead-band gate ---
+
+    @Test fun monitor_luxInsideBand_failsDeadBand() {
+        // lux is between low and high → inside the dead-band → suppressed.
+        assertFalse(monitor(lux = 50.0, low = 10.0, high = 100.0))
+    }
+
+    @Test fun monitor_luxBelowLow_passesDeadBand() {
+        assertTrue(monitor(lux = 5.0, low = 10.0, high = 100.0))
+    }
+
+    @Test fun monitor_luxAboveHigh_passesDeadBand() {
+        assertTrue(monitor(lux = 200.0, low = 10.0, high = 100.0))
+    }
+
+    @Test fun monitor_notSeeded_bypassesDeadBand() {
+        // First reading: thresholds not yet seeded → always enter the first-run init path.
+        assertTrue(monitor(lux = 50.0, low = 10.0, high = 100.0, seeded = false))
+    }
+
+    // --- prof760: main-loop mutex ---
+
+    @Test fun monitor_mainLoopOn_failsMutex() {
+        assertFalse(monitor(mainLoopOn = true))
+    }
+
+    @Test fun monitor_allGatesPass() {
+        assertTrue(monitor(trustUnreliable = false, accuracy = 3, lux = 5.0, mainLoopOn = false))
+    }
+
+    // --- prof758: dynamic scale ---
+
+    private fun scale(
+        nowMod: Double,
+        morningStart: Double = 6 * 3600.0,
+        morningEnd: Double = 8 * 3600.0,
+        eveningStart: Double = 18 * 3600.0,
+        eveningEnd: Double = 20 * 3600.0,
+        stale: Boolean = false,
+        scalingUse: Boolean = true,
+    ) = ProfileGates.dynamicScaleGate(
+        nowMod, morningStart, morningEnd, eveningStart, eveningEnd, stale, scalingUse,
+    )
+
+    @Test fun scale_scalingDisabled_alwaysFalse() {
+        // The final And2: (... ) AND (ScalingUse=true).
+        assertFalse(scale(nowMod = 7 * 3600.0, scalingUse = false))
+        assertFalse(scale(nowMod = 7 * 3600.0, stale = true, scalingUse = false))
+    }
+
+    @Test fun scale_insideMorningWindow_fires() {
+        assertTrue(scale(nowMod = 7 * 3600.0))
+    }
+
+    @Test fun scale_insideEveningWindow_fires() {
+        assertTrue(scale(nowMod = 19 * 3600.0))
+    }
+
+    @Test fun scale_outsideWindows_notStale_doesNotFire() {
+        assertFalse(scale(nowMod = 12 * 3600.0))
+    }
+
+    @Test fun scale_sunDataStale_firesEvenOutsideWindows() {
+        // c12 (sun data stale today) is an OR member of the inner group.
+        assertTrue(scale(nowMod = 12 * 3600.0, stale = true))
+    }
+
+    @Test fun scale_windowWrapsMidnight_matchesViaDayOffset() {
+        // Evening window 23:30→00:30 wraps midnight; now=00:10 must match via the ±86400 wrap.
+        val start = 23 * 3600.0 + 1800.0 // 23:30
+        val end = 24 * 3600.0 + 1800.0   // 00:30 next day (> 86400)
+        assertTrue(scale(nowMod = 600.0, eveningStart = start, eveningEnd = end))
+    }
+
+    // --- prof755: allow override ---
+
+    @Test fun override_allConditionsMet() {
+        assertTrue(
+            ProfileGates.allowOverrideGate(
+                serviceOn = true, autoBrightRunning = false, manualOverride = false,
+                initializing = false, detectOverrides = true,
+            ),
+        )
+    }
+
+    @Test fun override_eachBlockingConditionVetoes() {
+        assertFalse(ProfileGates.allowOverrideGate(false, false, false, false, true))   // service off
+        assertFalse(ProfileGates.allowOverrideGate(true, true, false, false, true))     // mid-write
+        assertFalse(ProfileGates.allowOverrideGate(true, false, true, false, true))     // already paused
+        assertFalse(ProfileGates.allowOverrideGate(true, false, false, true, true))     // initializing
+        assertFalse(ProfileGates.allowOverrideGate(true, false, false, false, false))   // detect off
+    }
+}

--- a/docs/rebuild/PARITY_CHECKLIST.md
+++ b/docs/rebuild/PARITY_CHECKLIST.md
@@ -11,15 +11,15 @@ filled by S1/S2 during extraction.
 
 | Profile | XML | Ported to | Status |
 |---|---|---|---|
-| prof753 Hibernate (Display Off) → task585 | L3 | | pending |
-| prof754 Throttle Reinitialization → task566 | L16 | | pending |
-| prof755 Allow Override → task567 | L56 | | pending |
-| prof756 Repost Paused Notification → task567 | L111 | | pending |
-| prof757 Repost Foreground Notification → task584 | L156 | | pending |
-| prof758 Dynamic Scale Engine → task90 | L195 | | pending |
+| prof753 Hibernate (Display Off) → task585 | L3 | runtime/BrightnessPipelineController.hibernate (S9a) | ported |
+| prof754 Throttle Reinitialization → task566 | L16 | runtime/BrightnessPipelineController.reinit (S9a) | ported |
+| prof755 Allow Override → task567 | L56 | runtime/OverrideMonitor + ProfileGates.allowOverrideGate (S9a) | ported |
+| prof756 Repost Paused Notification → task567 | L111 | runtime/AmbientMonitoringService paused notification (S9a) | ported |
+| prof757 Repost Foreground Notification → task584 | L156 | runtime/AmbientMonitoringService live notification (S9a) | ported |
+| prof758 Dynamic Scale Engine → task90 | L195 | gate transcribed: ProfileGates.dynamicScaleGate + truth-table test (S9a); task90 scheduling S9b/S12 | partial (gate S9a) |
 | prof759 Proximity Detection → task545 | L300 | | pending |
-| prof760 Monitor Ambient Light → task554 (incl. ConditionList gate) | L318 | | pending |
-| prof761 Initialize (Display On) → task618 | L386 | | pending |
+| prof760 Monitor Ambient Light → task554 (incl. ConditionList gate) | L318 | ProfileGates.monitorAmbientLightGate + truth-table test + BrightnessPipelineController (S9a) | ported |
+| prof761 Initialize (Display On) → task618 | L386 | runtime/BrightnessPipelineController.reinit/setInitialBrightness (S9a) | ported |
 | prof762 Context: App Changed → task43 | L398 | extraction/contexts_spec.md (S2) | pending |
 | prof763 Context: Battery Changed → task43 | L456 | extraction/contexts_spec.md (S2) | pending |
 | prof764 Context: Time Changed → task43 | L500 | extraction/contexts_spec.md (S2) | pending |
@@ -27,7 +27,7 @@ filled by S1/S2 during extraction.
 | prof766 Context: Location Refresher → task631 | L579 | extraction/contexts_spec.md (S2) | pending |
 | prof767 Context: Location Changed → task43 | L628 | extraction/contexts_spec.md (S2) | pending |
 | prof768 Context: WiFi (Dis)connected → task43 | L676 | extraction/contexts_spec.md (S2) | pending |
-| prof769 Panic (Reset) → task528 | L722 | | pending |
+| prof769 Panic (Reset) → task528 | L722 | runtime/BrightnessPipelineController.panic + notification action (S9a) | ported |
 | prof8 Context: Reset Serialized Cache → task26 | L744 | extraction/contexts_spec.md (S2) | pending |
 
 ## Pipeline & feature task clusters (~25)
@@ -43,19 +43,19 @@ filled by S1/S2 during extraction.
 | Compressed dynamic scale: 548 | | TaskerReference + taper.csv (S4) + BrightnessEngine.compressedDynamicScale (S5) | ported |
 | Continuity coefficients: 659 _UpdateBrightnessFormulae | | TaskerReference + formulae.csv (S4) + BrightnessFormulae.kt (S5) | ported |
 | Animation calc: 543 | | TaskerReference + animation.csv (S4) + BrightnessEngine.calculateAnimation (S5) | ported |
-| Brightness transitions: 696, 698 | | TaskerReference + transition.csv/dimming.csv (S4) | reference (S9a ports) |
+| Brightness transitions: 696, 698 | | TaskerReference + transition.csv/dimming.csv (S4); runtime/AnimationRunner per-frame write + read-back override detect (S9a); 698 DC-like dimming write S9b | ported (brightness; 698 dimming S9b) |
 | Software/super dimming math: 700, 645, 646, 647 | | SoftwareDimming.kt (S5 math, golden-tested superdimming.csv 2016 rows, CorePipelineParityTest); 650/653/654/644 privilege writes platform (S9b) | ported (math) |
 | Initial brightness on wake: 618 | | TaskerReference (S4) + InitialBrightness.kt (S5) + InitialBrightnessTest.kt (S5) | ported |
-| Hibernate/reset: 585 | | | pending |
-| Throttle reset: 566 | | | pending |
-| Manual override detect/resume: 567, 569, 561, 640, 641, 636 | | OverrideRules.kt (S5 pure logic, unit-tested OverrideRulesTest.kt S5); platform wiring + notification S9a | ported (logic) |
-| Panic reset: 528 | | | pending |
+| Hibernate/reset: 585 | | runtime/BrightnessPipelineController.hibernate (S9a — sensor unregister + runtime-state clear) | ported |
+| Throttle reset: 566 | | runtime/BrightnessPipelineController.reinit (S9a — throttle = settings default on wake) | ported |
+| Manual override detect/resume: 567, 569, 561, 640, 641, 636 | | OverrideRules.kt (S5 pure logic, OverrideRulesTest.kt S5); runtime wiring: OverrideMonitor + controller pause/resume + recordOverridePoint (S9a). 640/641/636 override-array CRUD UI = S12 | ported (detect/pause/resume) |
+| Panic reset: 528 | | runtime/BrightnessPipelineController.panic + notification Reset action (S9a) | ported |
 | Init/defaults: 570 Initialize AAB Defaults | | | pending |
 | Circadian dynamic scale: 90 (+ polar handling) | | SolarCalculator.kt + DynamicScaleEngine.kt (S6 domain, golden-tested circadian.csv 576 rows, CircadianParityTest + 4 polar assertions); BrightnessEngine delegates computeDynamicScale (D-031) | ported |
 | Context evaluation: 43, 623, 624, 625, 626, 628, 630, 631, 633, 105, 26 | | S2 extracted → contexts_spec.md | pending |
 | Privilege detection/grant: 378, 643, 563 | | S2 extracted → features_spec.md; platform layer: AndroidPrivilegeManager + ShizukuGrantGateway stub (S7); UI wiring S11 | platform-ported (S7) |
 | QS tile: 551, 552 | | S2 extracted → features_spec.md | pending |
-| Foreground notification: 584, 692 | | S2 extracted → features_spec.md | pending |
+| Foreground notification: 584, 692 | | S2 extracted → features_spec.md; runtime/AmbientMonitoringService live lux/target notification + Pause/Resume/Reset/Disable actions (S9a) | ported |
 | Curve suggestion wizard: 38, 655 | | CurveSuggestionEngine.kt (S6 domain, golden-tested wizard.csv 12 rows, WizardParityTest); applyToLiveCurve = task655 | ported |
 | Formula validation: 583, 707 | | S2 extracted → features_spec.md; SettingsValidator.kt (S8 — 5 rules: form2A<0, form3A<0, form2C>zone1End advisory + predicted-brightness@1000lux<25 safety) | ported |
 | Power draw calibration: 524 | | S2 extracted → features_spec.md | pending |
@@ -125,8 +125,8 @@ filled by S1/S2 during extraction.
 | task655 L32591 · _SetSuggestedVariables | ✓ S1 | ✓ S6 (delegate) | CurveSuggestionEngine.applyToLiveCurve (S6) | ported |
 | task657 L32986 · _GenerateCompressionGraph | ✓ S1 | | | pending |
 | task663 L33944+L34370 · _GenerateGraph (×2) | ✓ S1 | ✓ S4 (cross-validation oracle, D-002) | chart render = S13 BrightnessCurveChart | reference (chart S13) |
-| task696 L35733 · Smooth Brightness Transition | ✓ S1 | ✓ S4 | runtime write loop = S9a AnimationRunner | reference (S9a ports) |
-| task698 L36043 · Smooth DC-Like Transition | ✓ S1 | ✓ S4 | runtime write loop = S9a AnimationRunner | reference (S9a ports) |
+| task696 L35733 · Smooth Brightness Transition | ✓ S1 | ✓ S4 | runtime/AnimationRunner (S9a) | ported |
+| task698 L36043 · Smooth DC-Like Transition | ✓ S1 | ✓ S4 | runtime/AnimationRunner brightness path (S9a); DC-like dimming write S9b | ported (brightness; dimming S9b) |
 | task703 L36847 · _GenerateReactivityGraph | ✓ S1 | | | pending |
 | task705 L37517 · _GenerateCircadianDimmingGraph | ✓ S1 | | | pending |
 | task90 L40429+L41085 · Dynamic Scale V13 (×2) | ✓ S1 | ✓ S6 (delegate) | SolarCalculator.kt + DynamicScaleEngine.kt (S6) | ported |

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -21,18 +21,28 @@ next session does not know it.
 | S7 platform adapters + privilege | 2026-06-12 | Sonnet/medium | DONE | (see push) | `sensor/LightSensorSource.kt` (TYPE_LIGHT callbackFlow); `brightness/ScreenBrightnessController.kt` (read/write 0–255, OEM range norm via config_screenBrightnessSettingMaximum, suppress-echo hook); `brightness/SecureDimmingController.kt` (reduce_bright_colors via Settings.Secure, ELEVATED-gated); `privilege/PrivilegeManager.kt` (Tier NONE/BASIC/ELEVATED; BASIC=canWrite, ELEVATED=checkPermission; tierFlow; root+Shizuku grant helpers); `privilege/ShizukuGrantGateway.kt` (binder check + permission request stub — exec TODO S11, D-032); `observe/BrightnessObserver.kt` (ContentObserver callbackFlow, null-Handler for synchronous dispatch, self-write filter via suppress-echo); `context/{BatteryStateReader,LocationReader,ForegroundAppMonitor,WifiInfoReader}.kt`. ShizukuProvider added to manifest; shizuku-api added to platform + app deps; shizuku-provider added to app deps. SystemAdapters.kt marked @Deprecated("S9b removes"). Robolectric tests: 19 total (brightness write/read/mode-force, tier-gating, observer dispatch+self-write-filter, LightSensorSource cancel). `:platform:test` GREEN (19 tests); `:app:assembleDebug` GREEN. |
 
 | S8.5 review (Fable→Opus) | 2026-06-12/13 | Fable+Opus | IN PROGRESS | 3c6a585, cd3fd15, (this) | Sequential reviews (one agent at a time per owner). DONE: full acceptance suite green; S7 review → D-034 (suppress-echo redesign, OEM rounding, +8 tests); D-035 model policy (Opus from S9a); checklist unstale'd; **S4/S5 review → D-036** (2 CRITICAL parity holes fixed: task661 ScalingUse=false/%AAB_Scale branch + %AAB_ScaleDynamicCompress surfacing; new calculated.csv golden + 3 tests; existing 8 CSVs byte-identical); **S6 review → D-037** (port verified faithful; fixed oracle-circularity by adding independent SolarInvariantTest [7 astronomical invariants, all pass] + wizard abort test + dawn/dusk golden assertions); **S8 review → D-038** (CRITICAL: contextOverride default true→false [would lock context switching on fresh install]; fixed 2 vacuous safety-validator tests). All four reviews (S4/S5, S6, S7, S8) COMPLETE. Build green. S9a may proceed (Opus per D-035). |
+| S9a runtime core | 2026-06-13 | Opus/high | DONE | (see push) | Runtime pipeline rebuilt (D-039). New: `runtime/ProfileGates.kt` (hardcoded prof760/758/755 ConditionList booleans, D-021 provenance); `PipelineState.kt` (single runtime-state holder + PipelineEvent sealed type); `AnimationRunner.kt` (task696 per-frame write + read-back override detect, suppress-echo); `OverrideMonitor.kt` (BrightnessObserver→OverrideRules prof755 gate); `BrightnessPipelineController.kt` (single-coroutine pipeline, drop-not-queue MainLoop mutex via AtomicBoolean, sensor→gate→throttle→BrightnessEngine.evaluate→animate, override/pause/resume, hibernate/reinit/panic); `AmbientMonitoringService.kt` REBUILT (ServiceCompat specialUse FGS, live lux/target notification + Pause/Resume/Reset/Disable actions, dynamic SCREEN_ON/OFF receiver→reinit/hibernate). Tests: ProfileGatesTest (prof760+758+755 truth table), AnimationRunnerTest (4), BrightnessPipelineControllerTest (first-run/throttle/mid-cycle-drop/override/resume/hibernate, 5), AmbientMonitoringServiceTest (Robolectric foreground notif + lifecycle, 2). Full ladder GREEN: `:app:assembleDebug :app:testDebugUnitTest :domain:test :platform:test :app:lintDebug`. Legacy fakes still present (S9b rips out). No compaction. |
 
 Status values: DONE · PARTIAL · BLOCKED (see failure protocol in CLAUDE.md).
 
 ## Current state
 
-S1 through S8 DONE. Build is GREEN: `:platform:test` 19 tests; `:app:testDebugUnitTest` 20 new tests (+ pre-existing); `:app:assembleDebug` ✅ `:app:lintDebug` ✅.
-Settings schema v2 complete: AabSettings gains animSteps/thresholdMidpoint/contextOverride/setupTitle; scale changed to Float; throttle default corrected to 1310. Mapper extended with all 4 domain config conversion functions. SettingsValidator implements all 5 Tasker validation rules (task583×3 advisory + task707×2 safety). DefaultProfiles has all 5 built-in profiles from task592. ContextOverrideRules data model is ready for S10 engine wiring. Parallel window B complete.
+S1 through S9a DONE. Build is GREEN across the full ladder: `:domain:test`, `:platform:test`,
+`:app:testDebugUnitTest` (incl. 13 new S9a runtime tests), `:app:assembleDebug`, `:app:lintDebug`.
+The runtime is now the real sensor-event-driven Tasker pipeline: BrightnessPipelineController owns
+all runtime state and drives a single serialized cycle (drop-not-queue MainLoop mutex);
+AnimationRunner does per-frame writes with read-back override detection; OverrideMonitor + controller
+implement detect/pause/resume; AmbientMonitoringService is a specialUse FGS with a live notification
+(Pause/Resume/Reset/Disable) and SCREEN_ON/OFF → reinit/hibernate. Profile gates prof760/758/755 are
+hardcoded booleans (ProfileGates) with a truth-table test. **Legacy fakes still present** (AppModule,
+EvaluateAndApplyBrightnessUseCase, BrightnessPolicyEngine, Ports, SystemAdapters) — S9b rips them out.
 
 ## Next up
 
-- S9a: Runtime pipeline core (preconditions S5 ✅, S6 ✅, S7 ✅, S8 ✅)
-- Then S9b → Gate 1.
+- S9b: super-dimming wiring + QS tile + boot start + legacy rip-out → **GATE 1**.
+  Note for S9b (D-039): pass `BrightnessPolicyOutput.scaleDynamicCompress` into the dimming path;
+  wire SecureDimmingController writes from the pipeline coroutine; replace AppModule with the real
+  graph (the controller's adapter set is the template); proximity damp (task545) is still unwired.
 
 ## Deviations & discoveries ledger
 
@@ -388,7 +398,38 @@ Seeded by the S0 audit (details in CLAUDE.md "Facts & corrections ledger"):
   mapper conversions; 5 DefaultProfiles vs task592; ContextOverrideRules JSON interop. (Affects
   S10, S12, S14.)
 
-Append new entries as D-039, D-040, … with which segments they affect.
+- D-039: S9a RUNTIME CORE design decisions (all sanctioned by the S9a brief; flagged for S9b/S12/S14).
+  (a) **Engine owns the dead-band; controller owns the prof760 gate.** The controller applies the
+  prof760 ConditionList (accuracy-trust + absolute dead-band using the PREVIOUS cycle's stored
+  ThreshAbsLow/High + MainLoop mutex) BEFORE calling the golden-tested BrightnessEngine, which
+  internally recomputes its own absolute band (`shouldUpdate`). When a tick passes the controller
+  gate but the engine treats it as a no-op (luxAlpha→0, same target), the result is a redundant
+  write of the same value — harmless; the controller additionally skips the animation when
+  `target == brightness.read()`. No behavioral divergence from the engine (which is the oracle), only
+  avoided redundant writes. The two gates use the SAME stored band on the common path so they agree.
+  (b) **Fast intra-cycle flags live outside the immutable snapshot.** `autoRunning` and `initializing`
+  flip many times within one cycle and are read by the observer coroutine, so they are `@Volatile`
+  vars in the controller, not fields of the StateFlow `PipelineState` (which holds the durable
+  runtime vars per pipeline_spec §5). Everything durable is written ONLY from the consumer coroutine.
+  (c) **MainLoop mutex = `AtomicBoolean inCycle` + `compareAndSet`.** Sensor ticks that lose the CAS
+  (or whose gate sees `mainLoopOn`) are dropped at the collector, never enqueued (Tasker drop-not-
+  queue, D-021/D-027). Control events (screen/pause/resume/panic/override) go through an UNLIMITED
+  channel and are NOT dropped; one event still runs to completion (incl. animation) before the next.
+  (d) **secondsOfDay is derived from UTC wall-clock** (`(clock()/1000)%86400`) with default ramp
+  windows. Irrelevant in S9a (scalingEnabled defaults false → engine ignores circadian), but S9b/S12
+  MUST supply real LOCAL seconds-of-day + solar windows (SolarCalculator) when wiring circadian.
+  (e) **prof758 gate transcribed + truth-table-tested in ProfileGates, but task90 is NOT scheduled
+  in S9a** — the periodic dynamic-scale recompute (prof758→task90) is S9b/S12. (f) **task696 only**
+  in AnimationRunner; the task698 DC-like dimming write + SecureDimmingController wiring is S9b
+  (pass `output.scaleDynamicCompress` to OverrideRules.recordOverridePoint — already done in the
+  controller's handleOverride). (g) **Proximity damp (task545/prof759) is unwired** — the engine has
+  no proximity concept and S9a's scope is the core loop; revisit if a later segment surfaces it.
+  (h) **task567's CycleTime re-check wait is collapsed**: handleOverride applies OverrideRules
+  .shouldCommitPause immediately rather than waiting %AAB_CycleTime, because the single-cycle model
+  already guarantees no animation is mid-flight when an OverrideDetected event is dequeued. (Affects
+  S9b, S10, S12, S14.)
+
+Append new entries as D-040, D-041, … with which segments they affect.
 
 ## Blockers
 


### PR DESCRIPTION
## Summary

Ports the Tasker auto-brightness sensor→brightness loop (prof760/task554 main loop, prof755/task567 override detection, prof753/task585 hibernate, prof754/task566 reinit) into a Kotlin runtime pipeline with a serialized coroutine consumer, animated brightness writes, and a foreground service host.

## Key Changes

**Core Pipeline (`BrightnessPipelineController.kt`)**
- Single-consumer coroutine event loop processing `PipelineEvent` (SensorTick, ScreenOn/Off, Pause/Resume, Panic, OverrideDetected)
- Re-entry mutex (`inCycle` AtomicBoolean) implements prof760's `%AAB_MainLoop != On` gate: sensor ticks arriving mid-cycle are **dropped, not queued** (D-027 BINDING concurrency model)
- Throttle gate (task544 act2-9): drops ticks within the throttle window; resets on screen-on (prof754/task566)
- Cycle runner calls `BrightnessEngine.evaluate()` with settings-derived configs, animates the result via `AnimationRunner`, records state snapshots
- Hibernate (prof753/task585): stops sensor on screen-off, clears runtime state
- Reinit (prof754/task566): restarts sensor and sets initial brightness on screen-on
- Override handling (prof755/task567): pauses pipeline when external brightness changes detected mid-animation or via observer

**Profile Gates (`ProfileGates.kt`)**
- Hardcoded Kotlin transcriptions of prof760 (accuracy-trust + absolute dead-band + mutex) and prof758 (dynamic scale engine with midnight-wrap windows)
- Each gate is a hand-written boolean expression with D-021 parenthesization provenance comments
- `ProfileGatesTest.kt` asserts every branch of each clause (truth-table coverage)

**Animation (`AnimationRunner.kt`)**
- Executes smooth brightness transitions (task696) with per-frame read-back override detection
- Aborts and signals `OVERRIDDEN` if an external write is observed mid-animation (suppress-echo via `ScreenBrightnessController` hook)
- Testable with fake controller; no Android dependencies beyond the interface

**Override Monitor (`OverrideMonitor.kt`)**
- Bridges platform `BrightnessObserver` (prof755 ContentObserver) to domain `OverrideRules`
- Applies remaining prof755 gate clauses; observer already filters self-writes (D-034)
- Emits observed brightness levels that qualify as manual overrides

**Pipeline State (`PipelineState.kt`)**
- Immutable snapshot of runtime `%AAB_*` variables (smoothedLux, lastRawLux, thresholds, cycleTime, scaleDynamicCompress, paused, overrideHistory)
- Written ONLY from the consumer coroutine; UI/notification read via StateFlow (D-027)

**Service (`AmbientMonitoringService.kt`)**
- Foreground service (specialUse type) hosting the pipeline controller
- Composes live platform adapters: `AndroidLightSensorSource`, `AndroidScreenBrightnessController`, `AndroidBrightnessObserver`
- Routes screen ON/OFF broadcasts to pipeline's reinit/hibernate paths
- Posts live notification with lux/target readout and Pause/Resume/Disable/Panic actions
- Persists disable setting so boot/screen receivers do not restart the loop

**Tests**
- `BrightnessPipelineControllerTest.kt`: throttle gate, mid-cycle sensor drop, external override pause, resume clears pause
- `AnimationRunnerTest.kt`: animation completion, single-step write, external change detection
- `ProfileGatesTest.kt`: truth-table coverage of prof760 and prof758 gates
- `AmbientMonitoringServiceTest.kt`: foreground notification posting, lifecycle

## Notable Implementation Details

- **Concurrency model (D-027)**: Single consumer coroutine serializes all events; sensor/observer collectors signal via an unbounded channel; mid-cycle ticks are dropped by the `inCycle` mutex

https://claude.ai/code/session_018STMpzkR2dyxNMHe8Gsj6d