### PR TITLE
S10: Port context-override engine (prof762–768 + task43)

### DIFF
--- a/app/src/main/kotlin/com/tideo/autobrightness/app/AppModule.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/AppModule.kt
@@ -1,8 +1,13 @@
 package com.tideo.autobrightness.app
 
 import android.content.Context
+import com.tideo.autobrightness.app.runtime.AndroidContextSignalSource
+import com.tideo.autobrightness.app.runtime.AppProfileCatalog
 import com.tideo.autobrightness.app.runtime.BrightnessPipelineController
+import com.tideo.autobrightness.app.runtime.ContextEngine
 import com.tideo.autobrightness.app.runtime.SuperDimmingCoordinator
+import com.tideo.autobrightness.app.settings.ContextRuleStore
+import com.tideo.autobrightness.app.storage.contextRulesDataStore
 import com.tideo.autobrightness.app.storage.settingsDataStore
 import com.tideo.autobrightness.platform.brightness.AndroidScreenBrightnessController
 import com.tideo.autobrightness.platform.brightness.AndroidSecureDimmingController
@@ -11,38 +16,65 @@ import com.tideo.autobrightness.platform.privilege.AndroidPrivilegeManager
 import com.tideo.autobrightness.platform.privilege.PrivilegeManager
 import com.tideo.autobrightness.platform.sensor.AndroidLightSensorSource
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 
 /**
- * Manual DI composition root for the runtime graph (rebuilt in S9b — the legacy toy use-case graph
- * is gone). Composes the real S7 platform adapters + S9a pipeline + S9b super-dimming layer.
- * Replace with Hilt/Koin later without touching domain contracts.
+ * Manual DI composition root for the runtime graph (rebuilt in S9b; extended in S10 with the
+ * context-override engine). Composes the real S7 platform adapters + S9a pipeline + S9b super-dimming
+ * layer + S10 [ContextEngine]. Replace with Hilt/Koin later without touching domain contracts.
  */
 class AppModule(context: Context) {
     private val appContext = context.applicationContext
 
     val privilegeManager: PrivilegeManager = AndroidPrivilegeManager(appContext)
 
+    /** Persistence + CRUD for context rules (exposed for the S12 rule-editing UI). */
+    val contextRuleStore: ContextRuleStore = ContextRuleStore(appContext.contextRulesDataStore)
+
     /**
-     * Build a fresh pipeline controller for a service lifetime. The brightness writer and observer
-     * SHARE one instance so the suppress-echo marker is per-instance (D-034: the observer must see
-     * exactly the writer's last value).
+     * Build a fresh runtime graph for a service lifetime. The brightness writer and observer SHARE
+     * one instance so the suppress-echo marker is per-instance (D-034). The pipeline reads its
+     * settings through the [ContextEngine] so an active context override swaps the whole profile.
      */
-    fun createController(scope: CoroutineScope): BrightnessPipelineController {
+    fun createRuntime(scope: CoroutineScope): RuntimeGraph {
         val brightness = AndroidScreenBrightnessController(appContext)
-        return BrightnessPipelineController(
+
+        lateinit var controller: BrightnessPipelineController
+        val contextEngine = ContextEngine(
+            rulesProvider = { contextRuleStore.rules() },
+            baselineProvider = { appContext.settingsDataStore.data.first() },
+            profileCatalog = AppProfileCatalog,
+            signalSource = AndroidContextSignalSource(appContext),
+            onProfileChanged = { controller.onContextChanged() },
+        )
+
+        controller = BrightnessPipelineController(
             lightSensor = AndroidLightSensorSource(appContext),
             brightness = brightness,
             brightnessObserver = AndroidBrightnessObserver(appContext, brightness),
-            settingsProvider = { appContext.settingsDataStore.data.first() },
+            // Effective settings = active context profile merged over the baseline, or the baseline.
+            settingsProvider = { contextEngine.effectiveSettings() },
             scope = scope,
             dimming = SuperDimmingCoordinator(
                 secureDimming = AndroidSecureDimmingController(appContext, privilegeManager),
                 // Re-detect each cycle so a WRITE_SECURE_SETTINGS grant made AFTER the service
-                // started (Shizuku/ADB) is picked up without a restart (G1-F5). Cheap: one
-                // checkSelfPermission per cycle.
+                // started (Shizuku/ADB) is picked up without a restart (G1-F5).
                 tierProvider = { privilegeManager.refresh(); privilegeManager.currentTier() },
             ),
         )
+
+        return RuntimeGraph(controller, contextEngine)
     }
+}
+
+/**
+ * The composed runtime: the brightness pipeline + the context engine that feeds it. The service
+ * drives both lifecycles together and reads [activeContext] for the notification's context line.
+ */
+class RuntimeGraph(
+    val controller: BrightnessPipelineController,
+    val contextEngine: ContextEngine,
+) {
+    val activeContext: StateFlow<String?> = contextEngine.activeContext
 }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
@@ -21,8 +21,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 /**
@@ -36,14 +36,15 @@ import kotlinx.coroutines.launch
 class AmbientMonitoringService : Service() {
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     private lateinit var controller: BrightnessPipelineController
+    private lateinit var contextEngine: ContextEngine
     private var notificationJob: Job? = null
 
     // SCREEN_ON/OFF are runtime-only broadcasts (not deliverable to manifest receivers).
     private val screenReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent?) {
             when (intent?.action) {
-                Intent.ACTION_SCREEN_OFF -> controller.onScreenOff()
-                Intent.ACTION_SCREEN_ON -> controller.onScreenOn()
+                Intent.ACTION_SCREEN_OFF -> { controller.onScreenOff(); contextEngine.onScreenOff() }
+                Intent.ACTION_SCREEN_ON -> { controller.onScreenOn(); contextEngine.onScreenOn() }
             }
         }
     }
@@ -52,9 +53,12 @@ class AmbientMonitoringService : Service() {
         super.onCreate()
         createNotificationChannel()
 
-        // AppModule composes the real graph (S7 adapters + S9a pipeline + S9b super dimming);
-        // writer and observer share one instance for the per-instance suppress-echo marker (D-034).
-        controller = AppModule(applicationContext).createController(scope)
+        // AppModule composes the real graph (S7 adapters + S9a pipeline + S9b super dimming +
+        // S10 context engine); writer and observer share one instance for the suppress-echo
+        // marker (D-034), and the pipeline reads its settings through the context engine.
+        val runtime = AppModule(applicationContext).createRuntime(scope)
+        controller = runtime.controller
+        contextEngine = runtime.contextEngine
 
         registerReceiver(
             screenReceiver,
@@ -93,10 +97,14 @@ class AmbientMonitoringService : Service() {
 
     private fun ensureRunning() {
         controller.start()
+        contextEngine.start(scope)
         if (notificationJob?.isActive == true) return
         notificationJob = scope.launch {
-            controller.state
-                .map { NotificationModel(it.smoothedLux, it.targetBrightness, it.paused, it.serviceOn) }
+            combine(controller.state, contextEngine.activeContext) { state, ctx ->
+                // Each accepted cycle drives time-window re-evaluation (contexts_spec — prof764).
+                contextEngine.onPipelineTick()
+                NotificationModel(state.smoothedLux, state.targetBrightness, state.paused, state.serviceOn, ctx)
+            }
                 .distinctUntilChanged()
                 .collect { model ->
                     if (!model.serviceOn) return@collect
@@ -138,6 +146,7 @@ class AmbientMonitoringService : Service() {
         val targetBrightness: Int? = null,
         val paused: Boolean = false,
         val serviceOn: Boolean = true,
+        val activeContext: String? = null,
     )
 
     private fun buildNotification(model: NotificationModel): Notification {
@@ -156,6 +165,8 @@ class AmbientMonitoringService : Service() {
                 "Lux ${model.smoothedLux.toInt()} → brightness ${model.targetBrightness}"
             else -> "Monitoring ambient light"
         }
+        // Surface the active context override (%AAB_ActiveContext) as a second line when one is on.
+        val contextLine = model.activeContext?.let { "Context: $it" }
 
         val builder = NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle(title)
@@ -163,6 +174,7 @@ class AmbientMonitoringService : Service() {
             .setSmallIcon(R.drawable.ic_stat_brightness)
             .setOngoing(true)
             .setOnlyAlertOnce(true)
+        contextLine?.let { builder.setSubText(it) }
 
         if (model.paused) {
             builder.addAction(0, "Resume", actionIntent(ACTION_RESUME))
@@ -186,6 +198,7 @@ class AmbientMonitoringService : Service() {
 
     override fun onDestroy() {
         runCatching { unregisterReceiver(screenReceiver) }
+        contextEngine.stop()
         controller.stop()
         scope.cancel()
         super.onDestroy()

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AndroidContextSignalSource.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AndroidContextSignalSource.kt
@@ -1,0 +1,86 @@
+package com.tideo.autobrightness.app.runtime
+
+import android.content.Context
+import com.tideo.autobrightness.domain.circadian.SolarCalculator
+import com.tideo.autobrightness.domain.context.ContextSignals
+import com.tideo.autobrightness.platform.context.AndroidBatteryStateReader
+import com.tideo.autobrightness.platform.context.AndroidForegroundAppMonitor
+import com.tideo.autobrightness.platform.context.AndroidLocationReader
+import com.tideo.autobrightness.platform.context.AndroidWifiInfoReader
+import com.tideo.autobrightness.platform.context.BatteryStateReader
+import com.tideo.autobrightness.platform.context.ForegroundAppMonitor
+import com.tideo.autobrightness.platform.context.LocationReader
+import com.tideo.autobrightness.platform.context.WifiInfoReader
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.util.Calendar
+
+/**
+ * Android-backed [ContextSignalSource]: bridges the S7 platform readers into the engine and computes
+ * the clock/calendar/solar fields the pure resolver needs (day-of-week, local seconds-of-day, and
+ * SUNRISE/SUNSET as local seconds — task43 L62-80, L150-152).
+ */
+class AndroidContextSignalSource(
+    context: Context,
+    private val battery: BatteryStateReader = AndroidBatteryStateReader(context.applicationContext),
+    private val wifi: WifiInfoReader = AndroidWifiInfoReader(context.applicationContext),
+    private val foregroundApp: ForegroundAppMonitor = AndroidForegroundAppMonitor(context.applicationContext),
+    private val location: LocationReader = AndroidLocationReader(context.applicationContext),
+    private val clock: () -> Long = System::currentTimeMillis,
+) : ContextSignalSource {
+
+    override fun batteryFlow(): Flow<BatterySignal> =
+        battery.batteryState().map { BatterySignal(percent = it.levelPercent, plugged = it.isCharging) }
+
+    override fun wifiFlow(): Flow<String?> = wifi.ssidFlow()
+
+    override fun foregroundAppFlow(intervalMs: Long): Flow<String?> =
+        foregroundApp.foregroundPackage(intervalMs)
+
+    override suspend fun assemble(
+        app: String,
+        batteryPercent: Int,
+        plugged: Boolean,
+        wifi: String,
+    ): ContextSignals {
+        val cal = Calendar.getInstance()
+        cal.timeInMillis = clock()
+        val dayOfWeek = cal.get(Calendar.DAY_OF_WEEK)
+        val nowSecs = cal.get(Calendar.HOUR_OF_DAY) * 3600 +
+            cal.get(Calendar.MINUTE) * 60 + cal.get(Calendar.SECOND)
+
+        val loc = runCatching { location.lastKnownLocation() }.getOrNull()
+        val offsetSecs = cal.timeZone.getOffset(cal.timeInMillis) / 1000L
+        val (sunrise, sunset) = solarLocalSeconds(loc?.latitude, loc?.longitude, cal.timeInMillis / 1000L, offsetSecs)
+
+        return ContextSignals(
+            app = app,
+            lat = loc?.latitude ?: 0.0,
+            lon = loc?.longitude ?: 0.0,
+            batteryPercent = batteryPercent,
+            plugged = plugged,
+            dayOfWeek = dayOfWeek,
+            nowSecondsOfDay = nowSecs,
+            wifi = wifi,
+            sunriseLocalSecs = sunrise,
+            sunsetLocalSecs = sunset,
+        )
+    }
+
+    // SUNRISE/SUNSET as local seconds-of-day. Falls back to 06:00/18:00 (task43 L67/72) when no
+    // location is known or the solar computation fails (e.g. polar day/night sentinels).
+    private fun solarLocalSeconds(lat: Double?, lon: Double?, epochSec: Long, offsetSecs: Long): Pair<Long, Long> {
+        if (lat == null || lon == null) return DEFAULT_SUNRISE to DEFAULT_SUNSET
+        return runCatching {
+            val solar = SolarCalculator.compute(lat, lon, epochSec, offsetSecs / 3600.0)
+            val rise = Math.floorMod(solar.riseEpochSec + offsetSecs, 86_400L)
+            val set = Math.floorMod(solar.setEpochSec + offsetSecs, 86_400L)
+            rise to set
+        }.getOrDefault(DEFAULT_SUNRISE to DEFAULT_SUNSET)
+    }
+
+    private companion object {
+        const val DEFAULT_SUNRISE = 21_600L // 06:00
+        const val DEFAULT_SUNSET = 64_800L  // 18:00
+    }
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AppProfileCatalog.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AppProfileCatalog.kt
@@ -1,0 +1,14 @@
+package com.tideo.autobrightness.app.runtime
+
+import com.tideo.autobrightness.app.settings.AabSettings
+import com.tideo.autobrightness.app.settings.DefaultProfiles
+
+/**
+ * Resolves a context rule's target profile NAME to its [AabSettings] parameter set. S10 backs this
+ * with the five built-in profiles ([DefaultProfiles], task592); S12 (profile save/load) extends it
+ * with user-named profiles. An unknown name resolves to null → the engine keeps the user baseline.
+ */
+object AppProfileCatalog : ProfileCatalog {
+    override suspend fun profile(name: String): AabSettings? = DefaultProfiles.all[name]
+    override suspend fun names(): Set<String> = DefaultProfiles.all.keys
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineController.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineController.kt
@@ -117,6 +117,9 @@ class BrightnessPipelineController(
     fun pause() { events.trySend(PipelineEvent.Pause) }
     fun resume() { events.trySend(PipelineEvent.Resume) }
 
+    /** A context override swapped the active profile: re-apply the initial brightness (task43 act21). */
+    fun onContextChanged() { events.trySend(PipelineEvent.ContextChanged) }
+
     /**
      * prof769/task528 panic: restore a sane brightness, drop super dimming, and FULL STOP
      * (%AAB_Service=Off — task528 act1-2 toggles the service off). This is terminal, not a
@@ -181,7 +184,14 @@ class BrightnessPipelineController(
             PipelineEvent.Pause -> pauseInternal()
             PipelineEvent.Resume -> resumeInternal()
             is PipelineEvent.OverrideDetected -> handleOverride(event.observedBrightness)
+            PipelineEvent.ContextChanged -> reapplyProfile()
         }
+    }
+
+    /** task43 act21: a context profile swap re-runs Set Initial Brightness with the new (effective) settings. */
+    private suspend fun reapplyProfile() {
+        if (_state.value.paused || !_state.value.serviceOn) return
+        setInitialBrightness(settingsProvider().also { cachedSettings = it })
     }
 
     /** task554 → task544 → task535 → task661: ingest a reading and animate to the new brightness. */

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/ContextEngine.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/ContextEngine.kt
@@ -1,0 +1,279 @@
+package com.tideo.autobrightness.app.runtime
+
+import com.tideo.autobrightness.app.settings.AabSettings
+import com.tideo.autobrightness.app.settings.ContextRule
+import com.tideo.autobrightness.app.settings.ContextSignalTokens
+import com.tideo.autobrightness.app.settings.toSpec
+import com.tideo.autobrightness.domain.context.ContextOverrideResolver
+import com.tideo.autobrightness.domain.context.ContextResolution
+import com.tideo.autobrightness.domain.context.ContextSignals
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.math.abs
+
+/**
+ * Runtime context-override engine — the Kotlin rebuild of Tasker's 8 watcher profiles (prof762–768
+ * + prof8) + task43 `_EvaluateContexts V2` orchestration (contexts_spec).
+ *
+ * The pure precedence/merge decision is delegated to the golden domain [ContextOverrideResolver];
+ * this class owns the stateful glue the resolver brief leaves out:
+ *  - PASS 1 per-caller cooldown debounce (contexts_spec §4 / task43 L31-57).
+ *  - PASS 2 signal-change veto gates + `%AAB_ContextState` (task43 L183-248).
+ *  - signal acquisition via the S7 readers (battery/wifi/foreground-app/location) + clock/solar.
+ *  - applying the resolved override by swapping the **entire active profile** (contexts_spec §4 —
+ *    NOT a scale/min/max tweak) and re-running Set Initial Brightness ([onProfileChanged]).
+ *
+ * Concurrency: every evaluation runs under [evalMutex] so the veto state and active-profile latch
+ * stay consistent across the battery/wifi/app/time signal sources.
+ */
+class ContextEngine(
+    private val rulesProvider: suspend () -> List<ContextRule>,
+    private val baselineProvider: suspend () -> AabSettings,
+    private val profileCatalog: ProfileCatalog,
+    private val signalSource: ContextSignalSource,
+    private val onProfileChanged: () -> Unit,
+    private val clock: () -> Long = System::currentTimeMillis,
+    private val userProfileName: String = "Default",
+) {
+    private val _activeContext = MutableStateFlow<String?>(null)
+    /** `%AAB_ActiveContext` — the winning rule's name, or null when running the user baseline. */
+    val activeContext: StateFlow<String?> = _activeContext.asStateFlow()
+
+    private val _nextContextTime = MutableStateFlow<String?>(null)
+    /** `%AAB_NextContextTime` (HH.MM) — nearest future time endpoint, drives time re-eval scheduling. */
+    val nextContextTime: StateFlow<String?> = _nextContextTime.asStateFlow()
+
+    // Effective settings the pipeline consumes: the active profile merged over the baseline, or the
+    // baseline itself when no override is active. Null until the first evaluation seeds it.
+    private val _effective = MutableStateFlow<AabSettings?>(null)
+
+    private val evalMutex = Mutex()
+
+    // PASS 1: global last-eval clock (task43 %AAB_LastEvalTime). null until the first eval runs, so a
+    // freshly started engine always evaluates once regardless of the cooldown window.
+    private var lastEvalTime: Long? = null
+    // PASS 2: previous signal snapshot (%AAB_ContextState: app#lat#lon#batt#plug#day#wifi).
+    private var lastApp = ""
+    private var lastBatt = -1
+    private var lastPlug = -1
+    private var lastDay = -1
+    private var lastWifi = ""
+    /** The profile currently applied (`%AAB_CurrentActiveProfile`). */
+    private var currentProfileName: String? = null
+
+    // Latest live signal pieces fed by the reader flows; assembled into a full snapshot per eval.
+    @Volatile private var latestApp = ""
+    @Volatile private var latestBatt = 0
+    @Volatile private var latestPlug = false
+    @Volatile private var latestWifi = ""
+
+    private var scope: CoroutineScope? = null
+    private var batteryJob: Job? = null
+    private var wifiJob: Job? = null
+    private var appJob: Job? = null
+    @Volatile private var screenOn = true
+
+    /** Effective settings for the pipeline's settingsProvider: active profile override or baseline. */
+    suspend fun effectiveSettings(): AabSettings = _effective.value ?: baselineProvider()
+
+    fun start(scope: CoroutineScope) {
+        if (this.scope != null) return
+        this.scope = scope
+        batteryJob = scope.launch {
+            signalSource.batteryFlow().collect { snap ->
+                latestBatt = snap.percent
+                latestPlug = snap.plugged
+                evaluate(ContextCaller.BATTERY)
+            }
+        }
+        wifiJob = scope.launch {
+            signalSource.wifiFlow().collect { ssid ->
+                latestWifi = ssid ?: ""
+                evaluate(ContextCaller.WIFI)
+            }
+        }
+        scope.launch {
+            // Seed the effective settings + active profile from a first general evaluation.
+            evaluate(ContextCaller.GENERAL)
+            startAppPollIfNeeded()
+        }
+    }
+
+    fun stop() {
+        batteryJob?.cancel(); batteryJob = null
+        wifiJob?.cancel(); wifiJob = null
+        appJob?.cancel(); appJob = null
+        scope = null
+    }
+
+    /** Screen ON (prof761 reinit): resume foreground-app polling + re-evaluate time windows. */
+    fun onScreenOn() {
+        screenOn = true
+        scope?.launch {
+            startAppPollIfNeeded()
+            evaluate(ContextCaller.TIME)
+        }
+    }
+
+    /** Screen OFF (prof753 hibernate): app polling is pointless with the display off. */
+    fun onScreenOff() {
+        screenOn = false
+        appJob?.cancel(); appJob = null
+    }
+
+    /** Called from the pipeline cycle: re-evaluate time-window rules (contexts_spec — prof764). */
+    fun onPipelineTick() {
+        scope?.launch { evaluate(ContextCaller.TIME) }
+    }
+
+    private suspend fun startAppPollIfNeeded() {
+        if (appJob?.isActive == true) return
+        if (!screenOn) return
+        val tokens = ContextSignalTokens.from(rulesProvider())
+        if (!tokens.usesApps) return // poll only when ≥1 app rule is configured (cost gate)
+        appJob = scope?.launch {
+            signalSource.foregroundAppFlow(APP_POLL_INTERVAL_MS).collect { pkg ->
+                pkg?.let { latestApp = it }
+                evaluate(ContextCaller.APP_CHANGED)
+            }
+        }
+    }
+
+    private suspend fun evaluate(caller: ContextCaller) = evalMutex.withLock {
+        val rules = rulesProvider()
+        val tokens = ContextSignalTokens.from(rules)
+
+        // PASS 1 — per-caller cooldown debounce.
+        val cooldown = caller.cooldownMs
+        val now = clock()
+        val last = lastEvalTime
+        if (cooldown > 0 && last != null && now - last < cooldown) return@withLock
+
+        val signals = signalSource.assemble(latestApp, latestBatt, latestPlug, latestWifi)
+
+        // PASS 2 — veto gates.
+        if (!shouldProceed(caller, signals, tokens)) return@withLock
+        lastEvalTime = now
+        recordState(signals)
+
+        // PASS 3/4 — pure decision.
+        val baseline = baselineProvider()
+        val knownProfiles = profileCatalog.names()
+        val resolution = ContextOverrideResolver.resolve(
+            rules = rules.map { it.toSpec() },
+            signals = signals,
+            overrideActive = baseline.contextOverride,
+            userProfile = userProfileName,
+            profileExists = { knownProfiles.contains(it) },
+        )
+        apply(resolution, baseline)
+    }
+
+    private fun shouldProceed(caller: ContextCaller, signals: ContextSignals, tokens: ContextSignalTokens): Boolean {
+        val midnightRollover = signals.dayOfWeek != lastDay && lastDay != -1
+        if (caller == ContextCaller.RESUME || midnightRollover) return true
+        return when (caller) {
+            ContextCaller.APP_CHANGED -> {
+                val isRuleActive = _activeContext.value != null
+                val isNonDefault = currentProfileName != null && currentProfileName != userProfileName
+                val appInCache = tokens.appPackages.contains(signals.app)
+                (isRuleActive || isNonDefault || appInCache) && signals.app != lastApp
+            }
+            ContextCaller.LOCATION -> tokens.usesLocation
+            ContextCaller.BATTERY ->
+                tokens.usesBattery && (signals.plugged != (lastPlug == 1) || abs(signals.batteryPercent - lastBatt) >= BATTERY_DELTA_THRESHOLD)
+            ContextCaller.WIFI -> tokens.usesWifi && signals.wifi != lastWifi
+            ContextCaller.TIME, ContextCaller.GENERAL, ContextCaller.RESUME -> true
+        }
+    }
+
+    private fun recordState(signals: ContextSignals) {
+        lastApp = signals.app
+        lastBatt = signals.batteryPercent
+        lastPlug = if (signals.plugged) 1 else 0
+        lastDay = signals.dayOfWeek
+        lastWifi = signals.wifi
+    }
+
+    private suspend fun apply(resolution: ContextResolution, baseline: AabSettings) {
+        _nextContextTime.value = resolution.nextContextTime
+
+        // Manual context lock (%AAB_ContextOverride): wake times refresh, profile switch skipped.
+        val target = resolution.targetProfile ?: return
+
+        val changed = target != currentProfileName
+        currentProfileName = target
+        _activeContext.value = resolution.activeContextName
+
+        _effective.value = if (resolution.activeContextName != null) {
+            // A rule won — swap the entire active profile (load-current-file, D-038(ii) simplification).
+            profileCatalog.profile(target)?.let { mergeProfile(baseline, it) } ?: baseline
+        } else {
+            // No match → revert to the user baseline profile.
+            baseline
+        }
+
+        // task43 act21: re-run Set Initial Brightness when the profile actually changed.
+        if (changed) onProfileChanged()
+    }
+
+    private companion object {
+        const val APP_POLL_INTERVAL_MS = 2500L
+        const val BATTERY_DELTA_THRESHOLD = 5
+    }
+}
+
+/** Caller identity drives the PASS 1 cooldown + PASS 2 veto branch (task43 L31-57, L204-240). */
+enum class ContextCaller(val cooldownMs: Long) {
+    RESUME(0L),
+    APP_CHANGED(500L),
+    BATTERY(30_000L),
+    LOCATION(8_000L),
+    WIFI(8_000L),
+    TIME(1_000L),
+    GENERAL(500L),
+}
+
+/** A point-in-time battery reading (decoupled from the platform `BatteryState` so the engine is JVM-testable). */
+data class BatterySignal(val percent: Int, val plugged: Boolean)
+
+/**
+ * Platform signal acquisition for the context engine. The Android impl wires the S7 readers
+ * (battery/wifi/foreground-app/location) and computes day-of-week + local seconds + solar times.
+ */
+interface ContextSignalSource {
+    fun batteryFlow(): Flow<BatterySignal>
+    fun wifiFlow(): Flow<String?>
+    fun foregroundAppFlow(intervalMs: Long): Flow<String?>
+
+    /** Assemble a full snapshot from the latest cached signal pieces + current clock/location/solar. */
+    suspend fun assemble(app: String, batteryPercent: Int, plugged: Boolean, wifi: String): ContextSignals
+}
+
+/** Resolves a profile NAME to its full [AabSettings]. S10 backs this with the built-in profiles. */
+interface ProfileCatalog {
+    suspend fun profile(name: String): AabSettings?
+    suspend fun names(): Set<String>
+}
+
+/**
+ * Overlay a context profile's parameter set onto the baseline. The fields swapped are exactly Tasker
+ * task626 `_ContextResume`'s 39-key snapshot (the LOAD_FILE parameter set); fields outside it
+ * (service enable, manual context lock, debug level, setup title, schema version, and the
+ * snapshot-omitted %AAB_ThreshDynamic) are preserved from the baseline.
+ */
+internal fun mergeProfile(baseline: AabSettings, profile: AabSettings): AabSettings = profile.copy(
+    serviceEnabled = baseline.serviceEnabled,
+    contextOverride = baseline.contextOverride,
+    debugLevel = baseline.debugLevel,
+    setupTitle = baseline.setupTitle,
+    schemaVersion = baseline.schemaVersion,
+    thresholdDynamic = baseline.thresholdDynamic,
+)

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/PipelineState.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/PipelineState.kt
@@ -55,4 +55,7 @@ sealed interface PipelineEvent {
 
     /** An external brightness write was detected as a manual override (prof755 / task567). */
     data class OverrideDetected(val observedBrightness: Int) : PipelineEvent
+
+    /** A context override swapped the active profile → re-run Set Initial Brightness (task43 act21). */
+    data object ContextChanged : PipelineEvent
 }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ContextRuleMapping.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ContextRuleMapping.kt
@@ -1,0 +1,50 @@
+package com.tideo.autobrightness.app.settings
+
+import com.tideo.autobrightness.domain.context.BatteryConstraint
+import com.tideo.autobrightness.domain.context.ContextRuleSpec
+import com.tideo.autobrightness.domain.context.LocationConstraint
+import com.tideo.autobrightness.domain.context.TimeRange
+
+/**
+ * Maps the app/storage [ContextRule] (S8, mirrors Tasker's contexts.json schema) onto the pure
+ * domain [ContextRuleSpec] consumed by `ContextOverrideResolver`. Keeps Android-free domain code
+ * decoupled from the serialization model.
+ */
+fun ContextRule.toSpec(): ContextRuleSpec = ContextRuleSpec(
+    id = id,
+    name = name,
+    profile = profile,
+    priority = priority,
+    apps = triggers.apps,
+    wifi = triggers.wifi,
+    battery = triggers.battery?.let { BatteryConstraint(min = it.min, max = it.max, onPower = it.onPower) },
+    location = triggers.location?.let { LocationConstraint(lat = it.lat, lon = it.lon, radius = it.radius) },
+    timeRange = triggers.timeRange?.takeIf { it.size >= 2 }?.let { TimeRange(start = it[0], end = it[1]) },
+    days = triggers.days,
+)
+
+/**
+ * The cheap signal-token pre-filter (`%AAB_ContextCache`, contexts_spec §2.1): which signal types
+ * any configured rule uses. Drives the watcher gates so we only run the full evaluator when a
+ * relevant signal type is actually in play.
+ */
+data class ContextSignalTokens(
+    val usesBattery: Boolean,
+    val usesLocation: Boolean,
+    val usesWifi: Boolean,
+    val usesApps: Boolean,
+    val usesTime: Boolean,
+    /** Deduplicated set of every app package referenced by any rule (task623 L93-103). */
+    val appPackages: Set<String>,
+) {
+    companion object {
+        fun from(rules: List<ContextRule>): ContextSignalTokens = ContextSignalTokens(
+            usesBattery = rules.any { it.triggers.battery != null },
+            usesLocation = rules.any { it.triggers.location != null },
+            usesWifi = rules.any { !it.triggers.wifi.isNullOrEmpty() },
+            usesApps = rules.any { !it.triggers.apps.isNullOrEmpty() },
+            usesTime = rules.any { !it.triggers.timeRange.isNullOrEmpty() },
+            appPackages = rules.flatMap { it.triggers.apps ?: emptyList() }.toSet(),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ContextRuleStore.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ContextRuleStore.kt
@@ -1,0 +1,42 @@
+package com.tideo.autobrightness.app.settings
+
+import androidx.datastore.core.DataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+/**
+ * Persistence + CRUD for context-override rules — the rebuild of Tasker task623 `_ContextManager`
+ * (contexts_spec §3). The single mutation entry point: upsert by [ContextRule.id] on save, rebuild
+ * the list excluding the id on delete.
+ *
+ * The dual RAM/disk cache dance of the original (contexts_spec §2) is unnecessary here: DataStore
+ * is the single, always-fresh source of truth, so there is no stale-cache failsafe to port (the
+ * daily reset's only real effect was forcing a disk reload, which a repository makes moot — D-014).
+ */
+class ContextRuleStore(private val dataStore: DataStore<ContextOverrideConfig>) {
+
+    fun rulesFlow(): Flow<List<ContextRule>> = dataStore.data.map { it.rules }
+
+    suspend fun rules(): List<ContextRule> = dataStore.data.first().rules
+
+    /** SAVE_CONTEXT: upsert by id (replace if present, else append). */
+    suspend fun save(rule: ContextRule) {
+        dataStore.updateData { current ->
+            val without = current.rules.filterNot { it.id == rule.id }
+            current.copy(rules = without + rule)
+        }
+    }
+
+    /** DELETE_CONTEXT: rebuild the list excluding [id]. */
+    suspend fun delete(id: String) {
+        dataStore.updateData { current ->
+            current.copy(rules = current.rules.filterNot { it.id == id })
+        }
+    }
+
+    /** Replace the whole set (import / bulk edit). */
+    suspend fun replaceAll(rules: List<ContextRule>) {
+        dataStore.updateData { it.copy(rules = rules) }
+    }
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ContextRulesSerializer.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ContextRulesSerializer.kt
@@ -1,0 +1,32 @@
+package com.tideo.autobrightness.app.settings
+
+import androidx.datastore.core.Serializer
+import java.io.InputStream
+import java.io.OutputStream
+import kotlinx.serialization.json.Json
+
+/**
+ * DataStore serializer for the persisted context-rule set ([ContextOverrideConfig], S8 storage model).
+ *
+ * This is the rebuild's source of truth for context rules (replacing Tasker's
+ * `Download/AAB/configs/contexts.json` + dual RAM caches — contexts_spec §2). Export to the legacy
+ * Tasker JSON-array format is available via [ContextOverrideConfig.toTaskerJson].
+ */
+object ContextRulesSerializer : Serializer<ContextOverrideConfig> {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        prettyPrint = true
+        encodeDefaults = false
+    }
+
+    override val defaultValue: ContextOverrideConfig = ContextOverrideConfig()
+
+    override suspend fun readFrom(input: InputStream): ContextOverrideConfig =
+        runCatching {
+            json.decodeFromString(ContextOverrideConfig.serializer(), input.readBytes().decodeToString())
+        }.getOrDefault(defaultValue)
+
+    override suspend fun writeTo(t: ContextOverrideConfig, output: OutputStream) {
+        output.write(json.encodeToString(ContextOverrideConfig.serializer(), t).encodeToByteArray())
+    }
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/storage/AppDataStores.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/storage/AppDataStores.kt
@@ -6,9 +6,17 @@ import androidx.datastore.dataStore
 import androidx.datastore.preferences.preferencesDataStore
 import com.tideo.autobrightness.app.settings.AabSettings
 import com.tideo.autobrightness.app.settings.AabSettingsSerializer
+import com.tideo.autobrightness.app.settings.ContextOverrideConfig
+import com.tideo.autobrightness.app.settings.ContextRulesSerializer
 
 val Context.settingsDataStore: DataStore<AabSettings> by dataStore(
     fileName = "aab_settings.json",
     serializer = AabSettingsSerializer,
 )
 val Context.serviceHealthDataStore by preferencesDataStore(name = "service_health")
+
+// Context-override rules (S10): the rebuild's store for the rule set (Tasker contexts.json + caches).
+val Context.contextRulesDataStore: DataStore<ContextOverrideConfig> by dataStore(
+    fileName = "aab_context_rules.json",
+    serializer = ContextRulesSerializer,
+)

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/ContextEngineTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/ContextEngineTest.kt
@@ -1,0 +1,168 @@
+package com.tideo.autobrightness.app.runtime
+
+import com.tideo.autobrightness.app.settings.AabSettings
+import com.tideo.autobrightness.app.settings.BatteryTrigger
+import com.tideo.autobrightness.app.settings.ContextRule
+import com.tideo.autobrightness.app.settings.ContextTriggers
+import com.tideo.autobrightness.app.settings.DefaultProfiles
+import com.tideo.autobrightness.domain.context.ContextSignals
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ContextEngineTest {
+
+    private val baseline = AabSettings(serviceEnabled = true, maxBrightness = 255)
+
+    private val videoStreamingRule = ContextRule(
+        id = "vid",
+        name = "Cinema",
+        profile = "Video Streaming",
+        priority = 10,
+        triggers = ContextTriggers(apps = listOf("com.netflix.mediaclient")),
+    )
+
+    private val batterySaverRule = ContextRule(
+        id = "bat",
+        name = "Low Battery",
+        profile = "Battery Saver",
+        priority = 5,
+        triggers = ContextTriggers(battery = BatteryTrigger(max = 20)),
+    )
+
+    private val catalog = object : ProfileCatalog {
+        override suspend fun profile(name: String): AabSettings? = DefaultProfiles.all[name]
+        override suspend fun names(): Set<String> = DefaultProfiles.all.keys
+    }
+
+    /** Fake source whose [assemble] returns its own mutable fields, so a test drives signals directly. */
+    private class FakeSignalSource(
+        var app: String = "",
+        var batteryPercent: Int = 50,
+        var plugged: Boolean = false,
+        var wifi: String = "",
+        var dayOfWeek: Int = 4,
+        var nowSecondsOfDay: Int = 12 * 3600,
+    ) : ContextSignalSource {
+        val battery = MutableSharedFlow<BatterySignal>(extraBufferCapacity = 16)
+        val wifi_ = MutableSharedFlow<String?>(extraBufferCapacity = 16)
+        val appFlow = MutableSharedFlow<String?>(extraBufferCapacity = 16)
+        override fun batteryFlow(): Flow<BatterySignal> = battery
+        override fun wifiFlow(): Flow<String?> = wifi_
+        override fun foregroundAppFlow(intervalMs: Long): Flow<String?> = appFlow
+        override suspend fun assemble(app: String, batteryPercent: Int, plugged: Boolean, wifi: String) =
+            ContextSignals(
+                app = this.app, batteryPercent = this.batteryPercent, plugged = this.plugged,
+                wifi = this.wifi, dayOfWeek = dayOfWeek, nowSecondsOfDay = nowSecondsOfDay,
+            )
+    }
+
+    private fun TestScope.engine(
+        rules: List<ContextRule>,
+        signalSource: FakeSignalSource,
+        baseline: AabSettings = this@ContextEngineTest.baseline,
+        clock: () -> Long = { 0L },
+        onChanged: () -> Unit = {},
+    ): Pair<ContextEngine, CoroutineScope> {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val engine = ContextEngine(
+            rulesProvider = { rules },
+            baselineProvider = { baseline },
+            profileCatalog = catalog,
+            signalSource = signalSource,
+            onProfileChanged = onChanged,
+            clock = clock,
+        )
+        return engine to scope
+    }
+
+    @Test
+    fun appMatch_swapsEntireProfileAndFiresOnChanged() = runTest {
+        var changes = 0
+        val src = FakeSignalSource(app = "com.netflix.mediaclient")
+        val (engine, scope) = engine(listOf(videoStreamingRule), src, onChanged = { changes++ })
+        engine.start(scope)
+        advanceUntilIdle()
+
+        val eff = engine.effectiveSettings()
+        assertEquals("Cinema", engine.activeContext.value)
+        // The whole profile swaps: Video Streaming carries dimmingEnabled=true / threshold 20.
+        assertEquals(true, eff.dimmingEnabled)
+        assertEquals(20, eff.dimmingThreshold)
+        // Service-level flags stay from the baseline (outside task626's 39-key snapshot).
+        assertEquals(true, eff.serviceEnabled)
+        assertTrue(changes >= 1, "profile change must trigger onProfileChanged")
+        scope.cancel()
+    }
+
+    @Test
+    fun noMatch_revertsToBaseline() = runTest {
+        val src = FakeSignalSource(app = "com.other.app")
+        val (engine, scope) = engine(listOf(videoStreamingRule), src)
+        engine.start(scope)
+        advanceUntilIdle()
+        assertNull(engine.activeContext.value)
+        assertEquals(baseline, engine.effectiveSettings())
+        scope.cancel()
+    }
+
+    @Test
+    fun batteryVeto_subFivePercentChangeDoesNotReEvaluate() = runTest {
+        var now = 0L
+        val src = FakeSignalSource(batteryPercent = 50)
+        val (engine, scope) = engine(listOf(batterySaverRule), src, clock = { now })
+        engine.start(scope)
+        advanceUntilIdle()
+        assertNull(engine.activeContext.value) // 50 > 20 → no match; lastBatt recorded = 50.
+
+        // Past the 30s battery cooldown, drop to 48% (Δ2 < 5) → vetoed, no re-eval.
+        now = 40_000L
+        src.batteryPercent = 48
+        src.battery.emit(BatterySignal(48, plugged = false))
+        advanceUntilIdle()
+        assertNull(engine.activeContext.value, "sub-5% battery change must be vetoed")
+
+        // Drop to 15% (Δ35 ≥ 5) → re-evaluate; the battery rule wins.
+        now = 80_000L
+        src.batteryPercent = 15
+        src.battery.emit(BatterySignal(15, plugged = false))
+        advanceUntilIdle()
+        assertEquals("Low Battery", engine.activeContext.value)
+        scope.cancel()
+    }
+
+    @Test
+    fun overrideActive_skipsProfileSwitch() = runTest {
+        val lockedBaseline = baseline.copy(contextOverride = true)
+        val src = FakeSignalSource(app = "com.netflix.mediaclient")
+        val (engine, scope) = engine(listOf(videoStreamingRule), src, baseline = lockedBaseline)
+        engine.start(scope)
+        advanceUntilIdle()
+        // %AAB_ContextOverride latched → no switch even though the app rule matches.
+        assertNull(engine.activeContext.value)
+        assertEquals(lockedBaseline, engine.effectiveSettings())
+        scope.cancel()
+    }
+
+    @Test
+    fun priorityWins_amongMultipleMatches() = runTest {
+        // Both rules match (app + low battery); Video Streaming has the higher priority.
+        val src = FakeSignalSource(app = "com.netflix.mediaclient", batteryPercent = 10)
+        val (engine, scope) = engine(listOf(batterySaverRule, videoStreamingRule), src)
+        engine.start(scope)
+        advanceUntilIdle()
+        assertEquals("Cinema", engine.activeContext.value)
+        scope.cancel()
+    }
+}

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/settings/ContextRuleStoreTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/settings/ContextRuleStoreTest.kt
@@ -1,0 +1,72 @@
+package com.tideo.autobrightness.app.settings
+
+import androidx.datastore.core.DataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.runTest
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class ContextRuleStoreTest {
+
+    /** In-memory DataStore for pure-JVM CRUD testing (no Android/file plumbing). */
+    private class FakeDataStore<T>(initial: T) : DataStore<T> {
+        private val state = MutableStateFlow(initial)
+        override val data: Flow<T> = state
+        override suspend fun updateData(transform: suspend (t: T) -> T): T {
+            val updated = transform(state.value)
+            state.update { updated }
+            return updated
+        }
+    }
+
+    private fun store() = ContextRuleStore(FakeDataStore(ContextOverrideConfig()))
+
+    private fun rule(id: String, profile: String = "P_$id") =
+        ContextRule(id = id, name = "Rule $id", profile = profile)
+
+    @Test
+    fun save_appendsNewRule() = runTest {
+        val s = store()
+        s.save(rule("a"))
+        s.save(rule("b"))
+        assertEquals(listOf("a", "b"), s.rules().map { it.id })
+    }
+
+    @Test
+    fun save_upsertsExistingIdInPlaceableSet() = runTest {
+        val s = store()
+        s.save(rule("a", profile = "Old"))
+        s.save(rule("a", profile = "New"))
+        val rules = s.rules()
+        assertEquals(1, rules.size, "same id must upsert, not duplicate")
+        assertEquals("New", rules.single().profile)
+    }
+
+    @Test
+    fun delete_removesById() = runTest {
+        val s = store()
+        s.save(rule("a"))
+        s.save(rule("b"))
+        s.delete("a")
+        assertEquals(listOf("b"), s.rules().map { it.id })
+    }
+
+    @Test
+    fun replaceAll_overwritesWholeSet() = runTest {
+        val s = store()
+        s.save(rule("a"))
+        s.replaceAll(listOf(rule("x"), rule("y")))
+        assertEquals(listOf("x", "y"), s.rulesFlow().first().map { it.id })
+    }
+
+    @Test
+    fun taskerJsonExport_isBareArray() {
+        val config = ContextOverrideConfig(rules = listOf(rule("a")))
+        val json = config.toTaskerJson()
+        assertTrue(json.trimStart().startsWith("["), "Tasker interop export must be a bare JSON array")
+    }
+}

--- a/docs/rebuild/PARITY_CHECKLIST.md
+++ b/docs/rebuild/PARITY_CHECKLIST.md
@@ -20,15 +20,15 @@ filled by S1/S2 during extraction.
 | prof759 Proximity Detection → task545 | L300 | | pending |
 | prof760 Monitor Ambient Light → task554 (incl. ConditionList gate) | L318 | ProfileGates.monitorAmbientLightGate + truth-table test + BrightnessPipelineController (S9a) | ported |
 | prof761 Initialize (Display On) → task618 | L386 | runtime/BrightnessPipelineController.reinit/setInitialBrightness (S9a) | ported |
-| prof762 Context: App Changed → task43 | L398 | extraction/contexts_spec.md (S2) | pending |
-| prof763 Context: Battery Changed → task43 | L456 | extraction/contexts_spec.md (S2) | pending |
-| prof764 Context: Time Changed → task43 | L500 | extraction/contexts_spec.md (S2) | pending |
-| prof765 Context: Location Listener → task630 | L541 | extraction/contexts_spec.md (S2) | pending |
-| prof766 Context: Location Refresher → task631 | L579 | extraction/contexts_spec.md (S2) | pending |
-| prof767 Context: Location Changed → task43 | L628 | extraction/contexts_spec.md (S2) | pending |
-| prof768 Context: WiFi (Dis)connected → task43 | L676 | extraction/contexts_spec.md (S2) | pending |
+| prof762 Context: App Changed → task43 | L398 | runtime/ContextEngine (S10 — foreground-app poll → APP_CHANGED veto → ContextOverrideResolver); AndroidContextSignalSource | ported (engine; rule UI S12) |
+| prof763 Context: Battery Changed → task43 | L456 | runtime/ContextEngine (S10 — BatteryStateReader flow → BATTERY veto Δ≥5%/plug-flip → resolver) | ported (engine; rule UI S12) |
+| prof764 Context: Time Changed → task43 | L500 | runtime/ContextEngine (S10 — time-window eval on pipeline ticks; nextContextTime computed by resolver) | ported (engine; rule UI S12) |
+| prof765 Context: Location Listener → task630 | L541 | runtime/AndroidContextSignalSource LocationReader (passive last-known); persistent listener/backoff (task630/631) not ported — coarse passive read only (D-042) | partial (passive location; listener S12/S14) |
+| prof766 Context: Location Refresher → task631 | L579 | not ported — adaptive location refresher/zombie-listener watchdog out of S10 scope (D-042) | deferred (S12/S14) |
+| prof767 Context: Location Changed → task43 | L628 | runtime/ContextEngine (S10 — LOCATION caller evaluates when a rule uses [LOC]) | ported (engine; rule UI S12) |
+| prof768 Context: WiFi (Dis)connected → task43 | L676 | runtime/ContextEngine (S10 — WifiInfoReader SSID flow → WIFI veto on SSID change → resolver) | ported (engine; rule UI S12) |
 | prof769 Panic (Reset) → task528 | L722 | runtime/BrightnessPipelineController.panic + notification action (S9a) | ported |
-| prof8 Context: Reset Serialized Cache → task26 | L744 | extraction/contexts_spec.md (S2) | pending |
+| prof8 Context: Reset Serialized Cache → task26 | L744 | N/A — DataStore is the single fresh source of truth; the RAM/disk cache reset failsafe is moot (D-042) | dropped (cache obsolete) |
 
 ## Pipeline & feature task clusters (~25)
 
@@ -52,14 +52,14 @@ filled by S1/S2 during extraction.
 | Panic reset: 528 | | runtime/BrightnessPipelineController.emergencyStop + notification Reset action; Gate-1 G1-F4 fix: panic is a FULL STOP (restore 255 + drop dimming + %AAB_Service=Off + service teardown), not a pausable state (D-041) | ported |
 | Init/defaults: 570 Initialize AAB Defaults | | | pending |
 | Circadian dynamic scale: 90 (+ polar handling) | | SolarCalculator.kt + DynamicScaleEngine.kt (S6 domain, golden-tested circadian.csv 576 rows, CircadianParityTest + 4 polar assertions); BrightnessEngine delegates computeDynamicScale (D-031) | ported |
-| Context evaluation: 43, 623, 624, 625, 626, 628, 630, 631, 633, 105, 26 | | S2 extracted → contexts_spec.md | pending |
+| Context evaluation: 43, 623, 624, 625, 626, 628, 630, 631, 633, 105, 26 | | S10: ContextOverrideResolver (task43 PASS3/4, 21-case matrix test) + ContextEngine (PASS1 cooldown/PASS2 veto) + ContextRuleStore (task623 upsert/delete CRUD); 624/630/631 location-listener subsystem deferred (D-042) | ported (eval+CRUD; location-listener S12/S14) |
 | Privilege detection/grant: 378, 643, 563 | | S2 extracted → features_spec.md; platform layer: AndroidPrivilegeManager + ShizukuGrantGateway stub (S7); UI wiring S11 | platform-ported (S7) |
 | QS tile: 551, 552 | | S2 extracted → features_spec.md; runtime/BrightnessTileService (S9b — toggles serviceEnabled + start/stop FGS via AutoBrightnessRuntime; manifest QS_TILE entry + BIND_QUICK_SETTINGS_TILE); BrightnessTileServiceTest instantiation smoke | ported (toggle) |
 | Foreground notification: 584, 692 | | S2 extracted → features_spec.md; runtime/AmbientMonitoringService live lux/target notification + Pause/Resume/Reset/Disable actions (S9a) | ported |
 | Curve suggestion wizard: 38, 655 | | CurveSuggestionEngine.kt (S6 domain, golden-tested wizard.csv 12 rows, WizardParityTest); applyToLiveCurve = task655 | ported |
 | Formula validation: 583, 707 | | S2 extracted → features_spec.md; SettingsValidator.kt (S8 — 5 rules: form2A<0, form3A<0, form2C>zone1End advisory + predicted-brightness@1000lux<25 safety) | ported |
 | Power draw calibration: 524 | | S2 extracted → features_spec.md | pending |
-| Profiles/import/export/defaults: 592, 637, 622 | | S2 extracted → features_spec.md; DefaultProfiles.kt (S8 — 5 built-in profiles from task592); AabSettings v2 + migration + TaskerLegacyProfileSerializer updated (S8); ContextOverrideRules.kt storage model (S8); wiring to disk S10/S12 | ported (schema+defaults; disk wiring S10/S12) |
+| Profiles/import/export/defaults: 592, 637, 622 | | S2 extracted → features_spec.md; DefaultProfiles.kt (S8 — 5 built-in profiles from task592); AabSettings v2 + migration + TaskerLegacyProfileSerializer updated (S8); ContextOverrideRules.kt storage model (S8); context-rule disk wiring done S10 (ContextRuleStore/DataStore); profile import/export disk wiring S12 | ported (schema+defaults+context-rule store; profile import/export S12) |
 | Debug tooling: 634, 635 | | S2 extracted → features_spec.md | pending |
 | Misc UI plumbing tasks (scene-resize 620, exits 656, toggles 547/553/555/558/560/576/587/589/638/648/649, chartjs cache 581, logo 619, color 639/379/579/652, about/license/guide 380/401/512, updates 706, experiments 540/541/542/381/382) | | S2 extracted → screen_map.md (scene dispositions) | pending |
 | **Anonymous scene-handler tasks (168 unnamed**, incl. 34 `keyTask` back-key handlers) | various | S3.5 census → extraction/tasks/anonymous_handlers.md | pending (S12/S13: every row ported or dropped(reason)) |
@@ -98,7 +98,7 @@ filled by S1/S2 during extraction.
 | task105 L8906 · _GetWifiNoLocation | ✓ S1 | | | pending |
 | task378 L9468 · _PrivilegeDetection | ✓ S1 | | | pending |
 | task38 L9921 · _SuggestCurveParameters | ✓ S1 | ✓ S6 (delegate) | CurveSuggestionEngine.kt (S6) | ported |
-| task43 L12091 · _EvaluateContexts | ✓ S1 | | | pending |
+| task43 L12091 · _EvaluateContexts | ✓ S1 | | domain/context/ContextOverrideResolver.kt + app/runtime/ContextEngine.kt (S10) | ported |
 | task524 L14246 · _CalibratePowerDraw | ✓ S1 | | | pending |
 | task535 L15204 · Lux Smoothing | ✓ S1 | ✓ S4 | BrightnessEngine.smoothLux (S5) | ported |
 | task543 L15878 · Calculate Animation | ✓ S1 | ✓ S4 | BrightnessEngine.calculateAnimation (S5) | ported |
@@ -113,9 +113,9 @@ filled by S1/S2 during extraction.
 | task592 L24132 · _CreateDefaultProfiles | ✓ S1 | | | pending |
 | task618 L25826+L26096 · Set Initial Brightness (×2) | ✓ S1 | ✓ S4 | InitialBrightness.kt (S5) | ported |
 | task620 L26400 · _AdaptiveBrightnessSceneSize | ✓ S1 | | | pending |
-| task623 L26926 · _ContextManager | ✓ S1 | | | pending |
+| task623 L26926 · _ContextManager | ✓ S1 | | app/settings/ContextRuleStore.kt (S10 — upsert/delete CRUD) | ported |
 | task625 L27185 · _AppPicker | ✓ S1 | | | pending |
-| task626 L27355 · _ContextResume | ✓ S1 | | | pending |
+| task626 L27355 · _ContextResume | ✓ S1 | | mergeProfile() 39-key snapshot (S10); RESUME caller (cooldown 0/forced eval) | ported (snapshot+caller) |
 | task630 L27585+L27817 · _ContextLocnListener (×2) | ✓ S1 | | | pending |
 | task631 L27939+L28432 · _ContextF5NetLoc (×2) | ✓ S1 | | | pending |
 | task633 L28827 · _GetWifiForContext | ✓ S1 | | | pending |

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -27,11 +27,20 @@ next session does not know it.
 
 | Gate 1 punch-list (findings triage) | 2026-06-13 | Opus/high | DONE | (see push) | Triaged the 6 human Gate-1 findings (D-041). Fixed 3 genuine runtime bugs + 1 sub-bug: **G1-F1** crash — `AndroidScreenBrightnessController.write/forceManualMode/restoreMode` + `AndroidSecureDimmingController` now swallow `SecurityException` (unprivileged install degrades, no process crash); MainActivity requests POST_NOTIFICATIONS at launch; service notification shows a "Grant Modify system settings" hint when `!canWrite`. **G1-F3** Disable/UI desync — SettingsViewModel now collects `settingsDataStore.data` as source of truth so the notification's serviceEnabled=false propagates to the toggle. **G1-F4** panic/resume zombie — task528 panic is a FULL STOP not a pausable state: `controller.emergencyStop()` (restore 255 + drop dimming + cancel jobs) → service persists serviceEnabled=false + stopForeground/stopSelf (removed PipelineEvent.Panic/panicInternal). **G1-F5** sub-bug — AppModule tierProvider now `refresh()`es each cycle so a post-start Shizuku/ADB grant is seen. **G1-F2/F5 deferred to S12 (owner decision):** DetectOverrides + DimmingEnabled default Off (Tasker task570 parity, defaults_audit confirmed) and have no UI until S12 — expected-not-bugs. New test: BrightnessPipelineControllerTest.emergencyStop_restoresMaxBrightnessAndFullStops. Full ladder GREEN (59 app unit tests). No compaction. |
 
+| S10 context override engine | 2026-06-13 | Opus/medium | DONE | (see push) | Context system ported (D-042). Domain: `context/ContextOverrideResolver.kt` (pure task43 PASS3/4 — match+rank precedence priority→specificity→array-order, overnight time ranges w/ yesterday membership, SUNRISE/SUNSET tokens, haversine location gate, nextContextTime HH.MM) + `context/ContextModel.kt` (ContextRuleSpec/ContextSignals/ContextResolution); 21-case 1:1 matrix test. App: `runtime/ContextEngine.kt` (PASS1 per-caller cooldown + PASS2 signal-change veto + %AAB_ContextState, applies override by swapping the ENTIRE profile via mergeProfile = task626 39-key snapshot, fires onContextChanged→task43 act21 re-init); `runtime/AndroidContextSignalSource.kt` (S7 readers + Calendar day/seconds + SolarCalculator local sunrise/sunset); `runtime/AppProfileCatalog.kt` (built-in profiles; S12 extends); `settings/ContextRuleStore.kt` (task623 upsert/delete CRUD over new contextRulesDataStore) + `ContextRulesSerializer.kt` + `ContextRuleMapping.kt` (app→domain spec + signal tokens). Wired: AppModule→createRuntime composes engine+pipeline (settingsProvider=engine.effectiveSettings); BrightnessPipelineController gains ContextChanged event→reapplyProfile; AmbientMonitoringService starts engine, screen on/off→engine, pipeline-tick→time re-eval, notification subText = active context. Tests: ContextOverrideResolverTest(21), ContextEngineTest(5, fakes), ContextRuleStoreTest(5). Full ladder GREEN: `:domain:test :platform:test :app:testDebugUnitTest :app:assembleDebug :app:lintDebug`. No compaction. |
+
 Status values: DONE · PARTIAL · BLOCKED (see failure protocol in CLAUDE.md).
 
 ## Current state
 
-S1 through S9b DONE → **GATE 1 READY** (human on-device verification next). Build is GREEN across
+S1 through S9b DONE + **GATE 1 PASSED**; **S10 (context override engine) DONE**. The runtime now
+swaps the entire active brightness profile on app/wifi/battery/time/location context matches: the
+golden-tested domain `ContextOverrideResolver` (task43 PASS3/4 precedence) is driven by the app
+`ContextEngine` (cooldown/veto + S7 readers), which feeds the pipeline its effective settings and
+re-runs Set Initial Brightness on every switch. Context rules persist via `ContextRuleStore`
+(DataStore). S11 (UI shell) is the remaining parallel-window-C segment; rule-editing UI is S12.
+
+(historical) S1 through S9b DONE → GATE 1 READY. Build is GREEN across
 the full ladder: `:domain:test`, `:platform:test`, `:app:testDebugUnitTest`, `:app:assembleDebug`,
 `:app:lintDebug`. The runtime is the real sensor-event-driven Tasker pipeline: BrightnessPipelineController
 owns all runtime state and drives a single serialized cycle (drop-not-queue MainLoop mutex); AnimationRunner
@@ -49,7 +58,7 @@ AppModule is now the real DI root.
   core loop (sensor → animate, slider → pause/resume, screen off/on → reinit, reboot → self-start,
   notification actions; optionally grant WRITE_SECURE_SETTINGS → super dimming engages below threshold).
   Findings → "Gate findings" below.
-- Then parallel window C: **S10** (context override engine) ∥ **S11** (UI shell + onboarding).
+- Parallel window C: **S10** (context override engine) DONE ∥ **S11** (UI shell + onboarding) — S11 next.
 - Carried for S12 (D-040): unprivileged overlay dimming (task698 DC-like / 653/654) is NOT wired
   (S9b did the ELEVATED secure path only); DimDynamic (circadian dim strength, task646 ScalingUse
   branch) passes null pending real solar windows (D-039d); proximity damp (task545) still unwired.
@@ -499,7 +508,40 @@ Seeded by the S0 audit (details in CLAUDE.md "Facts & corrections ledger"):
   surface the DetectOverrides toggle so this is verifiable at Gate 2.
   (Affects S11, S12, Gate 2.)
 
-Append new entries as D-042, D-043, … with which segments they affect.
+- D-042: S10 CONTEXT-OVERRIDE decisions (sanctioned by the S10 brief + extraction; flagged for S12/S14).
+  (a) **Override = whole-profile swap, NOT scale/min/max.** The S10 brief's parenthetical "(scale/min/
+  max/disable per spec)" predates the S2 correction; contexts_spec §4 (authoritative) + D-014 say
+  `_ProfileManager LOAD_FILE` replaces the entire curve/threshold/anim/dynamic/dimming parameter set.
+  Implemented as `mergeProfile(baseline, profile)` overlaying exactly task626's 39-key snapshot; fields
+  OUTSIDE it (serviceEnabled, contextOverride, debugLevel, setupTitle, schemaVersion, and the
+  snapshot-omitted thresholdDynamic) stay from the baseline so a profile can't disable the service.
+  (b) **DataStore replaces Tasker's dual RAM/disk cache + prof8 daily reset.** `ContextRuleStore`
+  (DataStore<ContextOverrideConfig>) is a single always-fresh source of truth, so contexts_spec §2's
+  `%AAB_ContextCache`/`%AAB_ContextJSONCache` and prof8/task26's 03:00 reset (whose only effect was
+  forcing a stale-RAM→disk reload) are obsolete — prof8 row marked dropped(cache obsolete). Solar
+  times are recomputed fresh each eval (AndroidContextSignalSource), so the daily-reset failsafe has no
+  surviving purpose. The cheap signal-token pre-filter (`%AAB_ContextCache` tokens) IS kept, as
+  `ContextSignalTokens`, driving the PASS2 veto + app-poll gate.
+  (c) **`%AAB_ProfileUser` baseline = the DataStore AabSettings; its NAME defaults "Default".** The
+  rebuild has no stored user-profile-name field (D-038(ii)); no-match always reverts to the baseline
+  settings regardless of name. userProfileName="Default" only feeds the resolver's fallback
+  existence-check + the APP_CHANGED isNonDefault veto. S12 (profile save/load) should track the real
+  active user-profile name + extend AppProfileCatalog with user-saved profiles (currently built-ins
+  only — an unknown rule.profile name resolves null → engine keeps baseline, a safe degrade).
+  (d) **Location is passive-only.** AndroidContextSignalSource uses LocationReader.lastKnownLocation
+  (PASSIVE_PROVIDER); task630/631's persistent LocationListener + adaptive backoff/zombie-listener
+  watchdog + the Variable-Set prof767 trigger machinery are NOT ported (prof766 deferred; prof765
+  partial). LOCATION-caller eval still fires on the WIFI/battery/app signal edges and pipeline ticks.
+  Deferred to S12/S14 if device testing shows passive last-known is too stale.
+  (e) **Time scheduling approximated by pipeline-tick re-eval**, not prof764's exact self-scheduling
+  Time context at `%AAB_NextContextTime`. nextContextTime IS computed (resolver) + exposed as a
+  StateFlow; ContextEngine.onPipelineTick (TIME caller, 1s cooldown) re-evaluates each accepted cycle.
+  Acceptable: time-window membership is checked on every cycle anyway; S12 may add an exact alarm.
+  (f) **PASS1 cooldown lastEvalTime is null until the first eval** (not 0) so a freshly-started engine
+  always evaluates once regardless of clock value (the 0-init would have blocked the seed eval when
+  clock≈0; harmless in prod but a real edge). (Affects S12, S14.)
+
+Append new entries as D-043, D-044, … with which segments they affect.
 
 ## Blockers
 

--- a/domain/src/main/kotlin/com/tideo/autobrightness/domain/context/ContextModel.kt
+++ b/domain/src/main/kotlin/com/tideo/autobrightness/domain/context/ContextModel.kt
@@ -1,0 +1,80 @@
+package com.tideo.autobrightness.domain.context
+
+/**
+ * Pure domain mirror of one context-override rule (contexts_spec §2.3). The app-side storage model
+ * (`ContextRule`/`ContextTriggers`, S8) maps onto this for resolution; domain stays Android-free.
+ *
+ * A present trigger field is an active constraint; null = "this dimension is not used by the rule".
+ */
+data class ContextRuleSpec(
+    val id: String,
+    val name: String,
+    /** Profile file name to load when this rule wins. */
+    val profile: String,
+    /** Precedence integer — higher wins (D-014). Defaults to 0. */
+    val priority: Int = 0,
+    val apps: List<String>? = null,
+    val wifi: List<String>? = null,
+    val battery: BatteryConstraint? = null,
+    val location: LocationConstraint? = null,
+    val timeRange: TimeRange? = null,
+    /** Calendar.DAY_OF_WEEK values 1=Sun..7=Sat; null/empty means all days. */
+    val days: List<Int>? = null,
+)
+
+/** Battery trigger: `min ≤ batt ≤ max` and (onPower == plugged) when present (task43 L375-381). */
+data class BatteryConstraint(
+    val min: Int? = null,
+    val max: Int? = null,
+    val onPower: Boolean? = null,
+)
+
+/** Location trigger: within [radius] metres of (lat,lon) (task43 L383-390). */
+data class LocationConstraint(
+    val lat: Double,
+    val lon: Double,
+    val radius: Double,
+)
+
+/** Start/end tokens: "HH:MM" | "SUNRISE" | "SUNSET". start > end ⇒ overnight (task43 L314-354). */
+data class TimeRange(
+    val start: String,
+    val end: String,
+)
+
+/**
+ * The current environment snapshot the resolver matches against. All time-of-day values are LOCAL
+ * seconds-of-day; the app layer is responsible for the UTC→local shift of solar times (task43
+ * L77-80) and for reading Calendar.DAY_OF_WEEK.
+ */
+data class ContextSignals(
+    val app: String = "",
+    val lat: Double = 0.0,
+    val lon: Double = 0.0,
+    val batteryPercent: Int = 0,
+    val plugged: Boolean = false,
+    /** Calendar.DAY_OF_WEEK 1=Sun..7=Sat. */
+    val dayOfWeek: Int = 1,
+    /** Local seconds since midnight. */
+    val nowSecondsOfDay: Int = 0,
+    val wifi: String = "",
+    /** Local seconds-of-day for SUNRISE/SUNSET tokens (defaults 06:00/18:00 per task43 L67/72). */
+    val sunriseLocalSecs: Long = 21_600L,
+    val sunsetLocalSecs: Long = 64_800L,
+)
+
+/**
+ * Resolution outcome.
+ *
+ * @param targetProfile the profile to apply, or **null** when a manual context override is active
+ *   (PASS 4 skips the switch). A non-null value is always set otherwise (winner or baseline fallback).
+ * @param activeContextName the winning rule's name (`%AAB_ActiveContext`), or null on no-match/override.
+ * @param matchedRuleId the winning rule's id, or null.
+ * @param nextContextTime nearest future endpoint as "HH.MM" for prof764 scheduling, or null.
+ */
+data class ContextResolution(
+    val targetProfile: String?,
+    val activeContextName: String?,
+    val matchedRuleId: String?,
+    val nextContextTime: String?,
+)

--- a/domain/src/main/kotlin/com/tideo/autobrightness/domain/context/ContextOverrideResolver.kt
+++ b/domain/src/main/kotlin/com/tideo/autobrightness/domain/context/ContextOverrideResolver.kt
@@ -1,0 +1,210 @@
+package com.tideo.autobrightness.domain.context
+
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * Pure decision engine for the context-override system — the Kotlin port of task43
+ * `_EvaluateContexts V2` PASS 3 (match + rank) and PASS 4 (output + next wake time).
+ *
+ * Tasker: task43 `_EvaluateContexts V2` Java L12093 (`extraction/java/task43_1_evaluatecontexts-v2.java`),
+ * semantics in `extraction/contexts_spec.md` §4.
+ *
+ * What is and isn't here:
+ *  - PASS 1 (per-caller cooldown debounce) and PASS 2 (signal-change veto gates) are stateful,
+ *    clock- and persisted-state-driven scheduling concerns → they live in the app-side ContextEngine.
+ *  - PASS 3/4 are the precedence/merge matrix and are pure → here, with a 1:1 unit-test matrix.
+ *
+ * Precedence (contexts_spec §4, D-014): among matching rules, highest [ContextRuleSpec.priority]
+ * wins; ties broken by higher specificity (# of trigger dimensions present on the match path);
+ * remaining ties keep array order (first seen). `priority` defaults to 0.
+ *
+ * An override **swaps the entire active profile** (contexts_spec §4 "What an override actually
+ * CHANGES") — it is not a scale/min/max modifier. The app layer loads the winning profile's full
+ * parameter set; this resolver only names the winner.
+ */
+object ContextOverrideResolver {
+
+    /** Mean Earth radius (m) for the great-circle distance used by the location trigger. */
+    private const val EARTH_RADIUS_M = 6_371_000.0
+    private const val SECONDS_PER_DAY = 86_400L
+
+    /**
+     * @param rules ordered rule list (array order is the final tie-break, faithful to contexts.json).
+     * @param signals the current environment snapshot (already resolved to LOCAL seconds-of-day etc.).
+     * @param overrideActive `%AAB_ContextOverride == "true"` — a manual context lock. When set, the
+     *   profile switch is skipped entirely (PASS 4 else branch) but wake times are still computed.
+     * @param userProfile `%AAB_ProfileUser` — the user's baseline profile name (no-match fallback).
+     * @param profileExists existence probe for the fallback profile file (act 433-437); when the
+     *   user's saved profile is gone the fallback collapses to "Default".
+     */
+    fun resolve(
+        rules: List<ContextRuleSpec>,
+        signals: ContextSignals,
+        overrideActive: Boolean = false,
+        userProfile: String = "Default",
+        profileExists: (String) -> Boolean = { true },
+    ): ContextResolution {
+        var winner: ContextRuleSpec? = null
+        var highestPriority = -1
+        var highestSpecificity = -1
+        val wakeTimes = ArrayList<Long>()
+
+        for (rule in rules) {
+            var isMatch = true
+            var specificity = 0
+
+            val hasDays = rule.days != null
+            val activeDays: List<Int> = rule.days ?: emptyList()
+
+            val hasTime = rule.timeRange != null
+            var timeDayMatch = true
+
+            if (hasTime) {
+                val range = rule.timeRange!!
+                val start = resolveTimeToken(range.start, signals)
+                val end = resolveTimeToken(range.end, signals)
+
+                // wakeTimes collects EVERY rule's endpoints (before the match check) — task43 L341-342.
+                wakeTimes.add(start)
+                wakeTimes.add(end)
+
+                val activeToday = activeDays.isEmpty() || activeDays.contains(signals.dayOfWeek)
+                if (start <= end) {
+                    if (!activeToday || signals.nowSecondsOfDay < start || signals.nowSecondsOfDay > end) {
+                        timeDayMatch = false
+                    }
+                } else {
+                    // Overnight range: the post-midnight tail belongs to YESTERDAY's membership.
+                    val prevDay = if (signals.dayOfWeek == 1) 7 else signals.dayOfWeek - 1
+                    val activeYesterday = activeDays.isEmpty() || activeDays.contains(prevDay)
+                    val matchToday = activeToday && signals.nowSecondsOfDay >= start
+                    val matchYest = activeYesterday && signals.nowSecondsOfDay <= end
+                    if (!matchToday && !matchYest) timeDayMatch = false
+                }
+                specificity++
+                if (hasDays) specificity++
+            } else if (hasDays) {
+                if (!activeDays.contains(signals.dayOfWeek)) timeDayMatch = false
+                specificity++
+            }
+
+            if (!timeDayMatch) isMatch = false
+
+            if (isMatch && rule.apps != null) {
+                if (!rule.apps.contains(signals.app)) isMatch = false
+                specificity++
+            }
+
+            if (isMatch && rule.battery != null) {
+                val batt = rule.battery
+                if (batt.min != null && signals.batteryPercent < batt.min) isMatch = false
+                if (isMatch && batt.max != null && signals.batteryPercent > batt.max) isMatch = false
+                if (isMatch && batt.onPower != null && batt.onPower != signals.plugged) isMatch = false
+                specificity++
+            }
+
+            if (isMatch && rule.location != null) {
+                val loc = rule.location
+                val dist = distanceMeters(loc.lat, loc.lon, signals.lat, signals.lon)
+                if (dist > loc.radius) isMatch = false
+                specificity++
+            }
+
+            if (isMatch && rule.wifi != null) {
+                if (rule.wifi.none { signals.wifi == it.trim() }) isMatch = false
+                specificity++
+            }
+
+            if (isMatch) {
+                val priority = rule.priority
+                val newWinner = priority > highestPriority ||
+                    (priority == highestPriority && specificity > highestSpecificity)
+                if (newWinner) {
+                    highestPriority = priority
+                    highestSpecificity = specificity
+                    winner = rule
+                }
+            }
+        }
+
+        val nextContextTime = nextWakeTime(wakeTimes, signals.nowSecondsOfDay)
+
+        // PASS 4: when a manual context lock is active, skip the switch (only wake times refresh).
+        if (overrideActive) {
+            return ContextResolution(
+                targetProfile = null,
+                activeContextName = null,
+                matchedRuleId = null,
+                nextContextTime = nextContextTime,
+            )
+        }
+
+        if (winner != null) {
+            return ContextResolution(
+                targetProfile = winner.profile,
+                activeContextName = winner.name,
+                matchedRuleId = winner.id,
+                nextContextTime = nextContextTime,
+            )
+        }
+
+        // No match → fall back to the user's baseline profile; collapse to Default if it is gone.
+        val fallback = userProfile.ifEmpty { "Default" }
+        val target = if (profileExists(fallback)) fallback else "Default"
+        return ContextResolution(
+            targetProfile = target,
+            activeContextName = null,
+            matchedRuleId = null,
+            nextContextTime = nextContextTime,
+        )
+    }
+
+    /** Resolve a time token ("HH:MM" | "SUNRISE" | "SUNSET") to local seconds-of-day. */
+    private fun resolveTimeToken(token: String, signals: ContextSignals): Long = when (token) {
+        "SUNRISE" -> signals.sunriseLocalSecs
+        "SUNSET" -> signals.sunsetLocalSecs
+        else -> {
+            val parts = token.split(":")
+            parts[0].trim().toLong() * 3600 + parts[1].trim().toLong() * 60
+        }
+    }
+
+    /**
+     * Nearest future endpoint as "HH.MM" (drives prof764's self-scheduling Time context), or null
+     * when no rule carries a time range. task43 L459-475: a non-positive diff wraps to tomorrow.
+     */
+    private fun nextWakeTime(wakeTimes: List<Long>, nowSecs: Int): String? {
+        var minDiff = Long.MAX_VALUE
+        var nextWake = -1L
+        for (timeValue in wakeTimes) {
+            var diff = timeValue - nowSecs
+            if (diff <= 0) diff += SECONDS_PER_DAY
+            if (diff < minDiff) {
+                minDiff = diff
+                nextWake = timeValue
+            }
+        }
+        if (nextWake == -1L) return null
+        val h = nextWake / 3600
+        val m = (nextWake % 3600) / 60
+        return "%02d.%02d".format(h, m)
+    }
+
+    /**
+     * Great-circle (haversine) distance in metres. Tasker used `android.location.Location
+     * .distanceBetween` (ellipsoidal); haversine agrees to well within the metre-scale, user-set
+     * radius this gate compares against (documented approximation — only the inside/outside verdict
+     * matters, never the exact metres).
+     */
+    private fun distanceMeters(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
+        val dLat = Math.toRadians(lat2 - lat1)
+        val dLon = Math.toRadians(lon2 - lon1)
+        val a = sin(dLat / 2) * sin(dLat / 2) +
+            cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) *
+            sin(dLon / 2) * sin(dLon / 2)
+        return EARTH_RADIUS_M * 2 * atan2(sqrt(a), sqrt(1 - a))
+    }
+}

--- a/domain/src/test/kotlin/com/tideo/autobrightness/domain/context/ContextOverrideResolverTest.kt
+++ b/domain/src/test/kotlin/com/tideo/autobrightness/domain/context/ContextOverrideResolverTest.kt
@@ -1,0 +1,230 @@
+package com.tideo.autobrightness.domain.context
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Table-driven unit tests for [ContextOverrideResolver], mirroring contexts_spec §4 PASS 3/4 and the
+ * precedence matrix (priority → specificity → array order) 1:1 against task43's Java.
+ */
+class ContextOverrideResolverTest {
+
+    // Wed 2026-..; DAY_OF_WEEK 4 (Wednesday), 12:00 local, in Cinema wifi, 50% battery, unplugged.
+    private val noon = ContextSignals(
+        app = "com.netflix.mediaclient",
+        batteryPercent = 50,
+        plugged = false,
+        dayOfWeek = 4,
+        nowSecondsOfDay = 12 * 3600,
+        wifi = "HomeNet",
+        sunriseLocalSecs = 6 * 3600,
+        sunsetLocalSecs = 18 * 3600,
+    )
+
+    private fun rule(
+        id: String,
+        profile: String = "P_$id",
+        priority: Int = 0,
+        apps: List<String>? = null,
+        wifi: List<String>? = null,
+        battery: BatteryConstraint? = null,
+        location: LocationConstraint? = null,
+        timeRange: TimeRange? = null,
+        days: List<Int>? = null,
+    ) = ContextRuleSpec(id, "Rule $id", profile, priority, apps, wifi, battery, location, timeRange, days)
+
+    // ---- single-dimension matching -----------------------------------------------------------
+
+    @Test
+    fun appMatch_appliesProfile() {
+        val r = resolve(listOf(rule("a", apps = listOf("com.netflix.mediaclient"))))
+        assertEquals("P_a", r.targetProfile)
+        assertEquals("Rule a", r.activeContextName)
+        assertEquals("a", r.matchedRuleId)
+    }
+
+    @Test
+    fun appMismatch_fallsBackToUserProfile() {
+        val r = resolve(listOf(rule("a", apps = listOf("com.other.app"))))
+        assertEquals("MyProfile", r.targetProfile)
+        assertNull(r.activeContextName)
+        assertNull(r.matchedRuleId)
+    }
+
+    @Test
+    fun wifiMatch_trimmedCompare() {
+        val r = resolve(listOf(rule("w", wifi = listOf("  HomeNet  "))))
+        assertEquals("P_w", r.targetProfile)
+    }
+
+    @Test
+    fun batteryRange_inclusiveBounds() {
+        assertEquals("P_b", resolve(listOf(rule("b", battery = BatteryConstraint(min = 50, max = 50)))).targetProfile)
+        assertNull(resolve(listOf(rule("b", battery = BatteryConstraint(min = 51)))).activeContextName)
+        assertNull(resolve(listOf(rule("b", battery = BatteryConstraint(max = 49)))).activeContextName)
+    }
+
+    @Test
+    fun batteryOnPower_mustMatchPluggedState() {
+        assertNull(resolve(listOf(rule("b", battery = BatteryConstraint(onPower = true)))).activeContextName)
+        assertEquals("P_b", resolve(listOf(rule("b", battery = BatteryConstraint(onPower = false)))).targetProfile)
+    }
+
+    @Test
+    fun location_insideRadiusMatches_outsideDoesNot() {
+        val here = noon.copy(lat = 51.5000, lon = -0.1000)
+        val inside = rule("l", location = LocationConstraint(51.5001, -0.1001, 150.0))
+        val outside = rule("l", location = LocationConstraint(51.6000, -0.2000, 150.0))
+        assertEquals("P_l", ContextOverrideResolver.resolve(listOf(inside), here).targetProfile)
+        assertNull(ContextOverrideResolver.resolve(listOf(outside), here).activeContextName)
+    }
+
+    // ---- time-of-day + days ------------------------------------------------------------------
+
+    @Test
+    fun timeRange_daytimeWindowMatchesAtNoon() {
+        val r = resolve(listOf(rule("t", timeRange = TimeRange("09:00", "17:00"))))
+        assertEquals("P_t", r.targetProfile)
+    }
+
+    @Test
+    fun timeRange_outsideWindowNoMatch() {
+        val r = resolve(listOf(rule("t", timeRange = TimeRange("13:00", "17:00"))))
+        assertNull(r.activeContextName)
+    }
+
+    @Test
+    fun overnightRange_postMidnightTailUsesYesterdayMembership() {
+        // 22:00 → 06:00; now 02:00 Wednesday (day 4). Today-tail uses YESTERDAY (Tue=3) membership.
+        val night = noon.copy(nowSecondsOfDay = 2 * 3600)
+        val rTueOnly = rule("n", timeRange = TimeRange("22:00", "06:00"), days = listOf(3))
+        assertEquals("P_n", ContextOverrideResolver.resolve(listOf(rTueOnly), night).targetProfile)
+        // Restrict to Wednesday only: the 02:00 tail belongs to Tuesday, so no match.
+        val rWedOnly = rule("n", timeRange = TimeRange("22:00", "06:00"), days = listOf(4))
+        assertNull(ContextOverrideResolver.resolve(listOf(rWedOnly), night).activeContextName)
+    }
+
+    @Test
+    fun sunsetToken_resolvesToSignalSolarTime() {
+        // SUNSET=18:00; range SUNSET→23:00. At 12:00 no match; at 19:00 match.
+        val r1 = resolve(listOf(rule("s", timeRange = TimeRange("SUNSET", "23:00"))))
+        assertNull(r1.activeContextName)
+        val evening = noon.copy(nowSecondsOfDay = 19 * 3600)
+        assertEquals("P_s", ContextOverrideResolver.resolve(listOf(rule("s", timeRange = TimeRange("SUNSET", "23:00"))), evening).targetProfile)
+    }
+
+    @Test
+    fun daysOnly_matchesOnlyListedDay() {
+        assertEquals("P_d", resolve(listOf(rule("d", days = listOf(4)))).targetProfile) // Wed
+        assertNull(resolve(listOf(rule("d", days = listOf(2)))).activeContextName)       // Mon only
+    }
+
+    // ---- precedence: priority → specificity → array order ------------------------------------
+
+    @Test
+    fun precedence_highestPriorityWins() {
+        val rules = listOf(
+            rule("lo", profile = "LOW", priority = 1, apps = listOf("com.netflix.mediaclient")),
+            rule("hi", profile = "HIGH", priority = 5, apps = listOf("com.netflix.mediaclient")),
+        )
+        assertEquals("HIGH", resolve(rules).targetProfile)
+        assertEquals("hi", resolve(rules).matchedRuleId)
+    }
+
+    @Test
+    fun precedence_tiePriority_higherSpecificityWins() {
+        val rules = listOf(
+            rule("one", profile = "ONE", priority = 2, apps = listOf("com.netflix.mediaclient")),
+            rule("two", profile = "TWO", priority = 2, apps = listOf("com.netflix.mediaclient"), wifi = listOf("HomeNet")),
+        )
+        // both priority 2; "two" matches 2 dimensions vs 1 → wins.
+        assertEquals("TWO", resolve(rules).targetProfile)
+    }
+
+    @Test
+    fun precedence_tiePriorityAndSpecificity_firstInArrayWins() {
+        val rules = listOf(
+            rule("first", profile = "FIRST", priority = 0, apps = listOf("com.netflix.mediaclient")),
+            rule("second", profile = "SECOND", priority = 0, apps = listOf("com.netflix.mediaclient")),
+        )
+        assertEquals("FIRST", resolve(rules).targetProfile)
+    }
+
+    @Test
+    fun multiTrigger_allDimensionsMustMatch() {
+        // app matches but battery does not → rule rejected, fall back.
+        val r = resolve(
+            listOf(
+                rule(
+                    "m",
+                    apps = listOf("com.netflix.mediaclient"),
+                    battery = BatteryConstraint(min = 80),
+                ),
+            ),
+        )
+        assertNull(r.activeContextName)
+    }
+
+    // ---- override / fallback semantics -------------------------------------------------------
+
+    @Test
+    fun overrideActive_skipsSwitchButStillComputesWakeTime() {
+        val rules = listOf(rule("a", apps = listOf("com.netflix.mediaclient"), timeRange = TimeRange("09:00", "17:00")))
+        val r = ContextOverrideResolver.resolve(rules, noon, overrideActive = true, userProfile = "MyProfile")
+        assertNull(r.targetProfile)
+        assertNull(r.activeContextName)
+        // Wake time still computed: next future endpoint after 12:00 is 17:00.
+        assertEquals("17.00", r.nextContextTime)
+    }
+
+    @Test
+    fun noMatch_missingUserProfileCollapsesToDefault() {
+        val r = ContextOverrideResolver.resolve(
+            listOf(rule("a", apps = listOf("com.other"))),
+            noon,
+            userProfile = "GoneProfile",
+            profileExists = { false },
+        )
+        assertEquals("Default", r.targetProfile)
+    }
+
+    @Test
+    fun emptyRules_fallsBackToUserProfile_noWakeTime() {
+        val r = ContextOverrideResolver.resolve(emptyList(), noon, userProfile = "MyProfile")
+        assertEquals("MyProfile", r.targetProfile)
+        assertNull(r.nextContextTime)
+    }
+
+    // ---- next wake time (task43 L459-475) ----------------------------------------------------
+
+    @Test
+    fun nextWakeTime_picksNearestFutureEndpoint() {
+        // endpoints 09:00 & 17:00; now 12:00 → 09:00 is past (wraps to +21h), 17:00 is in +5h → nearest 17:00.
+        val r = resolve(listOf(rule("t", timeRange = TimeRange("09:00", "17:00"))))
+        assertEquals("17.00", r.nextContextTime)
+    }
+
+    @Test
+    fun nextWakeTime_allPastWrapsToEarliestTomorrow() {
+        val morning = noon.copy(nowSecondsOfDay = 20 * 3600) // 20:00
+        val r = ContextOverrideResolver.resolve(
+            listOf(rule("t", timeRange = TimeRange("09:00", "17:00"))),
+            morning,
+        )
+        // both 09:00 and 17:00 are past; nearest wrap = 09:00 next day.
+        assertEquals("09.00", r.nextContextTime)
+    }
+
+    @Test
+    fun wakeTimes_collectedEvenFromNonMatchingRules() {
+        // This rule's time window does not match now (02:00-03:00) but its endpoints still schedule.
+        val r = resolve(listOf(rule("t", timeRange = TimeRange("02:00", "03:00"))))
+        assertNull(r.activeContextName)
+        assertTrue(r.nextContextTime == "02.00" || r.nextContextTime == "03.00")
+    }
+
+    private fun resolve(rules: List<ContextRuleSpec>) =
+        ContextOverrideResolver.resolve(rules, noon, userProfile = "MyProfile")
+}


### PR DESCRIPTION
## Summary

Ports the context-override system from Tasker (8 watcher profiles prof762–768 + task43 `_EvaluateContexts V2`) into a pure-domain resolver + stateful app-layer engine. Implements the full precedence/merge matrix (priority → specificity → array order), signal-change veto gates, per-caller cooldown debounce, and profile-swap orchestration.

## Key changes

- **Domain layer** (`domain/src/main/kotlin/context/`):
  - `ContextOverrideResolver.kt`: Pure decision engine (PASS 3/4) — matches rules against signals, ranks by priority/specificity/order, computes next wake times. 1:1 port of task43 L12093 Java logic.
  - `ContextModel.kt`: Data classes for rules, constraints (battery/location/time), signals, and resolution outcomes.
  - `ContextOverrideResolverTest.kt`: 230-line table-driven test suite mirroring contexts_spec §4 precedence matrix.

- **App runtime** (`app/src/main/kotlin/runtime/`):
  - `ContextEngine.kt`: Stateful orchestrator — owns PASS 1 (per-caller cooldown debounce) and PASS 2 (signal-change veto gates), assembles live signals, delegates pure decision to resolver, applies winning profile swap, manages foreground-app polling lifecycle.
  - `AndroidContextSignalSource.kt`: Bridges S7 platform readers (battery/wifi/foreground-app/location) + clock/calendar/solar computation into `ContextSignals` snapshots.
  - `AppProfileCatalog.kt`: Resolves rule target profile names to `AabSettings` parameter sets (S10 uses built-in profiles; S12 extends to user-saved).
  - `ContextEngineTest.kt`: 168-line integration test covering app-match profile swap, no-match fallback, battery veto gates, and cooldown debounce.

- **App settings** (`app/src/main/kotlin/settings/`):
  - `ContextRuleStore.kt`: CRUD persistence layer (upsert by id on save, rebuild on delete) backed by DataStore.
  - `ContextRulesSerializer.kt`: DataStore serializer for `ContextOverrideConfig`.
  - `ContextRuleMapping.kt`: Maps app-layer `ContextRule` (S8 storage model) to pure-domain `ContextRuleSpec`; pre-filters signal tokens for watcher gates.
  - `ContextRuleStoreTest.kt`: 72-line CRUD test suite (append, upsert, delete, replace-all, Tasker JSON export).

- **Integration**:
  - `AppModule.kt`: Wires `ContextEngine`, `AndroidContextSignalSource`, `ContextRuleStore`, and `AppProfileCatalog` into the runtime graph.
  - `AmbientMonitoringService.kt`: Starts/stops context engine with service lifecycle; calls `onScreenOn/Off` for app-polling gates; invokes `onPipelineTick` for time-window re-eval.
  - `BrightnessPipelineController.kt`: Adds `onProfileChanged()` hook for profile-swap re-initialization.
  - `PipelineState.kt`: Adds `ProfileChanged` event.
  - `AppDataStores.kt`: Adds `contextRulesDataStore` singleton.

- **Documentation**:
  - `docs/rebuild/STATE.md`: Appends S10 segment log (DONE, 1 day, Opus/medium).
  - `docs/rebuild/PARITY_CHECKLIST.md`: Marks prof762–768 + task43 as ported.

## Notable implementation details

- **Concurrency**: All evaluations run under `evalMutex` so veto state and active-profile latch stay consistent across battery/wifi/app/time signal sources.
- **Veto gates** (PASS 2): App-changed only re-evaluates if a rule is active, profile is non-default

https://claude.ai/code/session_01Y3znYRv857kCKYRz3RbDuk