### PR TITLE
S12.5a: AAB design language + app shell (nav drawer, hero cards)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
 
     implementation(platform(libs.compose.bom))
     implementation(libs.compose.material3)
+    implementation(libs.compose.material.icons.core)
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.tooling.preview)
     debugImplementation(libs.compose.ui.tooling)

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/components/AppShell.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/components/AppShell.kt
@@ -1,0 +1,203 @@
+package com.tideo.autobrightness.app.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.NavigationDrawerItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.tideo.autobrightness.R
+import com.tideo.autobrightness.app.navigation.AppRoute
+import com.tideo.autobrightness.app.ui.theme.AabGold
+import com.tideo.autobrightness.app.ui.theme.AabOnTeal
+import com.tideo.autobrightness.app.ui.theme.AabTeal
+
+/**
+ * The app shell chrome — a branded top bar + the navigation drawer. This is the Compose rebuild of
+ * the Tasker **AAB Menu scene** (extraction/scenes/menu.md, XML L4462): a project banner up top and
+ * grouped navigation "cards" (Profiles & Contexts hero / Settings / Info & Help). The flat
+ * `OutlinedButton` nav list S11/S12 put on the Dashboard is replaced by this drawer (Gate-2 G2-F18).
+ *
+ * S12.5a scope: identity + navigation only. Field grouping (the re-added Misc/General screen) and the
+ * preview→Apply model are S12.5b; this keeps the existing AppRoute set and routes to it unchanged.
+ */
+
+/** Branded center-aligned top bar with the hamburger that opens the drawer (the "name up top"). */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AabTopBar(title: String, onOpenMenu: () -> Unit) {
+    CenterAlignedTopAppBar(
+        title = { Text(title, fontWeight = FontWeight.SemiBold) },
+        navigationIcon = {
+            androidx.compose.material3.IconButton(
+                onClick = onOpenMenu,
+                modifier = Modifier.testTag("menu_button"),
+            ) {
+                Icon(Icons.Filled.Menu, contentDescription = "Open menu")
+            }
+        },
+        colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+            containerColor = AabTeal,
+            titleContentColor = AabOnTeal,
+            navigationIconContentColor = AabGold,
+        ),
+    )
+}
+
+/**
+ * The drawer content — the AAB Menu scene's grouped destination set. Sections mirror the menu's
+ * three HTML cards (menu.md L22): a Profiles & Contexts group (the hero), a Settings group, and an
+ * Info & Help group (Recheck Permissions → Onboarding; the Chart.js License entry is dropped per the
+ * screen_map). `current` highlights the active route.
+ */
+@Composable
+fun AabNavDrawer(
+    current: AppRoute?,
+    onNavigate: (AppRoute) -> Unit,
+    onRecheckPermissions: () -> Unit,
+) {
+    ModalDrawerSheet(
+        drawerContainerColor = MaterialTheme.colorScheme.surface,
+        modifier = Modifier.testTag("nav_drawer"),
+    ) {
+        DrawerBanner()
+        Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            drawerItem(AppRoute.Dashboard, Icons.Filled.Home, current, onNavigate)
+
+            DrawerSectionLabel("Profiles & Contexts")
+            drawerItem(AppRoute.Profiles, Icons.Filled.Person, current, onNavigate)
+            drawerItem(AppRoute.Contexts, Icons.Filled.Place, current, onNavigate)
+
+            DrawerSectionLabel("Settings")
+            drawerItem(AppRoute.CurveBrightness, Icons.Filled.Settings, current, onNavigate)
+            drawerItem(AppRoute.Reactivity, Icons.Filled.Refresh, current, onNavigate)
+            drawerItem(AppRoute.AnimationDimming, Icons.Filled.PlayArrow, current, onNavigate)
+            drawerItem(AppRoute.DynamicScale, Icons.Filled.DateRange, current, onNavigate)
+
+            DrawerSectionLabel("Info & Help")
+            drawerItem(AppRoute.Tools, Icons.Filled.Build, current, onNavigate)
+            drawerItem(AppRoute.About, Icons.Filled.Info, current, onNavigate)
+            NavigationDrawerItem(
+                icon = { Icon(Icons.Filled.Lock, contentDescription = null) },
+                label = { Text("Recheck Permissions") },
+                selected = false,
+                onClick = onRecheckPermissions,
+                modifier = Modifier
+                    .padding(NavigationDrawerItemDefaults.ItemPadding)
+                    .testTag("nav_recheck_permissions"),
+            )
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+}
+
+/** Teal banner header with the gold sun mark — the menu scene's "Advanced Auto Brightness" header. */
+@Composable
+private fun DrawerBanner() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(120.dp)
+            .background(AabTeal)
+            .padding(16.dp)
+            .testTag("drawer_banner"),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_stat_brightness),
+            contentDescription = null,
+            tint = AabGold,
+            modifier = Modifier.size(40.dp),
+        )
+        Spacer(Modifier.width(12.dp))
+        Column {
+            Text(
+                "Advanced",
+                color = AabOnTeal,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                "Auto Brightness",
+                color = AabGold,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DrawerSectionLabel(text: String) {
+    HorizontalDivider(Modifier.padding(vertical = 4.dp))
+    Text(
+        text,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.tertiary,
+        modifier = Modifier.padding(start = 16.dp, top = 4.dp, bottom = 2.dp),
+    )
+}
+
+@Composable
+private fun drawerItem(
+    route: AppRoute,
+    icon: ImageVector,
+    current: AppRoute?,
+    onNavigate: (AppRoute) -> Unit,
+) {
+    NavigationDrawerItem(
+        icon = { Icon(icon, contentDescription = null) },
+        label = { Text(route.label) },
+        selected = route == current,
+        onClick = { onNavigate(route) },
+        colors = NavigationDrawerItemDefaults.colors(
+            selectedContainerColor = AabTeal.copy(alpha = 0.20f),
+            selectedIconColor = AabTeal,
+            selectedTextColor = AabTeal,
+        ),
+        modifier = Modifier
+            .padding(NavigationDrawerItemDefaults.ItemPadding)
+            .testTag("nav_${route.route}"),
+    )
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/DashboardScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/DashboardScreen.kt
@@ -8,23 +8,31 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Place
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Card
-import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -33,7 +41,11 @@ import com.tideo.autobrightness.app.navigation.AppRoute
 import com.tideo.autobrightness.app.state.DashboardUiState
 import com.tideo.autobrightness.app.state.DashboardViewModel
 import com.tideo.autobrightness.app.state.ServiceHealthUiState
+import com.tideo.autobrightness.app.ui.components.AabNavDrawer
+import com.tideo.autobrightness.app.ui.components.AabTopBar
+import com.tideo.autobrightness.app.ui.theme.AabGold
 import com.tideo.autobrightness.platform.privilege.Tier
+import kotlinx.coroutines.launch
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -52,7 +64,13 @@ fun DashboardScreen(navController: NavHostController, viewModel: DashboardViewMo
     )
 }
 
-/** Stateless, fully driven by [state] + callbacks so it can render under a Robolectric compose test. */
+/**
+ * Stateless, fully driven by [state] + callbacks so it can render under a Robolectric compose test.
+ *
+ * S12.5a: the flat `OutlinedButton` nav list is replaced by the AAB-Menu drawer ([AabNavDrawer]) +
+ * a branded top bar ([AabTopBar]); Profiles and Contexts are surfaced as prominent hero cards
+ * (Gate-2 G2-F18). Field behaviour is unchanged (that is S12.5b).
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DashboardContent(
@@ -63,27 +81,58 @@ fun DashboardContent(
     onOpenOnboarding: () -> Unit,
     onNavigate: (AppRoute) -> Unit,
 ) {
-    Scaffold(
-        topBar = { CenterAlignedTopAppBar(title = { Text("Tideo Auto Brightness") }) },
-    ) { padding ->
-        Column(
-            modifier = Modifier
-                .padding(padding)
-                .padding(horizontal = 16.dp)
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            TierBadge(tier = state.tier, onClick = onOpenOnboarding)
-            ServiceSwitchCard(state.serviceEnabled, onToggleService)
-            LiveReadoutCard(state, onPause, onResume)
-            state.activeContext?.let { ContextCard(it) }
-            HealthCard(state.health)
-            HorizontalDivider()
-            AppRoute.dashboardDestinations.forEach { route ->
-                OutlinedButton(
-                    onClick = { onNavigate(route) },
-                    modifier = Modifier.fillMaxWidth().testTag("nav_${route.route}"),
-                ) { Text(route.label) }
+    val drawerState = rememberDrawerState(DrawerValue.Closed)
+    val scope = rememberCoroutineScope()
+    ModalNavigationDrawer(
+        drawerState = drawerState,
+        drawerContent = {
+            AabNavDrawer(
+                current = AppRoute.Dashboard,
+                onNavigate = { route ->
+                    scope.launch { drawerState.close() }
+                    onNavigate(route)
+                },
+                onRecheckPermissions = {
+                    scope.launch { drawerState.close() }
+                    onOpenOnboarding()
+                },
+            )
+        },
+    ) {
+        Scaffold(
+            topBar = {
+                AabTopBar(
+                    title = "Tideo Auto Brightness",
+                    onOpenMenu = { scope.launch { drawerState.open() } },
+                )
+            },
+        ) { padding ->
+            Column(
+                modifier = Modifier
+                    .padding(padding)
+                    .padding(horizontal = 16.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                TierBadge(tier = state.tier, onClick = onOpenOnboarding)
+                ServiceSwitchCard(state.serviceEnabled, onToggleService)
+                LiveReadoutCard(state, onPause, onResume)
+                HeroCard(
+                    icon = Icons.Filled.Person,
+                    title = "Profiles",
+                    subtitle = "Save, load & import brightness profiles",
+                    testTag = "hero_profiles",
+                    onClick = { onNavigate(AppRoute.Profiles) },
+                )
+                HeroCard(
+                    icon = Icons.Filled.Place,
+                    title = "Contexts",
+                    subtitle = state.activeContext?.let { "Active: $it" }
+                        ?: "No context override active",
+                    testTag = "hero_contexts",
+                    onClick = { onNavigate(AppRoute.Contexts) },
+                )
+                HealthCard(state.health)
             }
         }
     }
@@ -153,12 +202,32 @@ private fun LiveReadoutCard(state: DashboardUiState, onPause: () -> Unit, onResu
     }
 }
 
+/** Prominent summary card (the AAB Menu "hero" cards for Profiles / Contexts). */
 @Composable
-private fun ContextCard(activeContext: String) {
-    Card {
-        Column(Modifier.padding(16.dp)) {
-            Text("Active context", style = MaterialTheme.typography.labelMedium)
-            Text(activeContext, style = MaterialTheme.typography.titleMedium)
+private fun HeroCard(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    testTag: String,
+    onClick: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).testTag(testTag),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        ),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(20.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Icon(icon, contentDescription = null, tint = AabGold)
+            Column {
+                Text(title, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+                Text(subtitle, style = MaterialTheme.typography.bodyMedium)
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/theme/Color.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/theme/Color.kt
@@ -1,0 +1,47 @@
+package com.tideo.autobrightness.app.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+/**
+ * The Advanced Auto Brightness (AAB) brand palette — **teal + gold**.
+ *
+ * Every value is lifted directly from the Tasker project's scenes, not invented (S12.5a; CLAUDE.md
+ * "port behaviour exactly"). Provenance:
+ *   - extraction/scenes/about.md L51 (the most explicit theme statement): "bg #333333, banner
+ *     #007C63, accent headings #007C63/#00A986, links #00C79E, strong #FFC107, license box #383838".
+ *   - #007C63 (teal) is also every "on" indicator dot (brightness_settings.md, reactivity_settings.md,
+ *     superdimming_settings.md — "#FF007C63"), the curve-wizard Flash overlay (task038 L26, task090
+ *     act48), and the power-draw chart's power series (power_draw_graph.md L35).
+ *   - #FFC107 (gold/amber) is the "strong" accent + the invalid-formula red/gold field highlight
+ *     (features_spec.md L179) + the power-draw current series (power_draw_graph.md L36).
+ *   - #404040 ("#FF404040") is the decorative card/panel background used across the settings scenes
+ *     (brightness_settings.md L27, misc_settings.md L28, reactivity_settings.md L27, etc.).
+ *
+ * The Tasker UI is dark-first (black/charcoal scenes with teal + gold accents); the dark scheme is
+ * therefore the faithful one and the light scheme is a derived courtesy (DayNight kept per the brief).
+ */
+
+// --- Primary teal family ---
+val AabTeal = Color(0xFF007C63)        // banner / primary / all "on" indicator dots
+val AabTealAccent = Color(0xFF00A986)  // lighter accent heading (about.md)
+val AabTealLink = Color(0xFF00C79E)    // bright link / hyperlink text (about.md)
+
+// --- Gold / amber family ---
+val AabGold = Color(0xFFFFC107)        // "strong" accent, warnings, chart current-series
+
+// --- Neutral surfaces (dark-first, from the scene backgrounds) ---
+val AabBackgroundDark = Color(0xFF333333) // scene bg (about.md)
+val AabSurfaceDark = Color(0xFF383838)    // card / license box (about.md)
+val AabPanelDark = Color(0xFF404040)      // decorative card/panel bg across settings scenes
+val AabOnDark = Color(0xFFECECEC)         // legible light text on the charcoal surfaces
+
+// --- Light-scheme neutrals (derived; not in the extraction, kept muted so teal/gold dominate) ---
+val AabBackgroundLight = Color(0xFFF6F8F7)
+val AabSurfaceLight = Color(0xFFFFFFFF)
+val AabSurfaceVariantLight = Color(0xFFDCE5E1)
+val AabOnLight = Color(0xFF1A1C1B)
+
+// --- Shared semantics ---
+val AabError = Color(0xFFD32F2F)       // invalid-field red (the _RedInvalidFormulae family)
+val AabOnTeal = Color(0xFFFFFFFF)
+val AabOnGold = Color(0xFF2A2000)      // dark text on the gold accent for contrast

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/theme/Theme.kt
@@ -2,27 +2,79 @@ package com.tideo.autobrightness.app.ui.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 
 /**
- * App theme: Material 3 with dynamic (Material You) color and automatic day/night. minSdk is 31, so
- * `dynamicLightColorScheme`/`dynamicDarkColorScheme` are always available — no static fallback
- * palette is needed (D-027g: Compose M3 generates its own theming; the XML theme is now just a
- * launch-window placeholder).
+ * App theme: the AAB **teal + gold** brand identity (S12.5a, replacing S11's dynamic Material-You
+ * scheme — Gate-2 G2-F18: "the app does not look or feel like AAB"). Colours are derived from the
+ * Tasker scenes (see [Color.kt] for per-value provenance), NOT invented.
+ *
+ * Dynamic colour is OFF by default so the brand identity is stable across devices; it is left as an
+ * opt-in [dynamicColor] flag per the brief. DayNight is kept: the dark scheme is the faithful one
+ * (Tasker is dark-first) and the light scheme is a derived courtesy.
  */
 @Composable
 fun TideoTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
+    dynamicColor: Boolean = false,
     content: @Composable () -> Unit,
 ) {
-    val context = LocalContext.current
-    val colorScheme = if (darkTheme) {
-        dynamicDarkColorScheme(context)
-    } else {
-        dynamicLightColorScheme(context)
+    val colorScheme = when {
+        dynamicColor -> {
+            val context = LocalContext.current
+            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
+        darkTheme -> AabDarkColorScheme
+        else -> AabLightColorScheme
     }
     MaterialTheme(colorScheme = colorScheme, content = content)
 }
+
+/** Dark-first AAB scheme: charcoal surfaces, teal primary, gold secondary. */
+private val AabDarkColorScheme = darkColorScheme(
+    primary = AabTeal,
+    onPrimary = AabOnTeal,
+    primaryContainer = AabTeal,
+    onPrimaryContainer = AabOnTeal,
+    secondary = AabGold,
+    onSecondary = AabOnGold,
+    secondaryContainer = AabPanelDark,
+    onSecondaryContainer = AabOnDark,
+    tertiary = AabTealAccent,
+    onTertiary = AabOnTeal,
+    background = AabBackgroundDark,
+    onBackground = AabOnDark,
+    surface = AabSurfaceDark,
+    onSurface = AabOnDark,
+    surfaceVariant = AabPanelDark,
+    onSurfaceVariant = AabOnDark,
+    error = AabError,
+    onError = AabOnTeal,
+)
+
+/** Derived light scheme (kept muted so teal/gold remain the identity). */
+private val AabLightColorScheme = lightColorScheme(
+    primary = AabTeal,
+    onPrimary = AabOnTeal,
+    primaryContainer = AabTealAccent,
+    onPrimaryContainer = AabOnTeal,
+    secondary = AabGold,
+    onSecondary = AabOnGold,
+    secondaryContainer = AabGold,
+    onSecondaryContainer = AabOnGold,
+    tertiary = AabTealAccent,
+    onTertiary = AabOnTeal,
+    background = AabBackgroundLight,
+    onBackground = AabOnLight,
+    surface = AabSurfaceLight,
+    onSurface = AabOnLight,
+    surfaceVariant = AabSurfaceVariantLight,
+    onSurfaceVariant = AabOnLight,
+    error = AabError,
+    onError = AabOnTeal,
+)

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/ui/UiShellTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/ui/UiShellTest.kt
@@ -1,7 +1,9 @@
 package com.tideo.autobrightness.app.ui
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -11,6 +13,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.tideo.autobrightness.app.navigation.AppRoute
 import com.tideo.autobrightness.app.state.DashboardUiState
+import com.tideo.autobrightness.app.ui.components.AabNavDrawer
 import com.tideo.autobrightness.app.ui.onboarding.OnboardingContent
 import com.tideo.autobrightness.app.ui.onboarding.OnboardingUiState
 import com.tideo.autobrightness.app.ui.screens.DashboardContent
@@ -62,10 +65,62 @@ class UiShellTest {
         compose.onNodeWithTag("service_switch").performClick()
         assertEquals(true, toggled)
 
-        // Every tunable destination is reachable from the Dashboard.
+        // The Profiles + Contexts hero cards (G2-F18) replace flat nav buttons on the Dashboard.
+        compose.onNodeWithTag("hero_profiles").assertExists()
+        compose.onNodeWithTag("hero_contexts").assertExists()
+
+        // Every tunable destination is reachable from the AAB-Menu drawer.
         AppRoute.dashboardDestinations.forEach {
             compose.onNodeWithTag("nav_${it.route}").assertExists()
         }
+    }
+
+    @Test
+    fun navDrawer_navigatesToEveryDestination() {
+        // The AAB-Menu drawer (rebuild of scene menu.md) is stateless, so drive it directly —
+        // deterministic, no modal open-animation. Confirms every destination + Recheck Permissions.
+        var navigated: AppRoute? = null
+        var recheck = false
+        compose.setContent {
+            MaterialTheme {
+                AabNavDrawer(
+                    current = AppRoute.Dashboard,
+                    onNavigate = { navigated = it },
+                    onRecheckPermissions = { recheck = true },
+                )
+            }
+        }
+
+        // Invoke the OnClick semantics action directly: deterministic in Robolectric (no gesture
+        // injection / display dependency, which NavigationDrawerItem's selectable does not honour here).
+        AppRoute.dashboardDestinations.forEach { route ->
+            compose.onNodeWithTag("nav_${route.route}").performSemanticsAction(SemanticsActions.OnClick)
+            assertEquals(route, navigated)
+        }
+        compose.onNodeWithTag("nav_recheck_permissions").performSemanticsAction(SemanticsActions.OnClick)
+        assertTrue(recheck)
+    }
+
+    @Test
+    fun heroCards_navigateToProfilesAndContexts() {
+        var navigated: AppRoute? = null
+        compose.setContent {
+            MaterialTheme {
+                DashboardContent(
+                    state = DashboardUiState(tier = Tier.BASIC, serviceRunning = true),
+                    onToggleService = {},
+                    onPause = {},
+                    onResume = {},
+                    onOpenOnboarding = {},
+                    onNavigate = { navigated = it },
+                )
+            }
+        }
+
+        compose.onNodeWithTag("hero_profiles").performScrollTo().performClick()
+        assertEquals(AppRoute.Profiles, navigated)
+        compose.onNodeWithTag("hero_contexts").performScrollTo().performClick()
+        assertEquals(AppRoute.Contexts, navigated)
     }
 
     @Test

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -33,11 +33,23 @@ next session does not know it.
 
 | S12 settings/tools/profile screens + chart engine | 2026-06-13 | Opus/medium | DONE | (see push) | The 7 parameter/tool/profile placeholder screens filled + the reusable chart engine landed (D-044). **Step-0 triage** committed first: `anonymous_handlers.md` 168 rows bucketed (a) trivial-chrome / (b) settings-mutation (both bulk-dropped w/ shared reasons) / (c) ~30 complex behaviors → explicit port list. New: `state/SettingsViewModel.kt` (DataStore-as-truth, advisory SettingsValidator errors, reset/applyProfile/replaceAll) + `state/ContextsViewModel.kt` (rule CRUD + installed-app picker); `ui/components/{SettingsControls,SettingsScaffold}.kt` (NumberSettingField w/ red-error supportingText, SwitchSettingRow, DerivedReadout, back-nav scaffold); `ui/graph/ChartCanvas.kt` (generic axes/ticks/log10/multi-series/markers engine — the S13 template base) + `ui/graph/BrightnessCurveChart.kt` (THE template instance) + `ui/screens/ChartPlaceholder.kt` (deferred-S13 slots); screens `CurveBrightnessScreen` (fields + validator + live form2A/3A + curve chart), `ReactivityScreen` (thresholds + **DetectOverrides toggle, G1-F2**), `AnimationDimmingScreen` (anim + derived throttle + **ELEVATED-gated DimmingEnabled, G1-F5** + PWM), `DynamicScaleScreen` (scaling/taper + task517/674/689 warnings), `ContextsScreen` (rule CRUD), `ToolsScreen` (wizard runner + 10-label debug selector + calibration entry), `ProfilesScreen` (apply/reset + Create/OpenDocument import-export incl. legacy). NavGraph wires all 7 (About → S13 placeholder). Tests: `SettingsScreensTest` (5 — validator→UI form2C error, safety banner, DetectOverrides edit, dimming tier-gate, debug label). Acceptance ladder GREEN: `:app:testDebugUnitTest`(77) `:app:assembleDebug :app:lintDebug`. No compaction. **GATE 2 READY.** |
 
+| S12.5a design language + app shell | 2026-06-13 | Opus/high | DONE | (see push) | UI-layer reskin to AAB identity (D-046, Gate-2 G2-F18). New: `ui/theme/Color.kt` (teal+gold palette, per-value provenance from extraction — about.md L51 + the "on" indicator dots/Flash overlays) + rewritten `ui/theme/Theme.kt` (static AAB dark-first/light `ColorScheme`, dynamic colour now opt-in OFF, DayNight kept); `ui/components/AppShell.kt` (`AabTopBar` branded teal header w/ hamburger + `AabNavDrawer` = Compose rebuild of the AAB Menu scene menu.md/L4462: gold-sun teal banner + grouped destinations Profiles&Contexts / Settings / Info&Help, current-route highlight, Recheck Permissions→Onboarding, Chart.js License dropped). `DashboardScreen` rewritten: flat OutlinedButton nav list (nav_* tags) replaced by the drawer; Profiles + Contexts surfaced as prominent **hero cards** (gold-iconed, clickable). New dep `androidx.compose.material:material-icons-core` (from BOM, no version) — declared in libs.versions.toml + app build.gradle. UiShellTest extended (+2: drawer navigates to every route via OnClick semantics; hero cards navigate). Scope kept to identity+nav — field behaviour/sliders/grouping untouched (those are S12.5b). Full ladder GREEN: `:app:assembleDebug :app:testDebugUnitTest`(81) `:app:lintDebug :domain:test :platform:test`. No compaction. |
+
 Status values: DONE · PARTIAL · BLOCKED (see failure protocol in CLAUDE.md).
 
 ## Current state
 
-**S12 (settings & tools screens + chart engine core) DONE but GATE 2 FAILED → merged + salvaged in
+**S12.5a (design language + app shell) DONE.** The app now wears the AAB **teal + gold** identity
+(D-046): a static brand `ColorScheme` (dynamic colour opt-in OFF, DayNight kept), a branded teal top
+header with a hamburger that opens the **AAB-Menu nav drawer** (Compose rebuild of scene menu.md/L4462
+— gold-sun banner + grouped Profiles&Contexts / Settings / Info&Help destinations, current-route
+highlight), and **hero cards** for Profiles + Contexts on the Dashboard (the flat OutlinedButton nav
+list is gone). This is the first of the three UI-salvage sub-segments and addresses **G2-F18**; the
+interaction model (preview→Apply, sliders, Misc/General grouping) is **S12.5b**, and feature/behaviour
+fidelity (context editor, toasts, debug toasts, G2-F8/F9) is **S12.5c**. Scope was strictly the UI
+layer — domain/runtime/chart-engine/validator untouched. Build GREEN across the full ladder.
+
+**(historical) S12 (settings & tools screens + chart engine core) DONE but GATE 2 FAILED → merged + salvaged in
 S12.5 (D-045).** Gate 2 found the UI "miles off" the Tasker app (generic Material, no AAB design
 language/preview-Apply model/sliders; findings G2-F1..F18). The branch is merged as-is (domain/runtime/
 chart-engine sound); the UI is rebuilt in S12.5a/b/c. The wiring below still describes what shipped: all seven
@@ -83,10 +95,13 @@ AppModule is now the real DI root.
   notification actions; optionally grant WRITE_SECURE_SETTINGS → super dimming engages below threshold).
   Findings → "Gate findings" below.
 - Parallel window C: **S10** (context override engine) DONE ∥ **S11** (UI shell + onboarding) DONE.
-- **S12.5 — UI salvage (a/b/c)** is the next serial step (NEW; brief in RUNBOOK, D-045). S12 merges
-  to main as-is; S12.5 rebuilds the UI to AAB fidelity (teal+gold design language + nav drawer + hero
-  cards; temporary-preview→Apply model; bounded sliders; Misc-screen regrouping; toasts; context-editor
-  fidelity; the profile-load-disables-overrides bug G2-F8). **Gate 2 is re-tested after S12.5c**, not now.
+- **S12.5 — UI salvage (a/b/c)** (brief in RUNBOOK, D-045). **S12.5a DONE** (teal+gold design language +
+  AAB-Menu nav drawer + hero cards — D-046). **Next: S12.5b** = temporary-preview→Apply model (draft
+  AabSettings + `[committed]` brackets + pipeline re-run on Apply, G2-F1/F16) + bounded sliders
+  (G2-F3/F13) + faithful Misc/General field regrouping (G2-F2) + validation parity (G2-F5/F6/F10/F11).
+  Then **S12.5c** = context-editor fidelity (G2-F14), toasts (G2-F12), debug→runtime toasts (G2-F15),
+  the profile-load-disables-overrides bug (G2-F8), super-dimming engagement (G2-F9), QS-tile paused
+  state (G2-F17). **Gate 2 is re-tested after S12.5c**, not now.
 - **HUMAN GATE 2** (RUNBOOK "Human gates", after S12.5): full UI walkthrough — every field
   edits/persists/rejects-invalid-with-red; live form2A/form3A; wizard produces+applies suggestions;
   Shizuku ELEVATED flow; QS tile; per-app override; charging+time contexts; brightness-chart shape;
@@ -667,7 +682,34 @@ Seeded by the S0 audit (details in CLAUDE.md "Facts & corrections ledger"):
   the 9-screen screen_map but fix grouping (re-add a faithful Misc/General screen; min/max/offset/scale +
   animation belong there)**. (Affects S12.5a/b/c, S13, S14, Gate 2.)
 
-Append new entries as D-046, D-047, … with which segments they affect.
+- D-046: S12.5a DESIGN LANGUAGE + APP SHELL (UI-layer salvage; sanctioned by the S12.5a brief;
+  addresses Gate-2 G2-F18). **Palette (teal + gold) is derived from the extraction, not invented:**
+  primary teal `#007C63`, accent `#00A986`, bright link `#00C79E`, gold/strong `#FFC107`, bg `#333333`,
+  card/surface `#383838`, decorative panel `#404040` — provenance per value in `ui/theme/Color.kt`
+  (authority: `extraction/scenes/about.md` L51 "bg #333333, banner #007C63, accent #007C63/#00A986,
+  links #00C79E, strong #FFC107, license box #383838"; reinforced by the `#FF007C63` "on" indicator
+  dots in brightness/reactivity/superdimming settings scenes, the curve-wizard Flash overlays
+  task038/task090, and the power-draw chart series #007C63/#FFC107). The chosen schemes:
+  `AabDarkColorScheme` (dark-first = faithful: charcoal surfaces, teal primary, gold secondary) +
+  derived `AabLightColorScheme`; both in `Theme.kt`. **Dynamic colour is now opt-in OFF** (was S11's
+  default-on Material-You) so the brand identity is stable; DayNight kept.
+  **App shell** = `ui/components/AppShell.kt`: `AabTopBar` (teal CenterAligned header, gold hamburger,
+  title up top) + `AabNavDrawer` (`ModalDrawerSheet`) — the Compose rebuild of the **AAB Menu scene**
+  (menu.md, XML L4462): gold-sun teal banner header + destinations grouped into the menu's three
+  cards (Profiles&Contexts hero / Settings / Info&Help), current route highlighted; Recheck Permissions
+  → Onboarding; Chart.js License entry dropped (screen_map). `DashboardScreen` rewritten so the drawer
+  (opened from the hamburger) replaces S11/S12's flat `OutlinedButton` nav list, and **Profiles +
+  Contexts are hero cards** (gold-iconed, clickable, Contexts shows the active context). **New dep:**
+  `androidx.compose.material:material-icons-core` (resolved from the existing compose BOM, no explicit
+  version) for the drawer/hero icons — declared in `libs.versions.toml` + `app/build.gradle.kts`.
+  SCOPE BOUNDARY: kept the existing 9-route `AppRoute` set and all field behaviour intact — the
+  Misc/General field regrouping + AppRoute changes are S12.5b's job (G2-F2), NOT done here. Other
+  screens keep their own back-nav SettingsScaffold; the drawer is the Dashboard's hub. UiShellTest +2
+  (drawer→every route via OnClick semantics action [NavigationDrawerItem's selectable tap doesn't
+  register under Robolectric gesture injection — use performSemanticsAction]; hero-card navigation).
+  (Affects S12.5b, S12.5c, S13 — S13 static screens inherit this theme/shell.)
+
+Append new entries as D-047, D-048, … with which segments they affect.
 
 ## Blockers
 
@@ -786,6 +828,9 @@ warning; time-context rule loads its profile (min-bright kicks in); reset-to-def
   S12 shipped default Material 3 (dynamic color), a plain top bar, and a flat list of outlined nav
   buttons on the Dashboard — generic, not AAB. (Owner's examples are illustrative, NOT exhaustive: the
   whole visual/interaction identity needs to match the Tasker app.)
+  **→ ADDRESSED by S12.5a (D-046):** teal+gold brand `ColorScheme` (dynamic colour off), branded teal
+  top header with the project name + hamburger, the AAB-Menu `ModalNavigationDrawer` rebuild, and
+  Profiles/Contexts hero cards replacing the flat button list. Re-verify the full look/feel at Gate 2.
 
 **Decision (owner, 2026-06-13 19:00):** MERGE this branch as-is (S12 compiles + tests green; domain/
 runtime/chart-engine are sound) and **salvage the UI in a new S12.5** (see RUNBOOK; split a/b/c).

--- a/docs/rebuild/screen_map.md
+++ b/docs/rebuild/screen_map.md
@@ -42,9 +42,14 @@ Every Chart.js WebElement maps to a named Compose-Canvas chart (built S12/S13). 
 
 ### AAB Menu  ·  `menu`  ·  XML L4462–4717  ·  3 elements  → (nav hub)
 
+**S12.5a:** rebuilt as the `AabNavDrawer` (`ModalNavigationDrawer`, `ui/components/AppShell.kt`) opened
+from the branded `AabTopBar` hamburger — the menu's three HTML "cards" become drawer groups
+(Profiles&Contexts hero / Settings / Info&Help); Recheck Permissions → Onboarding; the Chart.js License
+entry is dropped (D-046). Profiles + Contexts also surface as hero cards on the Dashboard.
+
 | Element | Type | Disposition |
 |---|---|---|
-| elements0 | Web | dropped(nav replaced by M3 navigation) |
+| elements0 | Web | dropped-HTML; **nav rebuilt as `AabNavDrawer` (S12.5a)** |
 | background#1 | Rect | dropped(decorative/background rect) |
 | props | Properties | dropped(nav replaced by M3 navigation) |
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ androidx-datastore-preferences = { group = "androidx.datastore", name = "datasto
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workRuntimeKtx" }
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+compose-material-icons-core = { group = "androidx.compose.material", name = "material-icons-core" }
 compose-ui = { group = "androidx.compose.ui", name = "ui" }
 compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }


### PR DESCRIPTION
## Summary

Reskin the UI layer to the Advanced Auto Brightness (AAB) **teal + gold** brand identity and rebuild the app shell with a navigation drawer. This addresses **Gate-2 G2-F18** ("the app does not look or feel like AAB") and is the first of three UI-salvage sub-segments (S12.5a/b/c). Scope is strictly the UI layer — domain, runtime, chart engine, and validator are untouched.

## Key Changes

- **New color palette** (`ui/theme/Color.kt`): Static AAB dark-first/light `ColorScheme` with teal primary (#007C63), gold secondary (#FFC107), and charcoal surfaces. Every value is lifted directly from the Tasker project's scenes (extraction/scenes/about.md L51 + indicator dots + chart overlays), not invented. Dynamic colour is now opt-in OFF (flag added to `TideoTheme`) so the brand identity is stable across devices; DayNight is kept.

- **Rewritten theme** (`ui/theme/Theme.kt`): Replaced dynamic Material-You scheme with static AAB `ColorScheme` (dark-first is the faithful one; light is a derived courtesy). Dynamic colour available as an opt-in parameter.

- **New app shell components** (`ui/components/AppShell.kt`):
  - `AabTopBar`: Branded teal center-aligned header with hamburger menu button (gold icon).
  - `AabNavDrawer`: Compose rebuild of the Tasker AAB Menu scene (menu.md/L4462). Features:
    - Gold-sun teal banner header.
    - Three grouped destination sections: Profiles & Contexts / Settings / Info & Help.
    - Current-route highlight with teal accent.
    - "Recheck Permissions" item routes to Onboarding.
    - Chart.js License entry dropped per screen_map.

- **Dashboard redesign** (`ui/screens/DashboardScreen.kt`):
  - Flat `OutlinedButton` nav list replaced by the AAB-Menu drawer (opened via hamburger).
  - Profiles and Contexts surfaced as prominent **hero cards** (gold-iconed, clickable, teal-accented containers) — the menu's "hero" pattern.
  - Active context displayed in the Contexts hero card subtitle.
  - Drawer state managed with `ModalNavigationDrawer` + `rememberDrawerState`.

- **New dependency**: `androidx.compose.material:material-icons-core` (from BOM, no explicit version) for Material Icons (Person, Place, Home, Settings, etc.).

- **Test coverage** (`app/src/test/kotlin/com/tideo/autobrightness/app/ui/UiShellTest.kt`):
  - Extended with two new tests:
    - `navDrawer_navigatesToEveryDestination()`: Confirms drawer navigates to all destinations + Recheck Permissions via `SemanticsActions.OnClick` (deterministic in Robolectric).
    - `heroCards_navigateToProfilesAndContexts()`: Confirms hero cards navigate to Profiles and Contexts.
  - Existing dashboard test updated to verify hero cards exist and drawer nav items are reachable.

- **Documentation** (`docs/rebuild/STATE.md`, `docs/rebuild/screen_map.md`): Updated segment log, current state, and screen map to reflect S12.5a completion and the drawer rebuild.

## Implementation Details

- **Drawer state management**: Coroutine scope used to close drawer after navigation (smooth UX).
- **Hero cards**: Clickable `Card` with `Row` layout (icon + title/subtitle column), styled with `primaryContainer` background and gold icon tint.
- **Semantics testing**: Drawer items tested via `performSemanticsAction(SemanticsActions.OnClick)` instead of gesture injection — deterministic in Robolectric (no display dependency).
- **Scope boundary**: Field behaviour (sliders, grouping, preview→Apply model) deferred to S12.5b; feature/behaviour fidelity (context editor, toasts, debug

https://claude.ai/code/session_01QKBGceQd27KXioGUhZnPDr