### PR TITLE
S12.6a: Promote AAB Menu to home hub, rename Super Dimming & Circadian

### DIFF
--- a/app/src/main/kotlin/com/tideo/autobrightness/app/navigation/AppRoute.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/navigation/AppRoute.kt
@@ -1,18 +1,23 @@
 package com.tideo.autobrightness.app.navigation
 
 /**
- * The target Material 3 screen set from `docs/rebuild/screen_map.md`. S11 builds Dashboard and
- * Onboarding for real; the parameter/tool/profile screens are owned by S12 and the About/Guide
- * content by S13, so they resolve to a labelled placeholder until then ([owner] tags which segment
- * fills each in). Keeping the full route table here means navigation resolves end-to-end now.
+ * The target Material 3 screen set from `docs/rebuild/screen_map.md`.
+ *
+ * S12.6a (G2R-F1/F2/F3/F4): the **AAB Menu is now a real home screen** ([Menu]) — the app hub that
+ * the user returns to from every settings/tool screen (not the Dashboard). The Dashboard is a
+ * separate live-status destination reached from the Menu. Two screens are renamed to match Tasker:
+ * `Animation & Dimming` → **Super Dimming** and `Dynamic Scale` → **Circadian**.
  */
 enum class AppRoute(val route: String, val label: String, val owner: String) {
+    Menu("menu", "Menu", "S12.6a"),
     Dashboard("dashboard", "Dashboard", "S11"),
     Onboarding("onboarding", "Setup & Permissions", "S11"),
     CurveBrightness("curve_brightness", "Curve & Brightness", "S12"),
     Reactivity("reactivity", "Reactivity", "S12"),
-    AnimationDimming("animation_dimming", "Animation & Dimming", "S12"),
-    DynamicScale("dynamic_scale", "Dynamic Scale", "S12"),
+    // S12.6a rename (G2R-F3): the screen owns super dimming + PWM after S12.5b, so its name follows.
+    SuperDimming("super_dimming", "Super Dimming", "S12.6a"),
+    // S12.6a rename (G2R-F4): "Dynamic Scale" → "Circadian" (the Tasker name for the day/night curve).
+    Circadian("circadian", "Circadian", "S12.6a"),
     // S12.5b re-adds the Misc/General screen (G2-F2): the Tasker "Misc" scene's brightness range
     // (min/max/offset/scale), animation (steps + min/max wait + throttle), notifications and debug
     // fields live here — they were wrongly scattered onto other screens in S12.
@@ -23,10 +28,22 @@ enum class AppRoute(val route: String, val label: String, val owner: String) {
     About("about", "About & Guide", "S13");
 
     companion object {
-        /** Destinations surfaced as navigation entries on the Dashboard (everything the user tunes). */
-        val dashboardDestinations: List<AppRoute> = listOf(
-            CurveBrightness, Reactivity, AnimationDimming, DynamicScale, Misc,
-            Contexts, Tools, Profiles, About,
+        /** Profiles + Contexts — surfaced as the Menu's prominent hero cards (moved off the Dashboard). */
+        val heroDestinations: List<AppRoute> = listOf(Profiles, Contexts)
+
+        /** The tunable parameter screens — the Menu "Settings" group. */
+        val settingsDestinations: List<AppRoute> = listOf(
+            CurveBrightness, Reactivity, SuperDimming, Circadian, Misc,
         )
+
+        /** Tools + reference content — the Menu "Info & Help" group. */
+        val infoDestinations: List<AppRoute> = listOf(Tools, About)
+
+        /**
+         * Every destination surfaced as a plain navigation ROW in the Menu (the hero cards render
+         * separately). Drives the menu list + the navigation smoke tests.
+         */
+        val menuNavDestinations: List<AppRoute> =
+            listOf(Dashboard) + settingsDestinations + infoDestinations
     }
 }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/navigation/NavGraph.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/navigation/NavGraph.kt
@@ -8,22 +8,24 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.tideo.autobrightness.app.AppModule
 import com.tideo.autobrightness.app.ui.onboarding.OnboardingScreen
-import com.tideo.autobrightness.app.ui.screens.AnimationDimmingScreen
+import com.tideo.autobrightness.app.ui.screens.CircadianScreen
 import com.tideo.autobrightness.app.ui.screens.ContextsScreen
 import com.tideo.autobrightness.app.ui.screens.CurveBrightnessScreen
 import com.tideo.autobrightness.app.ui.screens.DashboardScreen
-import com.tideo.autobrightness.app.ui.screens.DynamicScaleScreen
+import com.tideo.autobrightness.app.ui.screens.MenuScreen
 import com.tideo.autobrightness.app.ui.screens.MiscScreen
 import com.tideo.autobrightness.app.ui.screens.PlaceholderScreen
 import com.tideo.autobrightness.app.ui.screens.ProfilesScreen
 import com.tideo.autobrightness.app.ui.screens.ReactivityScreen
+import com.tideo.autobrightness.app.ui.screens.SuperDimmingScreen
 import com.tideo.autobrightness.app.ui.screens.ToolsScreen
 import com.tideo.autobrightness.platform.privilege.Tier
 
 /**
- * The navigation shell over the [AppRoute] target screen set. S11 wired Dashboard + Onboarding; S12
- * fills the parameter/tool/profile destinations with real screens. About & Guide remains a labelled
- * [PlaceholderScreen] until S13. First-run routing sends the user to Onboarding when tier == NONE.
+ * The navigation shell over the [AppRoute] target screen set. S12.6a makes [AppRoute.Menu] the home
+ * hub and the start destination after onboarding; every other screen is reached from it and returns
+ * to it (see [navigateTopLevel]). First-run routing sends the user to Onboarding when tier == NONE.
+ * About & Guide remains a labelled [PlaceholderScreen] until S13.
  */
 @Composable
 fun AppNavGraph(
@@ -31,12 +33,13 @@ fun AppNavGraph(
     startDestination: String = rememberStartDestination(),
 ) {
     NavHost(navController = navController, startDestination = startDestination) {
+        composable(AppRoute.Menu.route) { MenuScreen(navController) }
         composable(AppRoute.Dashboard.route) { DashboardScreen(navController) }
         composable(AppRoute.Onboarding.route) { OnboardingScreen(navController) }
         composable(AppRoute.CurveBrightness.route) { CurveBrightnessScreen(navController) }
         composable(AppRoute.Reactivity.route) { ReactivityScreen(navController) }
-        composable(AppRoute.AnimationDimming.route) { AnimationDimmingScreen(navController) }
-        composable(AppRoute.DynamicScale.route) { DynamicScaleScreen(navController) }
+        composable(AppRoute.SuperDimming.route) { SuperDimmingScreen(navController) }
+        composable(AppRoute.Circadian.route) { CircadianScreen(navController) }
         composable(AppRoute.Misc.route) { MiscScreen(navController) }
         composable(AppRoute.Contexts.route) { ContextsScreen(navController) }
         composable(AppRoute.Tools.route) { ToolsScreen(navController) }
@@ -46,12 +49,25 @@ fun AppNavGraph(
     }
 }
 
-/** Start on Onboarding when tier == NONE (no brightness-write access), else the Dashboard. */
+/**
+ * Navigate to a top-level destination from the Menu hub (or the Dashboard's quick links), always
+ * rooting the back stack at [AppRoute.Menu] so a back press from any settings/tool screen returns to
+ * the Menu, never the Dashboard (S12.6a owner decision 1, G2R-F1). `launchSingleTop` avoids stacking
+ * duplicates when re-selecting the current destination.
+ */
+fun NavHostController.navigateTopLevel(route: AppRoute) {
+    navigate(route.route) {
+        popUpTo(AppRoute.Menu.route) { inclusive = false }
+        launchSingleTop = true
+    }
+}
+
+/** Start on Onboarding when tier == NONE (no brightness-write access), else the Menu hub. */
 @Composable
 private fun rememberStartDestination(): String {
     val context = LocalContext.current
     return remember {
         val tier = AppModule(context.applicationContext).privilegeManager.currentTier()
-        if (tier == Tier.NONE) AppRoute.Onboarding.route else AppRoute.Dashboard.route
+        if (tier == Tier.NONE) AppRoute.Onboarding.route else AppRoute.Menu.route
     }
 }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineController.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineController.kt
@@ -159,6 +159,12 @@ class BrightnessPipelineController(
      * and enqueue a [PipelineEvent.SensorTick]; everything else is dropped here (never queued).
      */
     private fun onSensorSample(lux: Double, accuracy: Int) {
+        // Record every delivered sample so the UI can show a live "last sample" age (G2R-F5), even
+        // for readings the prof760 dead-band/throttle gates later drop. This is the one PipelineState
+        // field written from the sensor collector rather than the consumer; it is a monotonic
+        // timestamp and MutableStateFlow.update is atomic (CAS retry), so it cannot corrupt or be
+        // lost against the consumer's snapshot writes.
+        _state.update { it.copy(lastSampleMs = clock()) }
         val settings = cachedSettings ?: return
         if (!settings.serviceEnabled) return
         val s = _state.value

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/PipelineState.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/PipelineState.kt
@@ -18,6 +18,9 @@ data class PipelineState(
     val lastRawLux: Double? = null,
     /** %LastAAB — TIMEMS of the last accepted tick (throttle anchor); null until first accept. */
     val lastAcceptedMs: Long? = null,
+    /** TIMEMS of the last sensor sample the collector saw (any sample, not just accepted ticks);
+     *  drives the Dashboard "last sample: Xs ago" health readout (G2R-F5). */
+    val lastSampleMs: Long? = null,
     /** %AAB_ThreshAbsLow — absolute dead-band low (task546); null until seeded. */
     val threshAbsLow: Double? = null,
     /** %AAB_ThreshAbsHigh — absolute dead-band high (task546). */

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/state/DashboardState.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/state/DashboardState.kt
@@ -18,6 +18,8 @@ data class DashboardUiState(
     val currentBrightness: Int? = null,
     val targetBrightness: Int? = null,
     val activeContext: String? = null,
+    /** TIMEMS of the last sensor sample the pipeline saw (live), for the "Xs ago" readout (G2R-F5). */
+    val lastSampleMs: Long? = null,
     val health: ServiceHealthUiState = ServiceHealthUiState(),
 )
 

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/state/DashboardViewModel.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/state/DashboardViewModel.kt
@@ -42,6 +42,7 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
         val current: Int?,
         val target: Int?,
         val context: String?,
+        val lastSampleMs: Long?,
     )
 
     private val liveFlow = combine(
@@ -49,7 +50,7 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
         LiveRuntimeState.activeContext,
         LiveRuntimeState.serviceRunning,
     ) { p, ctx, running ->
-        Live(running, p.paused, p.lastRawLux, p.smoothedLux, p.lastAppliedBrightness, p.targetBrightness, ctx)
+        Live(running, p.paused, p.lastRawLux, p.smoothedLux, p.lastAppliedBrightness, p.targetBrightness, ctx, p.lastSampleMs)
     }
 
     private val healthFlow = healthStore.telemetry.map {
@@ -77,6 +78,7 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
             currentBrightness = live.current,
             targetBrightness = live.target,
             activeContext = live.context,
+            lastSampleMs = live.lastSampleMs,
             health = health,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), DashboardUiState())

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/components/AppShell.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/components/AppShell.kt
@@ -1,7 +1,6 @@
 package com.tideo.autobrightness.app.ui.components
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,66 +9,53 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Build
-import androidx.compose.material.icons.filled.DateRange
-import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material.icons.filled.Menu
-import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Place
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalDrawerSheet
-import androidx.compose.material3.NavigationDrawerItem
-import androidx.compose.material3.NavigationDrawerItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.tideo.autobrightness.R
-import com.tideo.autobrightness.app.navigation.AppRoute
 import com.tideo.autobrightness.app.ui.theme.AabGold
 import com.tideo.autobrightness.app.ui.theme.AabOnTeal
 import com.tideo.autobrightness.app.ui.theme.AabTeal
 
 /**
- * The app shell chrome — a branded top bar + the navigation drawer. This is the Compose rebuild of
- * the Tasker **AAB Menu scene** (extraction/scenes/menu.md, XML L4462): a project banner up top and
- * grouped navigation "cards" (Profiles & Contexts hero / Settings / Info & Help). The flat
- * `OutlinedButton` nav list S11/S12 put on the Dashboard is replaced by this drawer (Gate-2 G2-F18).
+ * The app shell chrome — the branded top bar and the Menu-screen building blocks. This is the
+ * Compose rebuild of the Tasker **AAB Menu scene** (extraction/scenes/menu.md, XML L4462): a gold-sun
+ * teal banner over grouped navigation "cards" (Profiles & Contexts hero / Settings / Info & Help).
  *
- * S12.5a scope: identity + navigation only. Field grouping (the re-added Misc/General screen) and the
- * preview→Apply model are S12.5b; this keeps the existing AppRoute set and routes to it unchanged.
+ * S12.6a (G2R-F1/F2): the S12.5a slide-over `AabNavDrawer` is promoted into a real
+ * [com.tideo.autobrightness.app.ui.screens.MenuScreen] home destination — the canonical hub and the
+ * back-target from every settings/tool screen. These shared pieces ([AabMenuBanner],
+ * [AabSectionLabel]) render that screen; the top bar is reused by Menu/Dashboard.
  */
 
-/** Branded center-aligned top bar with the hamburger that opens the drawer (the "name up top"). */
+/**
+ * Branded center-aligned top bar. When [onBack] is non-null a back arrow is shown (the standard
+ * up-navigation that returns to the Menu); pass null on the home/Menu screen for no nav icon.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AabTopBar(title: String, onOpenMenu: () -> Unit) {
+fun AabTopBar(title: String, onBack: (() -> Unit)? = null) {
     CenterAlignedTopAppBar(
         title = { Text(title, fontWeight = FontWeight.SemiBold) },
         navigationIcon = {
-            androidx.compose.material3.IconButton(
-                onClick = onOpenMenu,
-                modifier = Modifier.testTag("menu_button"),
-            ) {
-                Icon(Icons.Filled.Menu, contentDescription = "Open menu")
+            if (onBack != null) {
+                IconButton(onClick = onBack, modifier = Modifier.testTag("back_button")) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                }
             }
         },
         colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
@@ -80,69 +66,16 @@ fun AabTopBar(title: String, onOpenMenu: () -> Unit) {
     )
 }
 
-/**
- * The drawer content — the AAB Menu scene's grouped destination set. Sections mirror the menu's
- * three HTML cards (menu.md L22): a Profiles & Contexts group (the hero), a Settings group, and an
- * Info & Help group (Recheck Permissions → Onboarding; the Chart.js License entry is dropped per the
- * screen_map). `current` highlights the active route.
- */
+/** Teal banner header with the gold sun mark — the rebuild's "Tideo Auto Brightness" brand header. */
 @Composable
-fun AabNavDrawer(
-    current: AppRoute?,
-    onNavigate: (AppRoute) -> Unit,
-    onRecheckPermissions: () -> Unit,
-) {
-    ModalDrawerSheet(
-        drawerContainerColor = MaterialTheme.colorScheme.surface,
-        modifier = Modifier.testTag("nav_drawer"),
-    ) {
-        DrawerBanner()
-        Column(
-            modifier = Modifier
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 12.dp),
-            verticalArrangement = Arrangement.spacedBy(2.dp),
-        ) {
-            drawerItem(AppRoute.Dashboard, Icons.Filled.Home, current, onNavigate)
-
-            DrawerSectionLabel("Profiles & Contexts")
-            drawerItem(AppRoute.Profiles, Icons.Filled.Person, current, onNavigate)
-            drawerItem(AppRoute.Contexts, Icons.Filled.Place, current, onNavigate)
-
-            DrawerSectionLabel("Settings")
-            drawerItem(AppRoute.CurveBrightness, Icons.Filled.Settings, current, onNavigate)
-            drawerItem(AppRoute.Reactivity, Icons.Filled.Refresh, current, onNavigate)
-            drawerItem(AppRoute.AnimationDimming, Icons.Filled.PlayArrow, current, onNavigate)
-            drawerItem(AppRoute.DynamicScale, Icons.Filled.DateRange, current, onNavigate)
-            drawerItem(AppRoute.Misc, Icons.Filled.Settings, current, onNavigate)
-
-            DrawerSectionLabel("Info & Help")
-            drawerItem(AppRoute.Tools, Icons.Filled.Build, current, onNavigate)
-            drawerItem(AppRoute.About, Icons.Filled.Info, current, onNavigate)
-            NavigationDrawerItem(
-                icon = { Icon(Icons.Filled.Lock, contentDescription = null) },
-                label = { Text("Recheck Permissions") },
-                selected = false,
-                onClick = onRecheckPermissions,
-                modifier = Modifier
-                    .padding(NavigationDrawerItemDefaults.ItemPadding)
-                    .testTag("nav_recheck_permissions"),
-            )
-            Spacer(Modifier.height(8.dp))
-        }
-    }
-}
-
-/** Teal banner header with the gold sun mark — the menu scene's "Advanced Auto Brightness" header. */
-@Composable
-private fun DrawerBanner() {
+fun AabMenuBanner() {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .height(120.dp)
             .background(AabTeal)
             .padding(16.dp)
-            .testTag("drawer_banner"),
+            .testTag("menu_banner"),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(
@@ -154,51 +87,29 @@ private fun DrawerBanner() {
         Spacer(Modifier.width(12.dp))
         Column {
             Text(
-                "Advanced",
+                "Tideo",
                 color = AabOnTeal,
-                style = MaterialTheme.typography.titleMedium,
+                style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
             )
             Text(
                 "Auto Brightness",
                 color = AabGold,
-                style = MaterialTheme.typography.titleMedium,
+                style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
             )
         }
     }
 }
 
+/** A grouped-section divider + label, mirroring the menu scene's three HTML cards. */
 @Composable
-private fun DrawerSectionLabel(text: String) {
-    HorizontalDivider(Modifier.padding(vertical = 4.dp))
+fun AabSectionLabel(text: String) {
+    HorizontalDivider(Modifier.padding(top = 8.dp))
     Text(
         text,
-        style = MaterialTheme.typography.labelMedium,
+        style = MaterialTheme.typography.labelLarge,
         color = MaterialTheme.colorScheme.tertiary,
-        modifier = Modifier.padding(start = 16.dp, top = 4.dp, bottom = 2.dp),
-    )
-}
-
-@Composable
-private fun drawerItem(
-    route: AppRoute,
-    icon: ImageVector,
-    current: AppRoute?,
-    onNavigate: (AppRoute) -> Unit,
-) {
-    NavigationDrawerItem(
-        icon = { Icon(icon, contentDescription = null) },
-        label = { Text(route.label) },
-        selected = route == current,
-        onClick = { onNavigate(route) },
-        colors = NavigationDrawerItemDefaults.colors(
-            selectedContainerColor = AabTeal.copy(alpha = 0.20f),
-            selectedIconColor = AabTeal,
-            selectedTextColor = AabTeal,
-        ),
-        modifier = Modifier
-            .padding(NavigationDrawerItemDefaults.ItemPadding)
-            .testTag("nav_${route.route}"),
+        modifier = Modifier.padding(start = 4.dp, top = 8.dp, bottom = 2.dp),
     )
 }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/CircadianScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/CircadianScreen.kt
@@ -14,14 +14,17 @@ import com.tideo.autobrightness.app.ui.components.SectionHeader
 import com.tideo.autobrightness.app.ui.components.SettingsColumn
 import com.tideo.autobrightness.app.ui.components.SwitchSettingRow
 
-/** Dynamic Scale (Tasker AAB Experiment Settings + Experiment/Taper graphs). Draft → Apply (S12.5b). */
+/**
+ * Circadian (Tasker AAB Experiment Settings + Experiment/Taper graphs). Renamed from "Dynamic Scale"
+ * in S12.6a (G2R-F4) to match the Tasker name for the day/night curve scaling. Draft → Apply (S12.5b).
+ */
 @Composable
-fun DynamicScaleScreen(navController: NavHostController, vm: DraftSettingsViewModel = viewModel()) {
+fun CircadianScreen(navController: NavHostController, vm: DraftSettingsViewModel = viewModel()) {
     val draft by vm.draft.collectAsStateWithLifecycle()
     val committed by vm.committed.collectAsStateWithLifecycle()
     val dirty by vm.dirty.collectAsStateWithLifecycle()
     val epoch by vm.epoch.collectAsStateWithLifecycle()
-    DynamicScaleContent(
+    CircadianContent(
         draft, committed, epoch, dirty,
         onEdit = vm::edit, onApply = vm::apply, onDiscard = vm::discard,
         onBack = { navController.popBackStack() },
@@ -29,7 +32,7 @@ fun DynamicScaleScreen(navController: NavHostController, vm: DraftSettingsViewMo
 }
 
 @Composable
-fun DynamicScaleContent(
+fun CircadianContent(
     draft: AabSettings,
     committed: AabSettings,
     epoch: Int,
@@ -39,7 +42,7 @@ fun DynamicScaleContent(
     onDiscard: () -> Unit,
     onBack: () -> Unit,
 ) {
-    DraftSettingsScaffold("Dynamic Scale", dirty, onApply, onDiscard, onBack) { padding ->
+    DraftSettingsScaffold("Circadian", dirty, onApply, onDiscard, onBack) { padding ->
         SettingsColumn(padding) {
             ChartPlaceholder("ExperimentChart / TaperChart", "dynamic_scale_chart")
 

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/DashboardScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/DashboardScreen.kt
@@ -1,6 +1,5 @@
 package com.tideo.autobrightness.app.ui.screens
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -8,31 +7,20 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Place
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -41,14 +29,8 @@ import com.tideo.autobrightness.app.navigation.AppRoute
 import com.tideo.autobrightness.app.state.DashboardUiState
 import com.tideo.autobrightness.app.state.DashboardViewModel
 import com.tideo.autobrightness.app.state.ServiceHealthUiState
-import com.tideo.autobrightness.app.ui.components.AabNavDrawer
 import com.tideo.autobrightness.app.ui.components.AabTopBar
-import com.tideo.autobrightness.app.ui.theme.AabGold
 import com.tideo.autobrightness.platform.privilege.Tier
-import kotlinx.coroutines.launch
-import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 
 /** Stateful wrapper: wires the [DashboardViewModel] and navigation. */
 @Composable
@@ -60,16 +42,17 @@ fun DashboardScreen(navController: NavHostController, viewModel: DashboardViewMo
         onPause = viewModel::pause,
         onResume = viewModel::resume,
         onOpenOnboarding = { navController.navigate(AppRoute.Onboarding.route) },
-        onNavigate = { route -> navController.navigate(route.route) },
+        onBack = { navController.popBackStack() },
     )
 }
 
 /**
  * Stateless, fully driven by [state] + callbacks so it can render under a Robolectric compose test.
  *
- * S12.5a: the flat `OutlinedButton` nav list is replaced by the AAB-Menu drawer ([AabNavDrawer]) +
- * a branded top bar ([AabTopBar]); Profiles and Contexts are surfaced as prominent hero cards
- * (Gate-2 G2-F18). Field behaviour is unchanged (that is S12.5b).
+ * S12.6a (G2R-F1/F2): the AAB Menu is now the home hub — the Profiles/Contexts hero cards and the
+ * nav drawer moved there ([MenuScreen]); the Dashboard is a focused live-status screen reached from
+ * the Menu, with a back arrow that returns to it. The "Last sensor sample" age is now driven by the
+ * live pipeline (G2R-F5).
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -79,61 +62,22 @@ fun DashboardContent(
     onPause: () -> Unit,
     onResume: () -> Unit,
     onOpenOnboarding: () -> Unit,
-    onNavigate: (AppRoute) -> Unit,
+    onBack: () -> Unit,
 ) {
-    val drawerState = rememberDrawerState(DrawerValue.Closed)
-    val scope = rememberCoroutineScope()
-    ModalNavigationDrawer(
-        drawerState = drawerState,
-        drawerContent = {
-            AabNavDrawer(
-                current = AppRoute.Dashboard,
-                onNavigate = { route ->
-                    scope.launch { drawerState.close() }
-                    onNavigate(route)
-                },
-                onRecheckPermissions = {
-                    scope.launch { drawerState.close() }
-                    onOpenOnboarding()
-                },
-            )
-        },
-    ) {
-        Scaffold(
-            topBar = {
-                AabTopBar(
-                    title = "Tideo Auto Brightness",
-                    onOpenMenu = { scope.launch { drawerState.open() } },
-                )
-            },
-        ) { padding ->
-            Column(
-                modifier = Modifier
-                    .padding(padding)
-                    .padding(horizontal = 16.dp)
-                    .verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                TierBadge(tier = state.tier, onClick = onOpenOnboarding)
-                ServiceSwitchCard(state.serviceEnabled, onToggleService)
-                LiveReadoutCard(state, onPause, onResume)
-                HeroCard(
-                    icon = Icons.Filled.Person,
-                    title = "Profiles",
-                    subtitle = "Save, load & import brightness profiles",
-                    testTag = "hero_profiles",
-                    onClick = { onNavigate(AppRoute.Profiles) },
-                )
-                HeroCard(
-                    icon = Icons.Filled.Place,
-                    title = "Contexts",
-                    subtitle = state.activeContext?.let { "Active: $it" }
-                        ?: "No context override active",
-                    testTag = "hero_contexts",
-                    onClick = { onNavigate(AppRoute.Contexts) },
-                )
-                HealthCard(state.health)
-            }
+    Scaffold(
+        topBar = { AabTopBar(title = "Dashboard", onBack = onBack) },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .padding(horizontal = 16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            TierBadge(tier = state.tier, onClick = onOpenOnboarding)
+            ServiceSwitchCard(state.serviceEnabled, onToggleService)
+            LiveReadoutCard(state, onPause, onResume)
+            HealthCard(state.lastSampleMs, state.health)
         }
     }
 }
@@ -202,43 +146,17 @@ private fun LiveReadoutCard(state: DashboardUiState, onPause: () -> Unit, onResu
     }
 }
 
-/** Prominent summary card (the AAB Menu "hero" cards for Profiles / Contexts). */
 @Composable
-private fun HeroCard(
-    icon: ImageVector,
-    title: String,
-    subtitle: String,
-    testTag: String,
-    onClick: () -> Unit,
-) {
-    Card(
-        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).testTag(testTag),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer,
-            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        ),
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(20.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            Icon(icon, contentDescription = null, tint = AabGold)
-            Column {
-                Text(title, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
-                Text(subtitle, style = MaterialTheme.typography.bodyMedium)
-            }
-        }
-    }
-}
-
-@Composable
-private fun HealthCard(health: ServiceHealthUiState) {
+private fun HealthCard(lastSampleMs: Long?, health: ServiceHealthUiState) {
     Card {
         Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
             Text("Service health", style = MaterialTheme.typography.labelMedium)
-            Text("Last sensor sample: ${health.lastSensorTimestampMs.toHumanTime()}")
-            Text("Last brightness apply: ${health.lastApplyTimestampMs.toHumanTime()}")
+            // G2R-F5: drive the last-sample readout from the live pipeline (PipelineState.lastSampleMs),
+            // not the never-written health store; recomputed each recomposition as a relative age.
+            Text(
+                "Last sensor sample: ${lastSampleMs.toRelativeAge()}",
+                modifier = Modifier.testTag("last_sample_age"),
+            )
             if (health.degradedMode) {
                 Text(
                     "Degraded: ${health.degradedReason ?: "unknown"}",
@@ -252,9 +170,14 @@ private fun HealthCard(health: ServiceHealthUiState) {
 private fun Double?.fmt(): String = this?.let { "%.0f".format(it) } ?: "—"
 private fun Int?.fmtInt(): String = this?.toString() ?: "—"
 
-private fun Long?.toHumanTime(): String {
-    if (this == null) return "Never"
-    return DateTimeFormatter.ISO_LOCAL_TIME.format(
-        Instant.ofEpochMilli(this).atZone(ZoneId.systemDefault()).toLocalTime().withNano(0),
-    )
+/** Relative "Xs ago" age for a millis timestamp; "never" when the sensor has not fired yet. */
+private fun Long?.toRelativeAge(now: Long = System.currentTimeMillis()): String {
+    if (this == null) return "never"
+    val secs = ((now - this) / 1000L).coerceAtLeast(0L)
+    return when {
+        secs < 1L -> "just now"
+        secs < 60L -> "${secs}s ago"
+        secs < 3600L -> "${secs / 60L}m ago"
+        else -> "${secs / 3600L}h ago"
+    }
 }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/MenuScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/MenuScreen.kt
@@ -1,0 +1,161 @@
+package com.tideo.autobrightness.app.ui.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
+import com.tideo.autobrightness.app.navigation.AppRoute
+import com.tideo.autobrightness.app.navigation.navigateTopLevel
+import com.tideo.autobrightness.app.runtime.LiveRuntimeState
+import com.tideo.autobrightness.app.ui.components.AabMenuBanner
+import com.tideo.autobrightness.app.ui.components.AabSectionLabel
+import com.tideo.autobrightness.app.ui.theme.AabGold
+
+/**
+ * The AAB **Menu** home screen (S12.6a, G2R-F1/F2): the Compose rebuild of the Tasker AAB Menu scene
+ * (menu.md, XML L4462) promoted from the S12.5a nav drawer into the app's canonical hub. It is the
+ * start destination after onboarding and the back-target from every settings/tool screen.
+ *
+ * Layout mirrors the menu scene's three HTML cards: the gold-sun teal banner, the **Profiles &
+ * Contexts hero cards** (moved off the Dashboard), a Settings group, and an Info & Help group
+ * (Recheck Permissions → Onboarding). The Dashboard is just another destination here (live status).
+ */
+@Composable
+fun MenuScreen(navController: NavHostController) {
+    val activeContext by LiveRuntimeState.activeContext.collectAsStateWithLifecycle()
+    MenuContent(
+        activeContext = activeContext,
+        onNavigate = { route -> navController.navigateTopLevel(route) },
+        onRecheckPermissions = { navController.navigateTopLevel(AppRoute.Onboarding) },
+    )
+}
+
+@Composable
+fun MenuContent(
+    activeContext: String?,
+    onNavigate: (AppRoute) -> Unit,
+    onRecheckPermissions: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+    ) {
+        AabMenuBanner()
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            // Live status — the former start destination, now reached from the hub.
+            MenuNavRow(AppRoute.Dashboard, Icons.Filled.Home, onNavigate)
+
+            AabSectionLabel("Profiles & Contexts")
+            MenuHeroCard(
+                icon = Icons.Filled.Person,
+                title = "Profiles",
+                subtitle = "Save, load & import brightness profiles",
+                testTag = "hero_profiles",
+                onClick = { onNavigate(AppRoute.Profiles) },
+            )
+            MenuHeroCard(
+                icon = Icons.Filled.Place,
+                title = "Contexts",
+                subtitle = activeContext?.let { "Active: $it" } ?: "No context override active",
+                testTag = "hero_contexts",
+                onClick = { onNavigate(AppRoute.Contexts) },
+            )
+
+            AabSectionLabel("Settings")
+            MenuNavRow(AppRoute.CurveBrightness, Icons.Filled.Settings, onNavigate)
+            MenuNavRow(AppRoute.Reactivity, Icons.Filled.Refresh, onNavigate)
+            MenuNavRow(AppRoute.SuperDimming, Icons.Filled.PlayArrow, onNavigate)
+            MenuNavRow(AppRoute.Circadian, Icons.Filled.DateRange, onNavigate)
+            MenuNavRow(AppRoute.Misc, Icons.Filled.Settings, onNavigate)
+
+            AabSectionLabel("Info & Help")
+            MenuNavRow(AppRoute.Tools, Icons.Filled.Build, onNavigate)
+            MenuNavRow(AppRoute.About, Icons.Filled.Info, onNavigate)
+            ListItem(
+                headlineContent = { Text("Recheck Permissions") },
+                leadingContent = { Icon(Icons.Filled.Lock, contentDescription = null) },
+                modifier = Modifier
+                    .clickable(onClick = onRecheckPermissions)
+                    .testTag("menu_recheck_permissions"),
+            )
+        }
+    }
+}
+
+/** A plain navigation row (tagged `menu_<route>`) used for the Dashboard + Settings + Info groups. */
+@Composable
+private fun MenuNavRow(route: AppRoute, icon: ImageVector, onNavigate: (AppRoute) -> Unit) {
+    ListItem(
+        headlineContent = { Text(route.label) },
+        leadingContent = { Icon(icon, contentDescription = null) },
+        modifier = Modifier
+            .clickable { onNavigate(route) }
+            .testTag("menu_${route.route}"),
+    )
+}
+
+/** Prominent summary card — the AAB Menu "hero" cards for Profiles / Contexts (G2R-F2). */
+@Composable
+private fun MenuHeroCard(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    testTag: String,
+    onClick: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).testTag(testTag),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        ),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(20.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Icon(icon, contentDescription = null, tint = AabGold)
+            Column {
+                Text(title, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+                Text(subtitle, style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/SuperDimmingScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/SuperDimmingScreen.kt
@@ -23,19 +23,19 @@ import com.tideo.autobrightness.app.ui.components.SwitchSettingRow
 import com.tideo.autobrightness.platform.privilege.Tier
 
 /**
- * Animation & Dimming (Tasker AAB Superdimming Settings + Color Filter). The animation fields moved
- * to Misc (G2-F2); this screen owns super dimming (ELEVATED) and PWM/software dimming. Draft → Apply
- * (S12.5b). Super dimming and PWM are **mutually exclusive** (G2-F10); the circadian dim-spread field
- * is gated on circadian scaling (G2-F11).
+ * Super Dimming (Tasker AAB Superdimming Settings + Color Filter). Renamed from "Animation & Dimming"
+ * in S12.6a (G2R-F3) — its content is super dimming (ELEVATED) + PWM/software dimming after the
+ * animation fields moved to Misc (G2-F2). Draft → Apply (S12.5b). Super dimming and PWM are
+ * **mutually exclusive** (G2-F10); the circadian dim-spread field is gated on circadian scaling (G2-F11).
  */
 @Composable
-fun AnimationDimmingScreen(navController: NavHostController, vm: DraftSettingsViewModel = viewModel()) {
+fun SuperDimmingScreen(navController: NavHostController, vm: DraftSettingsViewModel = viewModel()) {
     val draft by vm.draft.collectAsStateWithLifecycle()
     val committed by vm.committed.collectAsStateWithLifecycle()
     val dirty by vm.dirty.collectAsStateWithLifecycle()
     val epoch by vm.epoch.collectAsStateWithLifecycle()
     val tier by vm.tier.collectAsStateWithLifecycle()
-    AnimationDimmingContent(
+    SuperDimmingContent(
         draft, committed, epoch, dirty, tier,
         onEdit = vm::edit, onApply = vm::apply, onDiscard = vm::discard,
         onBack = { navController.popBackStack() },
@@ -44,7 +44,7 @@ fun AnimationDimmingScreen(navController: NavHostController, vm: DraftSettingsVi
 }
 
 @Composable
-fun AnimationDimmingContent(
+fun SuperDimmingContent(
     draft: AabSettings,
     committed: AabSettings,
     epoch: Int,
@@ -56,7 +56,7 @@ fun AnimationDimmingContent(
     onBack: () -> Unit,
     onOpenOnboarding: () -> Unit,
 ) {
-    DraftSettingsScaffold("Animation & Dimming", dirty, onApply, onDiscard, onBack) { padding ->
+    DraftSettingsScaffold("Super Dimming", dirty, onApply, onDiscard, onBack) { padding ->
         SettingsColumn(padding) {
             SectionHeader("Super dimming")
             if (tier != Tier.ELEVATED) {

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/ui/SettingsScreensTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/ui/SettingsScreensTest.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.test.performScrollTo
 import com.tideo.autobrightness.app.settings.AabSettings
 import com.tideo.autobrightness.app.settings.SettingsValidator
 import com.tideo.autobrightness.app.state.AppEntry
-import com.tideo.autobrightness.app.ui.screens.AnimationDimmingContent
+import com.tideo.autobrightness.app.ui.screens.SuperDimmingContent
 import com.tideo.autobrightness.app.ui.screens.ContextsContent
 import com.tideo.autobrightness.app.ui.screens.CurveBrightnessContent
 import com.tideo.autobrightness.app.ui.screens.MiscContent
@@ -88,10 +88,10 @@ class SettingsScreensTest {
     }
 
     @Test
-    fun animationDimming_dimmingRowsDisabledWithoutElevated() {
+    fun superDimming_dimmingRowsDisabledWithoutElevated() {
         compose.setContent {
             MaterialTheme {
-                AnimationDimmingContent(
+                SuperDimmingContent(
                     AabSettings(), AabSettings(), epoch = 0, dirty = false, tier = Tier.BASIC,
                     onEdit = {}, onApply = {}, onDiscard = {}, onBack = {}, onOpenOnboarding = {},
                 )

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/ui/UiShellTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/ui/UiShellTest.kt
@@ -3,20 +3,21 @@ package com.tideo.autobrightness.app.ui
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.tideo.autobrightness.app.navigation.AppRoute
+import com.tideo.autobrightness.app.navigation.navigateTopLevel
 import com.tideo.autobrightness.app.state.DashboardUiState
-import com.tideo.autobrightness.app.ui.components.AabNavDrawer
 import com.tideo.autobrightness.app.ui.onboarding.OnboardingContent
 import com.tideo.autobrightness.app.ui.onboarding.OnboardingUiState
 import com.tideo.autobrightness.app.ui.screens.DashboardContent
+import com.tideo.autobrightness.app.ui.screens.MenuContent
 import com.tideo.autobrightness.app.ui.screens.PlaceholderScreen
 import com.tideo.autobrightness.platform.privilege.Tier
 import org.junit.Rule
@@ -27,9 +28,10 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
- * Robolectric compose smoke test (S11 acceptance): the Dashboard renders its live readout and every
- * target route navigates. Drives the stateless content composables + the [AppRoute] table directly,
- * so it exercises the shell without standing up the ViewModels / DataStore.
+ * Robolectric compose smoke test: the Menu hub renders + navigates, the Dashboard renders its live
+ * readout, the S12.6a renames resolve, and back from a settings screen lands on the Menu. Drives the
+ * stateless content composables + the [AppRoute] table directly, so it exercises the shell without
+ * standing up the ViewModels / DataStore.
  */
 @RunWith(RobolectricTestRunner::class)
 class UiShellTest {
@@ -38,8 +40,49 @@ class UiShellTest {
     val compose = createComposeRule()
 
     @Test
+    fun menuContent_rendersHeroCardsAndNavigatesEveryDestination() {
+        // S12.6a (G2R-F2): the Profiles + Contexts hero cards live on the Menu hub, not the Dashboard.
+        var navigated: AppRoute? = null
+        var recheck = false
+        compose.setContent {
+            MaterialTheme {
+                MenuContent(
+                    activeContext = null,
+                    onNavigate = { navigated = it },
+                    onRecheckPermissions = { recheck = true },
+                )
+            }
+        }
+
+        compose.onNodeWithTag("hero_profiles").performScrollTo().performClick()
+        assertEquals(AppRoute.Profiles, navigated)
+        compose.onNodeWithTag("hero_contexts").performScrollTo().performClick()
+        assertEquals(AppRoute.Contexts, navigated)
+
+        // Every plain nav row (Dashboard + Settings + Info & Help groups) navigates.
+        AppRoute.menuNavDestinations.forEach { route ->
+            compose.onNodeWithTag("menu_${route.route}").performScrollTo()
+                .performSemanticsAction(SemanticsActions.OnClick)
+            assertEquals(route, navigated)
+        }
+        compose.onNodeWithTag("menu_recheck_permissions").performScrollTo()
+            .performSemanticsAction(SemanticsActions.OnClick)
+        assertTrue(recheck)
+    }
+
+    @Test
+    fun renamedRoutes_resolveToTaskerNames() {
+        // S12.6a (G2R-F3/F4): the routes carry the Tasker names.
+        assertEquals("super_dimming", AppRoute.SuperDimming.route)
+        assertEquals("Super Dimming", AppRoute.SuperDimming.label)
+        assertEquals("circadian", AppRoute.Circadian.route)
+        assertEquals("Circadian", AppRoute.Circadian.label)
+    }
+
+    @Test
     fun dashboardContent_rendersLiveReadoutAndToggles() {
         var toggled: Boolean? = null
+        var backed = false
         compose.setContent {
             MaterialTheme {
                 DashboardContent(
@@ -55,72 +98,41 @@ class UiShellTest {
                     onPause = {},
                     onResume = {},
                     onOpenOnboarding = {},
-                    onNavigate = {},
+                    onBack = { backed = true },
                 )
             }
         }
 
-        compose.onNodeWithText("Tideo Auto Brightness").assertExists()
+        compose.onNodeWithText("Dashboard").assertExists()
         compose.onNodeWithTag("tier_badge").assertExists()
         compose.onNodeWithTag("service_switch").performClick()
         assertEquals(true, toggled)
-
-        // The Profiles + Contexts hero cards (G2-F18) replace flat nav buttons on the Dashboard.
-        compose.onNodeWithTag("hero_profiles").assertExists()
-        compose.onNodeWithTag("hero_contexts").assertExists()
-
-        // Every tunable destination is reachable from the AAB-Menu drawer.
-        AppRoute.dashboardDestinations.forEach {
-            compose.onNodeWithTag("nav_${it.route}").assertExists()
-        }
+        // The live last-sample age renders (G2R-F5).
+        compose.onNodeWithTag("last_sample_age").performScrollTo().assertExists()
+        // Back returns to the Menu hub.
+        compose.onNodeWithTag("back_button").performClick()
+        assertTrue(backed)
     }
 
     @Test
-    fun navDrawer_navigatesToEveryDestination() {
-        // The AAB-Menu drawer (rebuild of scene menu.md) is stateless, so drive it directly —
-        // deterministic, no modal open-animation. Confirms every destination + Recheck Permissions.
-        var navigated: AppRoute? = null
-        var recheck = false
+    fun startsOnMenu_andBackFromSettingsLandsOnMenu() {
+        // Menu is the start destination; navigating to a settings screen and pressing back via the
+        // Menu-rooted pop returns to the Menu (S12.6a owner decision 1, G2R-F1).
+        lateinit var nav: androidx.navigation.NavHostController
         compose.setContent {
-            MaterialTheme {
-                AabNavDrawer(
-                    current = AppRoute.Dashboard,
-                    onNavigate = { navigated = it },
-                    onRecheckPermissions = { recheck = true },
-                )
+            nav = rememberNavController()
+            NavHost(navController = nav, startDestination = AppRoute.Menu.route) {
+                AppRoute.entries.forEach { route ->
+                    composable(route.route) { PlaceholderScreen(route.label, route.owner) }
+                }
             }
         }
 
-        // Invoke the OnClick semantics action directly: deterministic in Robolectric (no gesture
-        // injection / display dependency, which NavigationDrawerItem's selectable does not honour here).
-        AppRoute.dashboardDestinations.forEach { route ->
-            compose.onNodeWithTag("nav_${route.route}").performSemanticsAction(SemanticsActions.OnClick)
-            assertEquals(route, navigated)
-        }
-        compose.onNodeWithTag("nav_recheck_permissions").performSemanticsAction(SemanticsActions.OnClick)
-        assertTrue(recheck)
-    }
-
-    @Test
-    fun heroCards_navigateToProfilesAndContexts() {
-        var navigated: AppRoute? = null
-        compose.setContent {
-            MaterialTheme {
-                DashboardContent(
-                    state = DashboardUiState(tier = Tier.BASIC, serviceRunning = true),
-                    onToggleService = {},
-                    onPause = {},
-                    onResume = {},
-                    onOpenOnboarding = {},
-                    onNavigate = { navigated = it },
-                )
-            }
-        }
-
-        compose.onNodeWithTag("hero_profiles").performScrollTo().performClick()
-        assertEquals(AppRoute.Profiles, navigated)
-        compose.onNodeWithTag("hero_contexts").performScrollTo().performClick()
-        assertEquals(AppRoute.Contexts, navigated)
+        compose.onNodeWithText(AppRoute.Menu.label).assertExists()
+        compose.runOnUiThread { nav.navigateTopLevel(AppRoute.SuperDimming) }
+        compose.onNodeWithText(AppRoute.SuperDimming.label).assertExists()
+        compose.runOnUiThread { nav.popBackStack() }
+        compose.onNodeWithText(AppRoute.Menu.label).assertExists()
     }
 
     @Test
@@ -128,14 +140,14 @@ class UiShellTest {
         lateinit var nav: androidx.navigation.NavHostController
         compose.setContent {
             nav = rememberNavController()
-            NavHost(navController = nav, startDestination = AppRoute.Dashboard.route) {
+            NavHost(navController = nav, startDestination = AppRoute.Menu.route) {
                 AppRoute.entries.forEach { route ->
                     composable(route.route) { PlaceholderScreen(route.label, route.owner) }
                 }
             }
         }
 
-        AppRoute.entries.filter { it != AppRoute.Dashboard }.forEach { route ->
+        AppRoute.entries.filter { it != AppRoute.Menu }.forEach { route ->
             compose.runOnUiThread { nav.navigate(route.route) }
             compose.onNodeWithText(route.label).assertExists()
         }

--- a/docs/rebuild/PARITY_CHECKLIST.md
+++ b/docs/rebuild/PARITY_CHECKLIST.md
@@ -70,23 +70,23 @@ filled by S1/S2 during extraction.
 
 | Scene | XML | Ported to | Status |
 |---|---|---|---|
-| AAB Menu | L4462 | Dashboard (M3 nav) | ported (S11 — M3 nav shell + live Dashboard; nav to all target screens) |
+| AAB Menu | L4462 | Menu (home hub) | ported (S11 nav shell → S12.6a promoted to a real `Menu` home screen: banner + Profiles/Contexts hero cards + grouped nav; start dest + back-target for all screens) |
 | AAB Brightness Settings | L1415 | Curve & Brightness | ported (S12.5b — curve-zone coefficients + live form2A/3A + draft→Apply preview chart; min/max/offset/scale moved to Misc, G2-F2) |
 | AAB Reactivity Settings | L6739 | Reactivity | ported (S12.5b — thresholds + DetectOverrides/trust; draft→Apply; chart slot S13) |
-| AAB Superdimming Settings | L7533 | Animation & Dimming | ported (S12.5b — ELEVATED-gated super dimming + PWM, mutually-exclusive (G2-F10), dim-spread gated on circadian (G2-F11); anim moved to Misc; chart slot S13) |
+| AAB Superdimming Settings | L7533 | Super Dimming (renamed S12.6a/G2R-F3) | ported (S12.5b — ELEVATED-gated super dimming + PWM, mutually-exclusive (G2-F10), dim-spread gated on circadian (G2-F11); anim moved to Misc; chart slot S13) |
 | AAB Misc Settings | L4718 | Misc | ported (S12.5b — dedicated Misc screen, G2-F2: min/max sliders 0–75/150–255, offset/scale text, anim sliders + derived throttle, notifications + debug selector) |
-| AAB Experiment Settings | L3334 | Dynamic Scale | ported (S12.5b — scaling/taper + taper-midpoint slider 130–240 (G2-F13) + warnings; chart slot S13) |
+| AAB Experiment Settings | L3334 | Circadian (renamed S12.6a/G2R-F4) | ported (S12.5b — scaling/taper + taper-midpoint slider 130–240 (G2-F13) + warnings; chart slot S13) |
 | AAB Profile | L5724 | Profiles & Import/Export | ported (S12 — built-in profiles + reset + JSON/legacy import-export + context CRUD; reapply-on-load S12.5b; context-rule editor fidelity S12.5c — `<queries>` app list w/ icons, use-current-SSID, SUNRISE/SUNSET tokens, usage-access prompt, save/delete toasts; profile-load keeps DetectOverrides G2-F8) |
 | AAB Debug Scene | L2583 | Tools/Misc | ported (S12.5b — 10-label debug selector moved to Misc; S12.5c — selector now drives runtime debug toasts G2-F15 + %AAB_Test wizard report→clipboard; Tools keeps wizard + calibration entry) |
-| AAB Color Filter | L2552 | Animation & Dimming | ported (S12 — PWM-sensitive + exponent rows) |
+| AAB Color Filter | L2552 | Super Dimming | ported (S12 — PWM-sensitive + exponent rows) |
 | AAB Brightness Graph | L1202 | Curve & Brightness (BrightnessCurveChart) | ported (S12 — BrightnessCurveChart = chart template; ChartCanvas engine) |
 | AAB Alpha Graph | L1038 | Reactivity (alpha overlay) | partial (S12 host slot; chart render S13) |
 | AAB Reactivity Graph | L6563 | Reactivity (ReactivityChart) | partial (S12 host slot; chart render S13) |
-| AAB Dimming Graph | L3006 | Animation & Dimming (DimmingChart) | partial (S12 host slot; chart render S13) |
-| AAB Circadian Dimming Graph | L2388 | Animation & Dimming (CircadianChart; re-homed S3.5/D-026, visible only when %AAB_ScalingUse on) | partial (S12 host slot; chart render S13) |
-| AAB Taper Graph | L8387 | Dynamic Scale (TaperChart) | partial (S12 host slot; chart render S13) |
+| AAB Dimming Graph | L3006 | Super Dimming (DimmingChart) | partial (S12 host slot; chart render S13) |
+| AAB Circadian Dimming Graph | L2388 | Super Dimming (CircadianChart; re-homed S3.5/D-026, visible only when %AAB_ScalingUse on) | partial (S12 host slot; chart render S13) |
+| AAB Taper Graph | L8387 | Circadian (TaperChart) | partial (S12 host slot; chart render S13) |
 | AAB Power Draw Graph | L5611 | Tools (PowerDrawChart) | partial (S12 host slot; chart + on-device calibration S13/Gate) |
-| AAB Experiment Graph | L3170 | Dynamic Scale (ExperimentChart) | partial (S12 host slot; chart render S13) |
+| AAB Experiment Graph | L3170 | Circadian (ExperimentChart) | partial (S12 host slot; chart render S13) |
 | AAB About | L799 | About+Guide+Onboarding | partial (S11 — onboarding/privilege stepper done; About content S13) |
 | AAB User Guide | L8551 | About+Guide+Onboarding | partial (S11 — onboarding done; User Guide content S13) |
 | AAB Chart.Js License | L2194 | dropped(Chart.js removed) | pending (S2 extracted) |

--- a/docs/rebuild/RUNBOOK.md
+++ b/docs/rebuild/RUNBOOK.md
@@ -926,12 +926,21 @@ overlay + wizard have real input.
 4. **Curve chart overlays recorded override points** (G2R-F14): `BrightnessCurveChart` plots the recorded
    points as markers; the fitted/suggested curve shows only when ≥ 9 points exist (task38 threshold) — use
    the existing `ChartCanvas` marker API (do not modify ChartCanvas).
+5. **Fix manual-override FALSE POSITIVES on rapid light changes** (G2R-F26, added 2026-06-14; full
+   code-grounded analysis in STATE.md **D-049**). A fast lux swing pauses the pipeline as if the user moved
+   the slider. Primary suspect: `BrightnessPipelineController.handleOverride` commits the pause immediately,
+   omitting Tasker task567 act8's **cycle-time settle wait + re-read** ("before the new brightness has taken
+   hold"). Add that settle/re-check; then harden the single-latest self-write marker
+   (`ScreenBrightnessController.isSelfWrite`) and the OEM-range round-trip drift in `AnimationRunner`'s
+   read-back (compare in device space / with tolerance — see D-049 #2/#4). Add a regression test: a rapid
+   from→to with interleaved self-writes must NOT emit `OverrideDetected`, but a genuine external write after
+   settling MUST. Stay within the single-pipeline-coroutine model (D-027).
 
 **Non-goals:** the curve-fitting math (S6, golden), ChartCanvas internals. **HARD FENCE: domain/ untouched.**
 
 **Acceptance:** `:app:assembleDebug :app:testDebugUnitTest :app:lintDebug :domain:test :platform:test`
 green; regression tests for the reapply-uses-fresh-settings + min-brightness paths + override-point
-persistence; STATE.md/checklist updated; pushed.
+persistence + the rapid-light-change override false-positive (G2R-F26/D-049); STATE.md/checklist updated; pushed.
 
 ---
 

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -167,7 +167,8 @@ AppModule is now the real DI root.
   Circadian renames + Dashboard last-sample fix — landed the nav/testTag reshape b/c/d/e depend on),
   then **S12.6b** (Live Debug scene + per-screen diagnostic cards + global debug selector + teal toasts),
   **S12.6c** (reapply-uses-fresh-settings + min-bright runtime bug + override-point capture + curve
-  overlay), **S12.6d** (profile save/overwrite/factory-restore + SAF legacy import + per-screen reset +
+  overlay + **override false-positives on rapid light changes, G2R-F26/D-049**), **S12.6d** (profile
+  save/overwrite/factory-restore + SAF legacy import + per-screen reset +
   Apply-gate), **S12.6e** (label/long-press-help audit + context Wi-Fi/location + usage-access flow +
   load toasts). b/c/d/e are a parallel window now that a is merged. Domain/ + golden vectors +
   ChartCanvas API stay fenced. **NOTE for b/c/d/e:** the AAB Menu is now the home `AppRoute.Menu`;
@@ -874,7 +875,41 @@ Seeded by the S0 audit (details in CLAUDE.md "Facts & corrections ledger"):
   (D-044c) — the wizard still runs against an empty recorded set; S13/S14 should add runtime capture.
   (Affects S13, S14, Gate 2.)
 
-Append new entries as D-048, D-049, … with which segments they affect.
+- D-049: OVERRIDE-DETECTION FALSE POSITIVES ON RAPID LIGHT CHANGES (owner-reported 2026-06-14, G2R-F26).
+  **DEFERRED to S12.6c — not yet fixed.** Symptom: a fast lux swing makes the pipeline pause as a "manual
+  override" although nothing external wrote the brightness. Code-grounded analysis (S12.6a investigated,
+  did not change source — HARD FENCE: this is `app/runtime` + `platform` glue, NOT domain/):
+
+  Two override-detect paths exist, both suspect, and a Tasker settle step is MISSING:
+  1. **Missing cycle-time settle wait + re-read in `BrightnessPipelineController.handleOverride`.** Its own
+     comment says it "mirrors the prof755 gate after the cycle-time wait" (task567 act8), but it commits
+     the pause IMMEDIATELY via `OverrideRules.shouldCommitPause` with **no delay and no second read**.
+     Tasker task567 waits `%AAB_CycleTime` and RE-CHECKS that the brightness is still off-target before
+     pausing — exactly the owner's "before the new brightness has taken hold". This is the strongest
+     candidate: add the settle wait (≈ `cycleTimeMs`, fallback to throttle) + re-read; only pause if the
+     observed value is still not our last self-write after settling.
+  2. **Single-latest self-write marker is too weak under rapid multi-frame writes.**
+     `ScreenBrightnessController.isSelfWrite` matches ONLY `lastSelfWriteDevice` (the most recent write).
+     A fast animation writes f1..fN quickly; the system `ContentObserver` can coalesce/reorder/delay
+     callbacks, and `read()` re-reads the CURRENT value. Between back-to-back cycles a delayed callback can
+     observe a value that is no longer the latest marker → leaks to `OverrideMonitor` as external. Consider
+     a short-lived set OR a "self-write generation + grace window" (suppress any change within ~N ms of our
+     last write) instead of a single equality.
+  3. **`autoRunning` gate hole.** `runCycle` clears `autoRunning` in its `finally` the instant `animate()`
+     returns, but the final frame's `ContentObserver` callback can arrive a few ms later when
+     `autoRunning=false`, so the gate then relies solely on the (weak, see #2) marker. A post-write settle
+     window (#1/#2) closes this too.
+  4. **OEM range round-trip drift in `AnimationRunner` read-back.** `controller.read()` is
+     `toDomain(toDevice(x))`, which is NOT identity when `config_screenBrightnessSettingMaximum != 255`
+     (e.g. deviceMax 100/1023/2047/4095), so `observed != lastWritten` can fire `OVERRIDDEN` on EVERY
+     multi-frame animation on those devices — device-dependent, which may explain why it's intermittent.
+     Compare in DEVICE space (raw values) or with a ±1 tolerance, not domain space.
+  RECOMMENDED for the next model (S12.6c): start with #1 (the missing settle wait/re-read — most faithful
+  to Tasker and matches the owner's intuition), then harden #2/#4. Add a regression test: a rapid
+  from→to with an interleaved self-write sequence must NOT yield `OverrideDetected`; and a real external
+  write after settling MUST. Keep it inside the single-pipeline-coroutine model (D-027). (Affects S12.6c.)
+
+Append new entries as D-049, D-050, … with which segments they affect.
 
 ## Blockers
 
@@ -1064,6 +1099,11 @@ snippets are preserved (gold `#FFC107` highlight = the AAB value colour).
 - **G2R-F13** **Manual override points are not recorded** (the wizard's input; D-044c capture still unwired).
 - **G2R-F14** The brightness curve used to **overlay all recorded override points**; the fitted curve only
   appeared with **> 8 points**. Restore the point overlay + fit-only-when-≥9 behaviour.
+- **G2R-F26** (owner-reported 2026-06-14, post-S12.6a; NOT in the original re-test batch) **Manual-override
+  FALSE POSITIVES on rapid light changes** — a fast lux swing makes the pipeline pause as if the user
+  grabbed the slider, when nothing external wrote. Owner's read: a mutex issue, or new light readings are
+  allowed before the new brightness has "taken hold". **Deferred to S12.6c** (do NOT touch domain/; this is
+  controller/animation/observer glue). Code-grounded root-cause analysis + recommended fix in **D-049**.
 
 *Profiles & persistence (→ S12.6d):*
 - **G2R-F15** **Cannot save a custom profile**, and want to be able to **overwrite existing profiles** too

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -37,11 +37,23 @@ next session does not know it.
 | S12.5b interaction model (preview→Apply, sliders, grouping) | 2026-06-13 | Opus/high | DONE | (see push) | Ported AAB's temporary-preview→Apply editing model + bounded sliders + faithful Misc grouping + validation parity (D-047; addresses G2-F1/F2/F3/F4/F5/F6/F7/F10/F11/F13/F16). New `state/DraftSettingsViewModel.kt` (per-screen NavBackStackEntry-scoped draft: edit→draft only, **Apply** commits draft→DataStore + forces re-eval, **Discard**/dirty-back reverts; `epoch`-seeded fields fix mid-edit corruption G2-F7; advisory errors on the draft). `SettingsControls.kt`: seed-once `NumberSettingField` w/ committed `[bracket]` + empty-allowed (G2-F1/F7), new bounded `IntSliderSettingField` (G2-F3/F13), `DraftApplyBar` + `DraftSettingsScaffold` (Apply/Discard + dirty-back confirm). **6 sliders w/ exact Tasker ranges** (misc_settings.md / experiment_settings.md): MinBright 0–75, MaxBright 150–255, AnimSteps 0–100, MinWait 1–99, MaxWait 2–100, TaperMidpoint 130–240. New **Misc** screen (`AppRoute.Misc`, drawer Settings group, NavGraph wired) holds min/max sliders + offset/scale + anim sliders + derived throttle + notifications + the 10-label debug selector (moved off Tools) — the G2-F2 regrouping; Curve & Brightness now only the curve-zone coefficients, Animation & Dimming only super-dimming+PWM (mutually exclusive, G2-F10) + circadian-gated dim spread (G2-F11). Forced re-eval path: `AutoBrightnessRuntime.reapply`→service `ACTION_REAPPLY`→`controller.reapply()` (UNLIMITED ContextChanged event), gated on serviceEnabled; SettingsViewModel applyProfile/reset/replaceAll reapply too (G2-F16). Validator: +zone2End<zone1End NaN guard (G2-F6) + dangerously-low-scale (G2-F5); BrightnessCurveChart floors at minBrightness (G2-F4). Tests: `DraftSettingsViewModelTest`(3, real DataStore — edit/dirty/discard, apply commits, serviceEnabled preserved) + `SettingsScreensTest` rewritten (8: validator errors, draft bracket, slider ranges asserted, Apply/Discard wiring, debug label on Misc). Full ladder GREEN: `:app:assembleDebug :app:testDebugUnitTest`(85) `:app:lintDebug :domain:test :platform:test`. No compaction. |
 | S12.5c feature & behaviour fidelity | 2026-06-14 | Opus/high | DONE | (see push) | Closed the remaining Gate-2 behaviour gaps (D-048). **G2-F8** profile-load-disables-overrides FIXED: `detectOverrides` is a global preference, not a task626 snapshot key → preserved in `mergeProfile` + `SettingsViewModel.applyProfile/replaceAll`. **G2-F12** toasts restored via `ui/components/Toaster.kt` (`rememberToaster`): Apply (shared `DraftApplyBar`), profile apply/reset/import-export, context save/delete, wizard apply/copy. **G2-F14** context-rule editor fidelity: manifest `<queries>` LAUNCHER block + app icons (`AppEntry.icon`, core-ktx `toBitmap`), "use current Wi-Fi" (`WifiInfoReader.currentSsid()`), SUNRISE/SUNSET time tokens, usage-access prompt+deep-link when an app trigger is set. **G2-F15** runtime debug toasts: new `runtime/RuntimeDebug.kt` (`DebugCategory`×9/`DebugSink`/NoOp) + `ToastDebugSink` wired into the pipeline (LIGHT_EVAL/ANIMATION_DETAILS/DYNAMIC_SCALE/GRAPH_METRICS + SKIP_ANIMATIONS behaviour), SuperDimmingCoordinator (SUPER_DIMMING), ContextEngine (CONTEXT_AUTOMATION/LOCATION), gated on the live debugLevel; `%AAB_Test` wizard report → clipboard in Tools. **G2-F9** super-dimming: engagement logic verified + now driven by the S12.5b reapply; added a SUPER_DIMMING debug toast (engage / why-not) + precise AOSP-secure-key/OEM-variance note for the device gate (no logic bug found). **G2-F17** QS tile subtitle = Off/Active/Paused/Starting from LiveRuntimeState. New tests: RuntimeDebugTest(3), ContextEngineTest.mergeProfile_preservesDetectOverrides, SettingsScreensTest +2 (context editor SUNRISE/SSID + usage-access prompt). Full ladder GREEN: `:app:assembleDebug :app:testDebugUnitTest`(91) `:app:lintDebug :domain:test :platform:test`. Lint baseline unchanged. No compaction. **GATE 2 RE-TEST READY.** |
 
+| S12.6a IA & naming | 2026-06-14 | Opus/high | DONE | (see push) | Menu-as-home reshape + two renames + Dashboard last-sample fix (G2R-F1…F5). **AAB Menu promoted to a real home hub** (`AppRoute.Menu` + `ui/screens/MenuScreen.kt`): gold-sun teal banner (rebranded "Tideo Auto Brightness", not "Advanced"), Profiles/Contexts **hero cards moved off the Dashboard**, Settings/Info&Help nav groups; it is the start destination after onboarding (tier!=NONE→Menu) and the back-target from every settings/tool screen via new `NavHostController.navigateTopLevel` (popUpTo(menu)). The S12.5a `AabNavDrawer` retired; `AabTopBar` gained an optional back arrow (AutoMirrored). Dashboard slimmed to live-status (tier badge, master switch, live readout, health) + back→Menu. **Renames:** `AnimationDimming`→`SuperDimming` (route `super_dimming`, title "Super Dimming", G2R-F3); `DynamicScale`→`Circadian` (route `circadian`, title "Circadian", G2R-F4) — files `AnimationDimmingScreen.kt`→`SuperDimmingScreen.kt`, `DynamicScaleScreen.kt`→`CircadianScreen.kt` (composables + content fns + NavGraph + tests). **Last-sample fix (G2R-F5):** `PipelineState.lastSampleMs` recorded for every delivered sample in `onSensorSample` (atomic StateFlow.update), surfaced via LiveRuntimeState→DashboardUiState, rendered as relative "Xs ago" (replaces the never-written health-store source). Domain/golden/ChartCanvas untouched. Tests: `UiShellTest` rewritten (Menu hero+nav, renames resolve, start-on-Menu + back-from-settings→Menu, last-sample renders); `SettingsScreensTest` SuperDimming rename. Ladder GREEN: `:app:assembleDebug :app:testDebugUnitTest :app:lintDebug`. No compaction. |
+
 Status values: DONE · PARTIAL · BLOCKED (see failure protocol in CLAUDE.md).
 
 ## Current state
 
-**S12.5 UI salvage DONE + GATE-2 RE-TEST done → S12.6 planned (next work).** The owner re-tested the
+**S12.6a (IA & naming) DONE → S12.6b/c/d/e remain (parallel window).** The AAB Menu is now the app's
+home hub (start destination + back-target); the Profiles/Contexts hero cards live there (off the
+Dashboard), which is slimmed to a live-status screen reached from the Menu. `Animation & Dimming` is
+renamed **Super Dimming** and `Dynamic Scale` **Circadian** (routes, titles, files, tests). The
+Dashboard "Last sensor sample: never" bug is fixed (G2R-F5): the pipeline now records every sample's
+time in `PipelineState.lastSampleMs` and the Dashboard renders it as a live "Xs ago". The banner is
+rebranded "Tideo Auto Brightness" (owner note — was "Advanced"). Ladder GREEN
+(`:app:assembleDebug :app:testDebugUnitTest :app:lintDebug`). **Next: S12.6b/c/d/e (now unblocked — the
+nav/testTag reshape they depend on is landed), then HUMAN GATE 2 re-test after S12.6e.**
+
+**(historical) S12.5 UI salvage DONE + GATE-2 RE-TEST done → S12.6 planned (next work).** The owner re-tested the
 S12.5c build on-device (2026-06-14): two S12.5 fixes re-confirmed (min-bright graph, QS tile) but a
 second, larger batch of parity/behaviour gaps surfaced — **25 findings G2R-F1…F25** (see "Gate 2
 RE-TEST" below), structured and routed into a new **S12.6** (a–e, all Opus/high; RUNBOOK). Four binding
@@ -151,13 +163,16 @@ AppModule is now the real DI root.
   signed off.
 - **S12.6 — Gate-2 re-test salvage (a–e, all Opus/high)** is the NEXT work (brief in RUNBOOK). Owner
   decisions are binding (menu-as-home; block-Apply-on-critical-errors; all-profiles-editable+factory-
-  restore; SAF folder grant for legacy import). **S12.6a FIRST** (menu-as-home reshape + Super Dimming /
-  Circadian renames + Dashboard last-sample fix — touches all nav/testTags), then **S12.6b** (Live Debug
-  scene + per-screen diagnostic cards + global debug selector + teal toasts), **S12.6c** (reapply-uses-
-  fresh-settings + min-bright runtime bug + override-point capture + curve overlay), **S12.6d** (profile
-  save/overwrite/factory-restore + SAF legacy import + per-screen reset + Apply-gate), **S12.6e** (label/
-  long-press-help audit + context Wi-Fi/location + usage-access flow + load toasts). b/c/d/e are a
-  parallel window after a. Domain/ + golden vectors + ChartCanvas API stay fenced.
+  restore; SAF folder grant for legacy import). **S12.6a DONE** (menu-as-home reshape + Super Dimming /
+  Circadian renames + Dashboard last-sample fix — landed the nav/testTag reshape b/c/d/e depend on),
+  then **S12.6b** (Live Debug scene + per-screen diagnostic cards + global debug selector + teal toasts),
+  **S12.6c** (reapply-uses-fresh-settings + min-bright runtime bug + override-point capture + curve
+  overlay), **S12.6d** (profile save/overwrite/factory-restore + SAF legacy import + per-screen reset +
+  Apply-gate), **S12.6e** (label/long-press-help audit + context Wi-Fi/location + usage-access flow +
+  load toasts). b/c/d/e are a parallel window now that a is merged. Domain/ + golden vectors +
+  ChartCanvas API stay fenced. **NOTE for b/c/d/e:** the AAB Menu is now the home `AppRoute.Menu`;
+  use `navigateTopLevel` for any new top-level destination so back still returns to the Menu; the
+  global debug selector S12.6b moves OFF Misc belongs on the new Live Debug screen reached from the Menu.
 - **HUMAN GATE 2 — RE-TEST AGAIN** after S12.6e. Re-verify all G2R-Fn + the original Gate-2 set.
 - **S13** (chart replication + static screens) follows S12.6 on the serial spine — preconditions S12.6
   DONE (faithful screens + menu IA), S6 DONE. S13 copies `ui/graph/BrightnessCurveChart.kt` (over

--- a/docs/rebuild/screen_map.md
+++ b/docs/rebuild/screen_map.md
@@ -23,13 +23,20 @@ rects and `PropertiesElement` scene-chrome are dropped (replaced by the M3 Scaff
 > 10 `%AAB_Debug` categories (D-023); confirmations/warnings toast across screens (G2-F12); the QS
 > tile shows the live paused/running state (G2-F17). Behaviour-only — the screen set is unchanged.
 
+> **S12.6a update (IA + naming, G2R-F1/F2/F3/F4):** the **AAB Menu is now a real home screen** (hub +
+> back-target; route `menu`) — the S12.5a nav drawer was promoted into it, and the Profiles/Contexts
+> hero cards moved off the Dashboard onto the Menu. The Dashboard is now a focused live-status screen
+> reached from the Menu (back → Menu, not Dashboard). Two screens are **renamed** to the Tasker names:
+> `Animation & Dimming` → **Super Dimming** (`super_dimming`), `Dynamic Scale` → **Circadian** (`circadian`).
+
 | Screen | Source scenes | Charts |
 |---|---|---|
-| **Dashboard** | Menu (nav), Misc Settings (service switch) | — |
+| **Menu** (home hub) | AAB Menu scene (banner + grouped nav + Profiles/Contexts hero cards) | — |
+| **Dashboard** (live status) | Misc Settings (service switch), live pipeline readout | — |
 | **Curve & Brightness** | Brightness Settings (curve coefficients), Brightness Graph | BrightnessCurveChart |
 | **Reactivity** | Reactivity Settings, Reactivity Graph, Alpha Graph | ReactivityChart |
-| **Animation & Dimming** | Superdimming Settings, Color Filter, Dimming/Circadian Graphs | DimmingChart, CircadianChart |
-| **Dynamic Scale** | Experiment Settings, Experiment Graph, Taper Graph | ExperimentChart, TaperChart |
+| **Super Dimming** | Superdimming Settings, Color Filter, Dimming/Circadian Graphs | DimmingChart, CircadianChart |
+| **Circadian** | Experiment Settings, Experiment Graph, Taper Graph | ExperimentChart, TaperChart |
 | **Misc** | Misc Settings (min/max/offset/scale, anim steps + waits + throttle, notifications, debug) | — |
 | **Contexts** | (rules surfaced from contexts_spec — no dedicated Tasker scene; editor lives in AAB Profile) | — |
 | **Tools** | Debug Scene (wizard), Power Draw Graph, (wizard from Brightness Graph 'Suggest', calibration from task524) | PowerDrawChart |
@@ -55,12 +62,19 @@ Every Chart.js WebElement maps to a named Compose-Canvas chart (built S12/S13). 
 
 ## Per-scene element dispositions (all 450 rows)
 
-### AAB Menu  ·  `menu`  ·  XML L4462–4717  ·  3 elements  → (nav hub)
+### AAB Menu  ·  `menu`  ·  XML L4462–4717  ·  3 elements  → **Menu home screen**
 
-**S12.5a:** rebuilt as the `AabNavDrawer` (`ModalNavigationDrawer`, `ui/components/AppShell.kt`) opened
-from the branded `AabTopBar` hamburger — the menu's three HTML "cards" become drawer groups
+**S12.5a:** first rebuilt as the `AabNavDrawer` (`ModalNavigationDrawer`, `ui/components/AppShell.kt`)
+opened from the branded `AabTopBar` hamburger — the menu's three HTML "cards" become groups
 (Profiles&Contexts hero / Settings / Info&Help); Recheck Permissions → Onboarding; the Chart.js License
-entry is dropped (D-046). Profiles + Contexts also surface as hero cards on the Dashboard.
+entry is dropped (D-046).
+
+**S12.6a (G2R-F1/F2):** promoted into a real `AppRoute.Menu` home screen (`ui/screens/MenuScreen.kt`)
+= the app hub and the **start destination after onboarding**. Renders the gold-sun teal banner
+(`AabMenuBanner`, branded "Tideo Auto Brightness"), the **Profiles + Contexts hero cards** (moved OFF
+the Dashboard), and the Settings / Info&Help nav groups. Every settings/tool screen's back returns
+here (`navigateTopLevel` roots the back stack at `menu`). The Dashboard is now just another menu
+destination. The S12.5a drawer is retired.
 
 | Element | Type | Disposition |
 |---|---|---|


### PR DESCRIPTION
## Summary

Reshapes the app's information architecture to make the AAB Menu a real home hub (start destination and back-target from all screens), moves Profiles/Contexts hero cards off the Dashboard, and renames two screens to match Tasker names. Fixes the Dashboard's last-sample age readout to use the live pipeline.

## Key Changes

- **New Menu home screen** (`MenuScreen.kt`): Promotes the S12.5a nav drawer into a real destination with the gold-sun teal banner, Profiles/Contexts hero cards, and grouped navigation (Settings, Info & Help). Sets `AppRoute.Menu` as the start destination after onboarding.

- **Dashboard refocus**: Removes the nav drawer, hero cards, and menu button; adds a back arrow that returns to Menu. Becomes a focused live-status screen showing service switch, tier badge, and health readout.

- **Screen renames** (G2R-F3/F4):
  - `AnimationDimming` → `SuperDimming` (route `super_dimming`, label "Super Dimming")
  - `DynamicScale` → `Circadian` (route `circadian`, label "Circadian")

- **Top bar refactor** (`AabTopBar`): Replaces hamburger menu button with optional back arrow (null on Menu, present on all other screens). Rebrands banner from "Advanced" to "Tideo".

- **Last-sample age fix** (G2R-F5): Dashboard's health card now reads `lastSampleMs` from the live pipeline (`PipelineState`) instead of the never-written health store, computed as relative age on each recomposition.

- **Navigation model** (`navigateTopLevel`): All non-Menu screens use top-level navigation that pops back to Menu, ensuring consistent back behavior.

- **Test updates**: `UiShellTest` rewritten to verify Menu renders and navigates all destinations, Dashboard back button works, and renamed routes resolve to Tasker names.

## Implementation Details

- `MenuContent` is stateless and driven by callbacks, enabling Robolectric testing without ViewModels.
- `MenuHeroCard` extracted as a reusable component (previously `HeroCard` on Dashboard).
- `AabMenuBanner` extracted from the drawer (previously `DrawerBanner`).
- `AabSectionLabel` reused for section headers in Menu.
- `DashboardUiState` now carries `lastSampleMs: Long?` from the pipeline.
- `BrightnessPipelineController` records `lastSampleMs` on each sensor sample (G2R-F5).
- Removed `AabNavDrawer` entirely; its navigation logic is now in `MenuScreen`.

All changes are scoped to S12.6a (G2R-F1…F5) per the RUNBOOK. Full ladder green: `:app:assembleDebug :app:testDebugUnitTest :app:lintDebug :domain:test :platform:test`.

https://claude.ai/code/session_0194zsExsstvB8hCXQgarYCi