### PR TITLE
S12.6c: Pipeline behaviour correctness & override-point capture

### DIFF
--- a/app/src/main/kotlin/com/tideo/autobrightness/app/AppModule.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/AppModule.kt
@@ -9,7 +9,9 @@ import com.tideo.autobrightness.app.runtime.DebugSink
 import com.tideo.autobrightness.app.runtime.SuperDimmingCoordinator
 import com.tideo.autobrightness.app.runtime.ToastDebugSink
 import com.tideo.autobrightness.app.settings.ContextRuleStore
+import com.tideo.autobrightness.app.settings.OverridePointStore
 import com.tideo.autobrightness.app.storage.contextRulesDataStore
+import com.tideo.autobrightness.app.storage.overridePointsDataStore
 import com.tideo.autobrightness.app.storage.settingsDataStore
 import com.tideo.autobrightness.platform.brightness.AndroidScreenBrightnessController
 import com.tideo.autobrightness.platform.brightness.AndroidSecureDimmingController
@@ -33,6 +35,10 @@ class AppModule(context: Context) {
 
     /** Persistence + CRUD for context rules (exposed for the S12 rule-editing UI). */
     val contextRuleStore: ContextRuleStore = ContextRuleStore(appContext.contextRulesDataStore)
+
+    /** Recorded manual-override training points — captured by the pipeline, read by the wizard +
+     *  curve overlay (G2R-F13/F14). */
+    val overridePointStore: OverridePointStore = OverridePointStore(appContext.overridePointsDataStore)
 
     /**
      * Build a fresh runtime graph for a service lifetime. The brightness writer and observer SHARE
@@ -70,6 +76,8 @@ class AppModule(context: Context) {
                 debugSink = debugSink,
             ),
             debugSink = debugSink,
+            // Persist captured override points so the wizard + curve overlay have real input (G2R-F13).
+            overrideSink = { lux, brightness -> overridePointStore.record(lux, brightness) },
         )
 
         return RuntimeGraph(controller, contextEngine)

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
@@ -84,7 +84,13 @@ class AmbientMonitoringService : Service() {
                 // Settings Apply / profile load: re-run the pipeline now (G2-F16). ensureRunning()
                 // first so an Apply made while the service is up (but this start re-delivers) is safe.
                 ensureRunning()
-                controller.reapply()
+                // Refresh the effective settings from the FRESH baseline BEFORE re-applying, so a
+                // manual DataStore edit (e.g. min-brightness) takes effect immediately rather than
+                // using the stale context snapshot (G2R-F11/F12).
+                scope.launch {
+                    contextEngine.reevaluate()
+                    controller.reapply()
+                }
             }
             ACTION_PANIC -> {
                 // task528 panic = full stop (not a pausable state, G1-F4): restore brightness +

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AnimationRunner.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AnimationRunner.kt
@@ -47,24 +47,22 @@ class AnimationRunner(
         detectOverrides: Boolean,
     ): Result {
         val frames = steps.coerceAtLeast(1)
-        var lastWritten = from
         for (i in 1..frames) {
             // task696: re-read before writing the next frame; if the on-screen value is no longer
-            // our last self-write, an external app/user changed it → abort + override.
+            // our last self-write, an external app/user changed it → abort + override. The check is
+            // device-exact ([isOnScreenSelfWrite]) so OEM ranges where read() ≠ identity do not fire
+            // a spurious override on every frame (D-049 #4).
             if (detectOverrides && i > 1) {
-                val observed = controller.read()
-                if (observed != lastWritten) return Result.OVERRIDDEN
+                if (!controller.isOnScreenSelfWrite()) return Result.OVERRIDDEN
             }
             // Linear interpolation; the final frame lands exactly on `to`.
             val frame = if (i == frames) to else from + ((to - from) * i) / frames
             controller.write(frame)
-            lastWritten = frame
             if (waitMs > 0) sleep(waitMs)
         }
         // Final read-back: catch an override that landed during the last frame's wait.
         if (detectOverrides) {
-            val observed = controller.read()
-            if (observed != lastWritten) return Result.OVERRIDDEN
+            if (!controller.isOnScreenSelfWrite()) return Result.OVERRIDDEN
         }
         return Result.COMPLETED
     }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineController.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineController.kt
@@ -15,6 +15,7 @@ import com.tideo.autobrightness.platform.observe.BrightnessObserver
 import com.tideo.autobrightness.platform.sensor.LightSensorSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -51,6 +52,7 @@ class BrightnessPipelineController(
     private val animationRunner: AnimationRunner = AnimationRunner(brightness),
     private val dimming: DimmingCoordinator = NoOpDimmingCoordinator,
     private val debugSink: DebugSink = NoOpDebugSink,
+    private val overrideSink: OverridePointSink = NoOpOverridePointSink,
 ) {
     private val engine = BrightnessEngine()
 
@@ -226,7 +228,8 @@ class BrightnessPipelineController(
         try {
             val output = engine.evaluate(buildInput(rawLux, settings, s))
             val from = brightness.read()
-            val target = output.targetBrightness
+            // task661 act22-26 / task698 step 3: hold the hardware floor in PWM-sensitive mode (D-050).
+            val target = applyPwmFloor(output.targetBrightness, settings)
 
             // %AAB_Debug 3/4: Flash the light-evaluation + dynamic-scale figures (D-023, G2-F15).
             emitDebug(DebugCategory.LIGHT_EVAL, settings) {
@@ -305,22 +308,45 @@ class BrightnessPipelineController(
         )
     }
 
-    /** task567 Manual Override: record the point and latch paused; the service posts the notification. */
-    private fun handleOverride(observed: Int) {
+    /**
+     * task567 Manual Override: record the point and latch paused; the service posts the notification.
+     *
+     * task567 act8 settle: wait `%AAB_CycleTime` for the new brightness to "take hold", then RE-READ
+     * and re-check the gate before committing the pause. A rapid light swing makes the pipeline write
+     * its own multi-frame transition whose ContentObserver callbacks can lag/coalesce; only a value
+     * that, after settling, is still NOT what we last applied is a genuine manual override — so a fast
+     * lux swing no longer false-pauses the loop (G2R-F26/D-049 #1). This runs in the single pipeline
+     * consumer (D-027), so the settle delay simply defers the next event.
+     */
+    private suspend fun handleOverride(observed: Int) {
         val s = _state.value
-        // task567 act8 re-check guard (mirrors the prof755 gate after the cycle-time wait).
         if (!OverrideRules.shouldCommitPause(s.serviceOn, autoRunning, s.paused, initializing)) return
+
+        val settleMs = (s.cycleTimeMs?.toLong() ?: cachedSettings?.throttleDefaultMs ?: 0L).coerceAtLeast(0L)
+        if (settleMs > 0) delay(settleMs)
+
+        val s2 = _state.value
+        // Re-check the gate: a cycle/pause/panic may have started during the settle wait.
+        if (!OverrideRules.shouldCommitPause(s2.serviceOn, autoRunning, s2.paused, initializing)) return
+        val settled = brightness.read()
+        // Settled back to OUR last applied brightness → it was our in-flight write / a transient during
+        // a rapid swing, not a manual override (D-049 #1). Don't pause.
+        if (s2.lastAppliedBrightness != null && settled == s2.lastAppliedBrightness) return
+
         val history = OverrideRules.recordOverridePoint(
-            history = s.overrideHistory,
-            lux = s.smoothedLux ?: 0.0,
-            brightness = observed.toDouble(),
-            dynamicCompress = s.scaleDynamicCompress,
-            scalingUse = s.scalingUse,
+            history = s2.overrideHistory,
+            lux = s2.smoothedLux ?: 0.0,
+            brightness = settled.toDouble(),
+            dynamicCompress = s2.scaleDynamicCompress,
+            scalingUse = s2.scalingUse,
         )
         brightness.clearSelfWriteMarker()
         // task567: a manual override disengages any active super dimming.
         dimming.disengage()
         _state.update { it.copy(paused = true, overrideHistory = history) }
+        // Persist the captured training point (newest first) so the wizard + curve overlay have real
+        // input across restarts (G2R-F13; closes D-044c).
+        history.firstOrNull()?.let { (lux, bright) -> overrideSink.record(lux, bright) }
     }
 
     private fun pauseInternal() {
@@ -367,13 +393,14 @@ class BrightnessPipelineController(
         try {
             // previous = null → engine's first-run path maps the reading straight to a target.
             val output = engine.evaluate(buildInput(lux, settings, PipelineState()))
+            val target = applyPwmFloor(output.targetBrightness, settings)
             brightness.forceManualMode()
-            brightness.write(output.targetBrightness)
-            dimming.apply(output.targetBrightness, settings)
+            brightness.write(target)
+            dimming.apply(target, settings)
             _state.update {
                 it.copy(
-                    lastAppliedBrightness = output.targetBrightness,
-                    targetBrightness = output.targetBrightness,
+                    lastAppliedBrightness = target,
+                    targetBrightness = target,
                     lastAcceptedMs = clock(),
                 )
             }
@@ -381,6 +408,16 @@ class BrightnessPipelineController(
             initializing = false
         }
     }
+
+    /**
+     * task661 act22-26 / task698 step 3 hardware floor (D-050): when "Use software dimming
+     * (PWM-sensitive)" is on and the target falls below the dimming threshold, hold the HARDWARE
+     * brightness at the threshold (the panel's PWM-flicker floor). Further darkening is the
+     * secure/overlay layer's job (deferred, D-040) — not by writing a lower hardware value. The floor
+     * is in domain space; [ScreenBrightnessController] maps it onto the device range (cf. D-049 #4).
+     */
+    private fun applyPwmFloor(target: Int, settings: AabSettings): Int =
+        if (settings.pwmSensitive && target < settings.dimmingThreshold) settings.dimmingThreshold else target
 
     /** Emit a runtime debug Flash for [category] gated on the live debugLevel (D-023, G2-F15). */
     private fun emitDebug(category: DebugCategory, settings: AabSettings, message: () -> String) =
@@ -392,4 +429,18 @@ class BrightnessPipelineController(
     private companion object {
         const val PANIC_BRIGHTNESS = 255
     }
+}
+
+/**
+ * Sink for captured manual-override training points (task561 %AAB_Overrides). The runtime persists
+ * each genuine override so the curve wizard + curve overlay have real input (G2R-F13). Kept as a
+ * small interface so the controller stays unit-testable without a DataStore.
+ */
+fun interface OverridePointSink {
+    suspend fun record(lux: Double, brightness: Double)
+}
+
+/** No-op sink for controller unit tests / when no persistence is wired. */
+object NoOpOverridePointSink : OverridePointSink {
+    override suspend fun record(lux: Double, brightness: Double) = Unit
 }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/ContextEngine.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/ContextEngine.kt
@@ -84,6 +84,27 @@ class ContextEngine(
     /** Effective settings for the pipeline's settingsProvider: active profile override or baseline. */
     suspend fun effectiveSettings(): AabSettings = _effective.value ?: baselineProvider()
 
+    /**
+     * Re-derive the effective settings from the FRESH baseline now (settings Apply / profile load,
+     * G2R-F11/F12). [effectiveSettings] otherwise returns the cached `_effective` snapshot from the
+     * last context evaluation, so a manual DataStore edit (e.g. raising %AAB_MinBright) would not take
+     * effect until the next watcher eval — leaving the runtime on stale settings ("stuck at 10").
+     *
+     * This keeps the currently-resolved active context/profile (it does NOT re-run the watcher
+     * resolution, so it can't spuriously switch contexts) but re-reads the baseline and re-merges, so
+     * a global/baseline edit flows through immediately while any active override stays in effect.
+     * The service calls this before [BrightnessPipelineController.reapply].
+     */
+    suspend fun reevaluate() = evalMutex.withLock {
+        val baseline = baselineProvider()
+        val active = currentProfileName
+        _effective.value = if (_activeContext.value != null && active != null) {
+            profileCatalog.profile(active)?.let { mergeProfile(baseline, it) } ?: baseline
+        } else {
+            baseline
+        }
+    }
+
     fun start(scope: CoroutineScope) {
         if (this.scope != null) return
         this.scope = scope

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/OverridePointStore.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/OverridePointStore.kt
@@ -1,0 +1,75 @@
+package com.tideo.autobrightness.app.settings
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.Serializer
+import com.tideo.autobrightness.domain.wizard.OverridePoint
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * One persisted manual-override training point: the (lux, brightness) pair the user implicitly taught
+ * by grabbing the system slider. The brightness is the de-compressed "ideal base" brightness produced
+ * by [com.tideo.autobrightness.domain.brightness.OverrideRules.recordOverridePoint] (task561), so the
+ * curve wizard fits against the same value Tasker stores in `%AAB_Overrides<N>`.
+ */
+@Serializable
+data class OverridePointRecord(val lux: Double, val brightness: Double)
+
+/** The persisted override-point set (`%AAB_Overrides`, capped at [MAX_POINTS], newest first). */
+@Serializable
+data class OverridePoints(val points: List<OverridePointRecord> = emptyList()) {
+    companion object {
+        /** Tasker task561 caps %AAB_Overrides at 50 entries. */
+        const val MAX_POINTS = 50
+    }
+}
+
+/**
+ * DataStore serializer for the recorded override points. Survives service/process restarts so the
+ * Tools curve-suggestion wizard and the brightness-curve overlay (G2R-F13/F14) have real input,
+ * instead of always starting from an empty set (the D-044c gap).
+ */
+object OverridePointsSerializer : Serializer<OverridePoints> {
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    override val defaultValue: OverridePoints = OverridePoints()
+
+    override suspend fun readFrom(input: InputStream): OverridePoints =
+        runCatching {
+            json.decodeFromString(OverridePoints.serializer(), input.readBytes().decodeToString())
+        }.getOrDefault(defaultValue)
+
+    override suspend fun writeTo(t: OverridePoints, output: OutputStream) {
+        output.write(json.encodeToString(OverridePoints.serializer(), t).encodeToByteArray())
+    }
+}
+
+/**
+ * Persistence + capture for the manual-override training points. The pipeline records a point each
+ * time it pauses on a genuine manual override (newest-first, capped at [OverridePoints.MAX_POINTS],
+ * mirroring task561); the wizard / curve overlay read [points].
+ */
+class OverridePointStore(private val dataStore: DataStore<OverridePoints>) {
+
+    /** The recorded points as domain [OverridePoint]s (newest first), for the wizard + chart overlay. */
+    fun points(): Flow<List<OverridePoint>> = dataStore.data.map { stored ->
+        stored.points.map { OverridePoint(lux = it.lux, brightness = it.brightness) }
+    }
+
+    /** Append a captured override point (newest first), dropping the oldest beyond the cap. */
+    suspend fun record(lux: Double, brightness: Double) {
+        dataStore.updateData { current ->
+            val updated = listOf(OverridePointRecord(lux, brightness)) + current.points
+            OverridePoints(updated.take(OverridePoints.MAX_POINTS))
+        }
+    }
+
+    /** Clear all recorded points (Tools "reset overrides"). */
+    suspend fun clear() {
+        dataStore.updateData { OverridePoints() }
+    }
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/state/DraftSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/state/DraftSettingsViewModel.kt
@@ -9,6 +9,7 @@ import com.tideo.autobrightness.app.settings.AabSettings
 import com.tideo.autobrightness.app.settings.FieldError
 import com.tideo.autobrightness.app.settings.SettingsValidator
 import com.tideo.autobrightness.app.storage.settingsDataStore
+import com.tideo.autobrightness.domain.wizard.OverridePoint
 import com.tideo.autobrightness.platform.privilege.PrivilegeManager
 import com.tideo.autobrightness.platform.privilege.Tier
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -36,7 +37,12 @@ import kotlinx.coroutines.launch
  */
 class DraftSettingsViewModel(application: Application) : AndroidViewModel(application) {
     private val app = application
-    private val privilegeManager: PrivilegeManager = AppModule(application).privilegeManager
+    private val appModule = AppModule(application)
+    private val privilegeManager: PrivilegeManager = appModule.privilegeManager
+
+    /** Recorded manual-override points (newest first) overlaid on the curve preview (G2R-F14). */
+    val overridePoints: StateFlow<List<OverridePoint>> = appModule.overridePointStore.points()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     /** The committed/active settings (DataStore source of truth) shown in `[brackets]`. */
     val committed: StateFlow<AabSettings> = app.settingsDataStore.data

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/state/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/state/SettingsViewModel.kt
@@ -11,6 +11,7 @@ import com.tideo.autobrightness.app.settings.FieldError
 import com.tideo.autobrightness.app.settings.SettingsValidator
 import com.tideo.autobrightness.app.storage.settingsDataStore
 import com.tideo.autobrightness.domain.brightness.BrightnessFormulae
+import com.tideo.autobrightness.domain.wizard.OverridePoint
 import com.tideo.autobrightness.platform.privilege.PrivilegeManager
 import com.tideo.autobrightness.platform.privilege.Tier
 import kotlinx.coroutines.flow.SharingStarted
@@ -30,7 +31,12 @@ import kotlinx.coroutines.launch
  */
 class SettingsViewModel(application: Application) : AndroidViewModel(application) {
     private val app = application
-    private val privilegeManager: PrivilegeManager = AppModule(application).privilegeManager
+    private val appModule = AppModule(application)
+    private val privilegeManager: PrivilegeManager = appModule.privilegeManager
+
+    /** Recorded manual-override training points (newest first) feeding the curve wizard (G2R-F13). */
+    val overridePoints: StateFlow<List<OverridePoint>> = appModule.overridePointStore.points()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     val settings: StateFlow<AabSettings> = app.settingsDataStore.data
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AabSettings())

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/storage/AppDataStores.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/storage/AppDataStores.kt
@@ -8,6 +8,8 @@ import com.tideo.autobrightness.app.settings.AabSettings
 import com.tideo.autobrightness.app.settings.AabSettingsSerializer
 import com.tideo.autobrightness.app.settings.ContextOverrideConfig
 import com.tideo.autobrightness.app.settings.ContextRulesSerializer
+import com.tideo.autobrightness.app.settings.OverridePoints
+import com.tideo.autobrightness.app.settings.OverridePointsSerializer
 
 val Context.settingsDataStore: DataStore<AabSettings> by dataStore(
     fileName = "aab_settings.json",
@@ -19,4 +21,11 @@ val Context.serviceHealthDataStore by preferencesDataStore(name = "service_healt
 val Context.contextRulesDataStore: DataStore<ContextOverrideConfig> by dataStore(
     fileName = "aab_context_rules.json",
     serializer = ContextRulesSerializer,
+)
+
+// Recorded manual-override training points (%AAB_Overrides): captured at runtime by the pipeline so
+// the curve wizard + curve overlay have real input (G2R-F13/F14; closes the D-044c capture gap).
+val Context.overridePointsDataStore: DataStore<OverridePoints> by dataStore(
+    fileName = "aab_override_points.json",
+    serializer = OverridePointsSerializer,
 )

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/graph/BrightnessCurveChart.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/graph/BrightnessCurveChart.kt
@@ -29,6 +29,8 @@ fun BrightnessCurveChart(
     modifier: Modifier = Modifier,
     currentLux: Double? = null,
     currentBrightness: Int? = null,
+    overridePoints: List<Offset> = emptyList(),
+    fittedCurve: BrightnessCurveConfig? = null,
 ) {
     val minLux = 1f
     val maxLux = 120_000f
@@ -49,9 +51,24 @@ fun BrightnessCurveChart(
         Offset(lux, b.toFloat())
     }
 
+    // task38/task663: the suggested (fitted) curve, shown only when ≥ 9 override points exist — the
+    // caller passes a non-null fittedCurve only then (G2R-F14).
+    val fittedPoints = fittedCurve?.let { fc ->
+        logSpaced(minLux, maxLux, samples).map { lux ->
+            val b = engine.mapLuxToBrightness(lux.toDouble(), fc)
+                .coerceIn(fc.minBrightness.toDouble(), fc.maxBrightness.toDouble())
+            Offset(lux, b.toFloat())
+        }
+    }
+
     val series = buildList {
         add(ChartSeries("Curve", curvePoints, MaterialTheme.colorScheme.primary))
         if (curve.scalingUse) add(ChartSeries("Taper", taperPoints, MaterialTheme.colorScheme.tertiary, strokeWidthPx = 2f))
+        fittedPoints?.let { add(ChartSeries("Suggested", it, MaterialTheme.colorScheme.secondary, strokeWidthPx = 2f)) }
+        // Recorded override points (task561 %AAB_Overrides) overlaid as scatter dots: each is a
+        // single-point series, which ChartCanvas renders as a dot (G2R-F14; ChartCanvas unchanged).
+        val pointColor = MaterialTheme.colorScheme.error
+        overridePoints.forEach { add(ChartSeries("override", listOf(it), pointColor)) }
     }
 
     val markers = buildList {

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/CurveBrightnessScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/CurveBrightnessScreen.kt
@@ -6,7 +6,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -23,6 +25,10 @@ import com.tideo.autobrightness.app.ui.components.NumberSettingField
 import com.tideo.autobrightness.app.ui.components.SectionHeader
 import com.tideo.autobrightness.app.ui.components.SettingsColumn
 import com.tideo.autobrightness.app.ui.graph.BrightnessCurveChart
+import com.tideo.autobrightness.domain.brightness.BrightnessCurveConfig
+import com.tideo.autobrightness.domain.wizard.CurveSuggestionEngine
+import com.tideo.autobrightness.domain.wizard.CurveSuggestionInput
+import com.tideo.autobrightness.domain.wizard.OverridePoint
 
 internal fun List<FieldError>.forField(name: String): String? = firstOrNull { it.field == name }?.message
 
@@ -38,12 +44,17 @@ fun CurveBrightnessScreen(navController: NavHostController, vm: DraftSettingsVie
     val errors by vm.errors.collectAsStateWithLifecycle()
     val dirty by vm.dirty.collectAsStateWithLifecycle()
     val epoch by vm.epoch.collectAsStateWithLifecycle()
+    val overridePoints by vm.overridePoints.collectAsStateWithLifecycle()
     CurveBrightnessContent(
         draft, committed, errors, epoch, dirty,
         onEdit = vm::edit, onApply = vm::apply, onDiscard = vm::discard,
         onBack = { navController.popBackStack() },
+        overridePoints = overridePoints,
     )
 }
+
+/** task38 needs ≥ 9 recorded override points before it fits/suggests a curve. */
+private const val MIN_FIT_POINTS = 9
 
 @Composable
 fun CurveBrightnessContent(
@@ -56,10 +67,29 @@ fun CurveBrightnessContent(
     onApply: () -> Unit,
     onDiscard: () -> Unit,
     onBack: () -> Unit,
+    overridePoints: List<OverridePoint> = emptyList(),
 ) {
     DraftSettingsScaffold("Curve & Brightness", dirty, onApply, onDiscard, onBack) { padding ->
         SettingsColumn(padding) {
-            BrightnessCurveChart(draft.toBrightnessCurveConfig(), modifier = Modifier.testTag("brightness_curve_chart"))
+            val curveConfig = draft.toBrightnessCurveConfig()
+            val overlay = remember(overridePoints) {
+                overridePoints.map { Offset(it.lux.toFloat(), it.brightness.toFloat()) }
+            }
+            // The fitted/suggested curve only appears once ≥ 9 points are recorded (task38, G2R-F14).
+            val fittedCurve: BrightnessCurveConfig? = remember(overridePoints, curveConfig) {
+                if (overridePoints.size >= MIN_FIT_POINTS) {
+                    CurveSuggestionEngine.suggest(CurveSuggestionInput(overridePoints, curveConfig))
+                        ?.let { CurveSuggestionEngine.applyToLiveCurve(it, curveConfig) }
+                } else {
+                    null
+                }
+            }
+            BrightnessCurveChart(
+                curveConfig,
+                modifier = Modifier.testTag("brightness_curve_chart"),
+                overridePoints = overlay,
+                fittedCurve = fittedCurve,
+            )
 
             SectionHeader("Curve zones")
             NumberSettingField(

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ToolsScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ToolsScreen.kt
@@ -38,7 +38,9 @@ import com.tideo.autobrightness.domain.wizard.OverridePoint
 @Composable
 fun ToolsScreen(navController: NavHostController, vm: SettingsViewModel = viewModel()) {
     val settings by vm.settings.collectAsStateWithLifecycle()
+    val overridePoints by vm.overridePoints.collectAsStateWithLifecycle()
     ToolsContent(
+        recordedPoints = overridePoints,
         onBack = { navController.popBackStack() },
         onRunWizard = { overrides ->
             CurveSuggestionEngine.suggest(
@@ -65,10 +67,11 @@ fun ToolsContent(
     onBack: () -> Unit,
     onRunWizard: (List<OverridePoint>) -> CurveSuggestionResult?,
     onApplyWizard: (CurveSuggestionResult) -> Unit,
+    recordedPoints: List<OverridePoint> = emptyList(),
 ) {
     SettingsScaffold("Tools", onBack) { padding ->
         SettingsColumn(padding) {
-            WizardCard(onRunWizard, onApplyWizard)
+            WizardCard(recordedPoints, onRunWizard, onApplyWizard)
 
             SectionHeader("Power-draw calibration")
             Text(
@@ -84,14 +87,14 @@ fun ToolsContent(
 
 @Composable
 private fun WizardCard(
+    recorded: List<OverridePoint>,
     onRunWizard: (List<OverridePoint>) -> CurveSuggestionResult?,
     onApplyWizard: (CurveSuggestionResult) -> Unit,
 ) {
-    // Override-point capture/persistence is not yet wired (D-044); the wizard runs on demand against
-    // the currently-available recorded points. With < 9 it returns null (task38 error path).
+    // Override points are now captured at runtime + persisted (G2R-F13). The wizard runs against the
+    // recorded set; with < 9 it returns null (task38 error path).
     var result by remember { mutableStateOf<CurveSuggestionResult?>(null) }
     var message by remember { mutableStateOf<String?>(null) }
-    var recorded by remember { mutableStateOf<List<OverridePoint>>(emptyList()) }
     val clipboard = LocalClipboardManager.current
     val toast = rememberToaster()
 

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/AnimationRunnerTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/AnimationRunnerTest.kt
@@ -12,12 +12,14 @@ class AnimationRunnerTest {
         val writes = mutableListOf<Int>()
         var current = 0
         var overrideRead: Int? = null
+        private var lastWrite: Int? = null
         override fun read(): Int = overrideRead ?: current
-        override fun write(level: Int) { current = level; writes += level }
+        override fun write(level: Int) { current = level; lastWrite = level; writes += level }
         override fun forceManualMode() = Unit
         override fun restoreMode() = Unit
-        override fun isSelfWrite(rawDeviceValue: Int): Boolean = rawDeviceValue == current
-        override fun clearSelfWriteMarker() = Unit
+        override fun isSelfWrite(rawDeviceValue: Int): Boolean = rawDeviceValue == lastWrite
+        override fun isOnScreenSelfWrite(): Boolean = read() == lastWrite
+        override fun clearSelfWriteMarker() { lastWrite = null }
     }
 
     @Test

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineControllerTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineControllerTest.kt
@@ -36,12 +36,14 @@ class BrightnessPipelineControllerTest {
     private class FakeBrightness : ScreenBrightnessController {
         val writes = mutableListOf<Int>()
         var current = 0
+        private var lastWrite: Int? = null
         override fun read(): Int = current
-        override fun write(level: Int) { current = level; writes += level }
+        override fun write(level: Int) { current = level; lastWrite = level; writes += level }
         override fun forceManualMode() = Unit
         override fun restoreMode() = Unit
-        override fun isSelfWrite(rawDeviceValue: Int): Boolean = rawDeviceValue == current
-        override fun clearSelfWriteMarker() = Unit
+        override fun isSelfWrite(rawDeviceValue: Int): Boolean = rawDeviceValue == lastWrite
+        override fun isOnScreenSelfWrite(): Boolean = current == lastWrite
+        override fun clearSelfWriteMarker() { lastWrite = null }
     }
 
     private fun sample(lux: Double, accuracy: Int = 3) = LightSample(lux.toFloat(), accuracy, 0L)
@@ -154,6 +156,9 @@ class BrightnessPipelineControllerTest {
         advanceUntilIdle()
         assertNotNull(controller.state.value.smoothedLux)
 
+        // Simulate the external write landing on the system setting, then the observer firing: after
+        // the settle wait the on-screen value (200) is no longer our last applied → genuine override.
+        brightness.current = 200
         observer.flow.emit(200)
         advanceUntilIdle()
         assertTrue(controller.state.value.paused)
@@ -190,6 +195,82 @@ class BrightnessPipelineControllerTest {
         sensor.flow.emit(sample(lux = 5000.0))
         advanceUntilIdle()
         assertEquals(writesAfter, brightness.writes.size, "no writes after emergency stop")
+        scope.cancel()
+    }
+
+    // G2R-F11/F12: a settings change must reach the pipeline. The controller reads settingsProvider()
+    // freshly each cycle, so a higher minBrightness floors the applied target on the next reading.
+    @Test
+    fun minBrightness_isHonouredAtRuntime() = runTest {
+        val sensor = FakeSensor()
+        val brightness = FakeBrightness()
+        // High min brightness; low lux → mapped target would be ~5, but must be floored to 90.
+        val high = settings.copy(minBrightness = 90)
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val controller = BrightnessPipelineController(
+            lightSensor = sensor, brightness = brightness, brightnessObserver = FakeObserver(),
+            settingsProvider = { high }, scope = scope, clock = { 1000L },
+        )
+        controller.start()
+        sensor.flow.emit(sample(lux = 1.0))
+        advanceUntilIdle()
+        assertEquals(90, controller.state.value.targetBrightness, "min brightness must floor the target")
+        assertEquals(90, brightness.writes.last())
+        scope.cancel()
+    }
+
+    // G2R-F27/D-050: in PWM-sensitive mode the HARDWARE brightness is floored at the dimming
+    // threshold when the target would fall below it (task698 step 3).
+    @Test
+    fun pwmSensitive_floorsHardwareAtDimmingThreshold() = runTest {
+        val sensor = FakeSensor()
+        val brightness = FakeBrightness()
+        val pwm = settings.copy(minBrightness = 1, pwmSensitive = true, dimmingThreshold = 40)
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val controller = BrightnessPipelineController(
+            lightSensor = sensor, brightness = brightness, brightnessObserver = FakeObserver(),
+            settingsProvider = { pwm }, scope = scope, clock = { 1000L },
+        )
+        controller.start()
+        sensor.flow.emit(sample(lux = 1.0)) // maps to ~5, below threshold 40
+        advanceUntilIdle()
+        assertEquals(40, controller.state.value.targetBrightness, "PWM floor holds hardware at threshold")
+        assertEquals(40, brightness.writes.last())
+        scope.cancel()
+    }
+
+    // G2R-F26/D-049: handleOverride waits %AAB_CycleTime then RE-READS — a value that settles back to
+    // our applied brightness during the wait must NOT pause; one still external after it MUST.
+    @Test
+    fun rapidLightChange_doesNotFalsePause_butRealOverrideDoes() = runTest {
+        val sensor = FakeSensor()
+        val observer = FakeObserver()
+        val brightness = FakeBrightness()
+        // Advancing clock so the cycle records a non-zero %AAB_CycleTime → the settle wait is real.
+        var nowMs = 1000L
+        val (controller, scope) = newController(sensor, brightness, observer, clock = { nowMs += 50; nowMs })
+        controller.start()
+
+        // Establish a committed cycle so lastAppliedBrightness is set and on-screen.
+        sensor.flow.emit(sample(lux = 50.0))
+        advanceUntilIdle()
+        val applied = controller.state.value.lastAppliedBrightness!!
+        assertEquals(applied, brightness.current)
+
+        // False positive: an external value is present when the observer fires, but our pipeline
+        // restores our value before the cycle-time settle completes → must NOT pause (D-049 #1).
+        brightness.current = applied + 30
+        observer.flow.emit(applied + 30)
+        brightness.current = applied // settled back to our value during the wait
+        advanceUntilIdle()
+        assertTrue(!controller.state.value.paused, "transient settling to our value must not pause")
+
+        // Genuine override: the external value stays on screen through the settle wait.
+        brightness.current = applied + 60
+        observer.flow.emit(applied + 60)
+        advanceUntilIdle()
+        assertTrue(controller.state.value.paused, "a real external write must pause")
+        assertEquals(1, controller.state.value.overrideHistory.size)
         scope.cancel()
     }
 

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/ContextEngineTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/ContextEngineTest.kt
@@ -167,6 +167,32 @@ class ContextEngineTest {
     }
 
     @Test
+    fun reevaluate_picksUpFreshBaseline_withoutWatcherEval_G2RF11() = runTest {
+        // G2R-F11/F12: a manual settings Apply edits the DataStore baseline but fires no context
+        // signal. effectiveSettings() otherwise serves the cached snapshot (stale "stuck at 10");
+        // reevaluate() must re-read the fresh baseline so the change takes effect immediately.
+        var base = baseline.copy(minBrightness = 10)
+        val src = FakeSignalSource(app = "com.other.app") // no rule matches → baseline path
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val engine = ContextEngine(
+            rulesProvider = { listOf(videoStreamingRule) },
+            baselineProvider = { base },
+            profileCatalog = catalog,
+            signalSource = src,
+            onProfileChanged = {},
+            clock = { 0L },
+        )
+        engine.start(scope)
+        advanceUntilIdle()
+        assertEquals(10, engine.effectiveSettings().minBrightness)
+
+        base = base.copy(minBrightness = 90)
+        engine.reevaluate()
+        assertEquals(90, engine.effectiveSettings().minBrightness, "reevaluate re-reads the fresh baseline")
+        scope.cancel()
+    }
+
+    @Test
     fun mergeProfile_preservesDetectOverrides_G2F8() {
         // detectOverrides is a global reactivity preference, NOT a task626 snapshot key: a context
         // profile swap must keep the user's manual-override detection setting (G2-F8).

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/settings/OverridePointStoreTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/settings/OverridePointStoreTest.kt
@@ -1,0 +1,54 @@
+package com.tideo.autobrightness.app.settings
+
+import androidx.datastore.core.DataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.runTest
+import kotlin.test.assertEquals
+import org.junit.Test
+
+class OverridePointStoreTest {
+
+    private class FakeDataStore<T>(initial: T) : DataStore<T> {
+        private val state = MutableStateFlow(initial)
+        override val data: Flow<T> = state
+        override suspend fun updateData(transform: suspend (t: T) -> T): T {
+            val updated = transform(state.value)
+            state.update { updated }
+            return updated
+        }
+    }
+
+    private fun store() = OverridePointStore(FakeDataStore(OverridePoints()))
+
+    @Test
+    fun record_prependsNewestFirst() = runTest {
+        val s = store()
+        s.record(10.0, 20.0)
+        s.record(30.0, 40.0)
+        val points = s.points().first()
+        assertEquals(2, points.size)
+        assertEquals(30.0, points.first().lux, "newest point is first (task561 push at index 1)")
+        assertEquals(40.0, points.first().brightness)
+    }
+
+    @Test
+    fun record_capsAtMaxPoints() = runTest {
+        val s = store()
+        repeat(OverridePoints.MAX_POINTS + 10) { i -> s.record(i.toDouble(), i.toDouble()) }
+        val points = s.points().first()
+        assertEquals(OverridePoints.MAX_POINTS, points.size, "history is capped at the Tasker limit")
+        // Newest first: the last recorded (largest i) is at the head.
+        assertEquals((OverridePoints.MAX_POINTS + 9).toDouble(), points.first().lux)
+    }
+
+    @Test
+    fun clear_emptiesHistory() = runTest {
+        val s = store()
+        s.record(1.0, 2.0)
+        s.clear()
+        assertEquals(emptyList(), s.points().first())
+    }
+}

--- a/docs/rebuild/PARITY_CHECKLIST.md
+++ b/docs/rebuild/PARITY_CHECKLIST.md
@@ -48,7 +48,7 @@ filled by S1/S2 during extraction.
 | Initial brightness on wake: 618 | | TaskerReference (S4) + InitialBrightness.kt (S5) + InitialBrightnessTest.kt (S5) | ported |
 | Hibernate/reset: 585 | | runtime/BrightnessPipelineController.hibernate (S9a — sensor unregister + runtime-state clear) | ported |
 | Throttle reset: 566 | | runtime/BrightnessPipelineController.reinit (S9a — throttle = settings default on wake) | ported |
-| Manual override detect/resume: 567, 569, 561, 640, 641, 636 | | OverrideRules.kt (S5 pure logic, OverrideRulesTest.kt S5); runtime wiring: OverrideMonitor + controller pause/resume + recordOverridePoint (S9a). 640/641/636 override-array CRUD UI = S12 | ported (detect/pause/resume) |
+| Manual override detect/resume: 567, 569, 561, 640, 641, 636 | | OverrideRules.kt (S5 pure logic, OverrideRulesTest.kt S5); runtime wiring: OverrideMonitor + controller pause/resume + recordOverridePoint (S9a); S12.6c added the task567 act8 settle-wait re-read (no rapid-light false-pause, G2R-F26/D-049) + device-exact AnimationRunner read-back, and **captures+persists** the points to `OverridePointStore` (G2R-F13, closes D-044c). 640/641/636 override-array CRUD UI = S12.6d | ported (detect/pause/resume + capture/persist) |
 | Panic reset: 528 | | runtime/BrightnessPipelineController.emergencyStop + notification Reset action; Gate-1 G1-F4 fix: panic is a FULL STOP (restore 255 + drop dimming + %AAB_Service=Off + service teardown), not a pausable state (D-041) | ported |
 | Init/defaults: 570 Initialize AAB Defaults | | | pending |
 | Circadian dynamic scale: 90 (+ polar handling) | | SolarCalculator.kt + DynamicScaleEngine.kt (S6 domain, golden-tested circadian.csv 576 rows, CircadianParityTest + 4 polar assertions); BrightnessEngine delegates computeDynamicScale (D-031) | ported |
@@ -126,7 +126,7 @@ filled by S1/S2 during extraction.
 | task657 L32986 · _GenerateCompressionGraph | ✓ S1 | | | pending |
 | task663 L33944+L34370 · _GenerateGraph (×2) | ✓ S1 | ✓ S4 (cross-validation oracle, D-002) | chart render = S13 BrightnessCurveChart | reference (chart S13) |
 | task696 L35733 · Smooth Brightness Transition | ✓ S1 | ✓ S4 | runtime/AnimationRunner (S9a) | ported |
-| task698 L36043 · Smooth DC-Like Transition | ✓ S1 | ✓ S4 | runtime/AnimationRunner brightness path (S9a); S9b wires the ELEVATED secure-dimming layer (task646/650/645 via SuperDimmingCoordinator); DC-like unprivileged overlay deferred S12 (D-040) | ported (brightness + secure dimming; overlay S12) |
+| task698 L36043 · Smooth DC-Like Transition | ✓ S1 | ✓ S4 | runtime/AnimationRunner brightness path (S9a); S9b wires the ELEVATED secure-dimming layer (task646/650/645 via SuperDimmingCoordinator); S12.6c adds the **PWM-sensitive hardware floor** (step 3: clamp hardware up to dimmingThreshold, G2R-F27/D-050); DC-like unprivileged overlay still deferred (D-040) | ported (brightness + secure dimming + PWM hardware floor; overlay deferred) |
 | task703 L36847 · _GenerateReactivityGraph | ✓ S1 | | | pending |
 | task705 L37517 · _GenerateCircadianDimmingGraph | ✓ S1 | | | pending |
 | task90 L40429+L41085 · Dynamic Scale V13 (×2) | ✓ S1 | ✓ S6 (delegate) | SolarCalculator.kt + DynamicScaleEngine.kt (S6) | ported |

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -186,8 +186,10 @@ AppModule is now the real DI root.
   capture/persistence G2R-F13 + curve overlay G2R-F14 + override false-positives G2R-F26/D-049 +
   PWM-sensitive hardware-floor clamp G2R-F27/D-050 — D-051). Remaining: **S12.6d** (profile
   save/overwrite/factory-restore + SAF legacy import + per-screen reset +
-  Apply-gate), **S12.6e** (label/long-press-help audit + context Wi-Fi/location + usage-access flow +
-  load toasts). b/c/d/e are a parallel window now that a is merged. Domain/ + golden vectors +
+  Apply-gate + **manual-load context-lock/Resume G2R-F30**), **S12.6e** (label/long-press-help audit +
+  context Wi-Fi/location [**G2R-F22 root cause found, see findings**] + **time-picker modal G2R-F28** +
+  usage-access flow + load toasts). A Live Debug refinement (**G2R-F29** Performance & Timings parity)
+  is carried too. b/c/d/e are a parallel window now that a is merged. Domain/ + golden vectors +
   ChartCanvas API stay fenced. **NOTE for b/c/d/e:** the AAB Menu is now the home `AppRoute.Menu`;
   use `navigateTopLevel` for any new top-level destination so back still returns to the Menu; the
   global debug selector S12.6b moves OFF Misc belongs on the new Live Debug screen reached from the Menu.
@@ -1231,6 +1233,36 @@ snippets are preserved (gold `#FFC107` highlight = the AAB value colour).
   instruction on how to fix it (surface that instruction/flow here).
 - **G2R-F24** The setup/permissions screen should show **usage access as optional by default**.
 - **G2R-F25** There is **no toast when a rule/profile is loaded**.
+
+#### Additional owner findings during S12.6c testing (2026-06-14) — triaged to future sub-segments
+These five were reported while S12.6c was in flight. S12.6c investigated/triaged them but did NOT
+implement them: each belongs to a future S12.6 sub-segment (owner-confirmed rule — "if it was supposed
+to be addressed already, fix now; otherwise leave for future stages"; none are S12.6c scope). Routed:
+- **G2R-F22 (S12.6e) — Wi-Fi "use current SSID" reports "Not connected" — ROOT CAUSE FOUND (S12.6c
+  investigation).** `AndroidWifiInfoReader.currentSsid()` uses the SYNCHRONOUS
+  `ConnectivityManager.getNetworkCapabilities(activeNetwork)`, whose `transportInfo` WifiInfo SSID is
+  REDACTED to `<unknown ssid>` on API 29+ (our minSdk 31) — only a `NetworkCallback` registered with
+  `FLAG_INCLUDE_LOCATION_INFO` (as `ssidFlow()` already does) returns the real SSID, and only with
+  FINE_LOCATION granted AND location services ON. **S12.6e fix:** make `currentSsid()` a `suspend` that
+  reads the SSID via a one-shot `registerNetworkCallback(..., FLAG_INCLUDE_LOCATION_INFO)` with a short
+  timeout; surface targeted messages for not-on-Wi-Fi vs needs-FINE_LOCATION vs location-services-off
+  (don't conflate all three as "Not connected"). Also G2R-F22's **live location** half (LocationTrigger
+  lat/lon/radius editor + "use current location" via the existing `AndroidLocationReader`) is still
+  unimplemented — the rule editor exposes no location fields at all.
+- **G2R-F28 (S12.6e, NEW) — context-rule time inputs are free-text "HH:MM"; should open the system
+  TimePicker modal.** The From/To fields in `ContextsScreen.RuleEditor` are `OutlinedTextField`s; replace
+  with a tap→Material3 `TimePicker` dialog (keep the SUNRISE/SUNSET token buttons).
+- **G2R-F29 (S12.6b refinement, NEW) — Live Debug "Performance & Timings" lacks full Tasker parity.** The
+  Tasker debug scene (debug.md L19-23) surfaces `%LuxAlpha`, `%AAB_CycleTotal`, Reactivity Cooldown
+  (throttle), Last Animation (steps×wait) and Last Update under Performance/Automation; the rebuilt card
+  shows only cycle time + last sample. A future Live Debug pass should add luxAlpha / animation
+  (steps×wait) / throttle / last-update to `PipelineState` (runtime holder, NOT the domain engine API)
+  and render them.
+- **G2R-F30 (S12.6d, NEW) — manually loading a profile does not pause context automation or offer a
+  Resume.** In Tasker a manual profile load latches `%AAB_ContextOverride=true` (the manual context lock,
+  D-014/D-038a) so watchers stop overriding the user's choice; the rebuild's `applyProfile` does not set
+  it and the UI shows no "context automation paused / Resume" affordance. S12.6d (profiles) should set
+  the lock on manual apply + surface a resume control that clears `contextOverride` (+ re-evaluates).
 
 ### Gate 3 (after S14) — pending
 

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -40,11 +40,22 @@ next session does not know it.
 | S12.6a IA & naming | 2026-06-14 | Opus/high | DONE | (see push) | Menu-as-home reshape + two renames + Dashboard last-sample fix (G2R-F1…F5). **AAB Menu promoted to a real home hub** (`AppRoute.Menu` + `ui/screens/MenuScreen.kt`): gold-sun teal banner (rebranded "Tideo Auto Brightness", not "Advanced"), Profiles/Contexts **hero cards moved off the Dashboard**, Settings/Info&Help nav groups; it is the start destination after onboarding (tier!=NONE→Menu) and the back-target from every settings/tool screen via new `NavHostController.navigateTopLevel` (popUpTo(menu)). The S12.5a `AabNavDrawer` retired; `AabTopBar` gained an optional back arrow (AutoMirrored). Dashboard slimmed to live-status (tier badge, master switch, live readout, health) + back→Menu. **Renames:** `AnimationDimming`→`SuperDimming` (route `super_dimming`, title "Super Dimming", G2R-F3); `DynamicScale`→`Circadian` (route `circadian`, title "Circadian", G2R-F4) — files `AnimationDimmingScreen.kt`→`SuperDimmingScreen.kt`, `DynamicScaleScreen.kt`→`CircadianScreen.kt` (composables + content fns + NavGraph + tests). **Last-sample fix (G2R-F5):** `PipelineState.lastSampleMs` recorded for every delivered sample in `onSensorSample` (atomic StateFlow.update), surfaced via LiveRuntimeState→DashboardUiState, rendered as relative "Xs ago" (replaces the never-written health-store source). Domain/golden/ChartCanvas untouched. Tests: `UiShellTest` rewritten (Menu hero+nav, renames resolve, start-on-Menu + back-from-settings→Menu, last-sample renders); `SettingsScreensTest` SuperDimming rename. Ladder GREEN: `:app:assembleDebug :app:testDebugUnitTest :app:lintDebug`. No compaction. |
 
 | S12.6b glass-box diagnostics + Live Debug scene | 2026-06-14 | Opus/high | DONE | (see push) | The runtime "glass box" surfaced (G2R-F6…F10). New: **Live Debug Info** scene (`AppRoute.LiveDebug`, in the Menu Info&Help group + `navigateTopLevel` back→Menu) = `LiveDebugScreen`/`LiveDebugContent` over `LiveDebugViewModel` (combines LiveRuntimeState pipeline/context/running + DataStore min/max/debugLevel) — live `%AAB_*` readout grouped per debug.md HTML cards (Core Metrics / Circadian & Scale / System Status / Performance & Timings), gold `#FFC107` values via new `ui/components/DiagnosticCard.kt` (`DiagnosticCard`/`DiagnosticLine`/`goldValue`). **Per-screen DiagnosticCards** (G2R-F7/F8): `ReactivityDiagnosticCard` (threshold + dead zone) + `CircadianDiagnosticCard` (uncompressed vs true scale + min/max) embedded on those screens; stateless `*Content(state)` builders for tests. To feed them, `PipelineState` gains `threshDynamic` (%AAB_ThreshDynamic) + `scaleDynamic` (%AAB_ScaleDynamic uncompressed), populated in `runCycle` from existing `BrightnessPolicyOutput.dynamicThreshold`/`scaleDynamic` (no domain API change). **Debug selector → global + relocated** (G2R-F9): moved off Misc to Live Debug (`LiveDebugViewModel.setDebugLevel` writes DataStore directly); `debugLevel` now preserved across `SettingsViewModel.applyProfile/replaceAll/resetDefaults` + `DraftSettingsViewModel.apply`/re-sync (already in `mergeProfile`) — `DEBUG_LABELS`/`DebugLevelSelector` moved MiscScreen→LiveDebugScreen. **Teal debug toasts** (G2R-F10): `ToastDebugSink` builds a teal-rounded custom TextView (via `makeText`+`setView` so ShadowToast still records text). Tests: SettingsScreensTest (Live Debug + Reactivity/Circadian diagnostic cards render seeded PipelineState; selector relocation) + new `SettingsViewModelTest` (debugLevel survives profile apply + reset) + ContextEngineTest `mergeProfile_preservesDebugLevel`. Full ladder GREEN: `:app:testDebugUnitTest`(102) `:app:assembleDebug :app:lintDebug :domain:test :platform:test`. No compaction. **NEW FINDING recorded (verified, deferred to S12.6c): G2R-F27/D-050 — PWM-sensitive mode never locks the hardware brightness floor (`pwmSensitive` unread by the runtime).** |
+| S12.6c pipeline behaviour correctness | 2026-06-14 | Opus/high | DONE | (see push) | Fixed the runtime bugs the re-test found + wired override-point capture (D-051; G2R-F11/F12/F13/F14/F26/F27). **G2R-F11/F12** (Apply/profile-load + min-brightness ignored until a light change): root = the pipeline's `settingsProvider`=`ContextEngine.effectiveSettings()` served the STALE cached `_effective` snapshot. Added `ContextEngine.reevaluate()` (re-reads the FRESH baseline + re-merges the active profile, no watcher re-resolution) and the service's `ACTION_REAPPLY` now calls it BEFORE `controller.reapply()` → manual edits take effect immediately (min-bright no longer "stuck at 10"). **G2R-F13** override-point capture (closes D-044c): new `OverridePointStore` (DataStore, newest-first cap 50) + `OverridePointSink`; `handleOverride` persists the de-compressed point; `SettingsViewModel`/`DraftSettingsViewModel` expose `overridePoints`; Tools wizard reads the recorded set. **G2R-F14** `BrightnessCurveChart` overlays the recorded points as dots + shows the fitted/suggested curve only at ≥9 points (ChartCanvas unchanged). **G2R-F26/D-049** override false-positives: `handleOverride` now does the task567 act8 settle (wait %AAB_CycleTime → re-read → only pause if still ≠ our last applied) + the AnimationRunner read-back is now device-exact (`ScreenBrightnessController.isOnScreenSelfWrite`, kills OEM round-trip drift, D-049 #4). **G2R-F27/D-050** PWM-sensitive hardware floor: `applyPwmFloor` clamps the hardware write up to `dimmingThreshold` when `pwmSensitive && target<threshold` (task698 step3) in runCycle + setInitialBrightness. **HARD FENCE honoured: domain/, golden vectors, ChartCanvas API untouched.** New tests: controller minBrightness/PWM-floor/override-false-positive (3), ContextEngine reevaluate-fresh-baseline, OverridePointStore (3). Full ladder GREEN: `:platform:test :app:testDebugUnitTest`(104) `:domain:test :app:assembleDebug :app:lintDebug`. No compaction. |
 Status values: DONE · PARTIAL · BLOCKED (see failure protocol in CLAUDE.md).
 
 ## Current state
 
-**S12.6a (IA & naming) + S12.6b (glass-box diagnostics) DONE → S12.6c/d/e remain (parallel window).**
+**S12.6a + S12.6b + S12.6c DONE → S12.6d/e remain.** S12.6c (pipeline behaviour correctness, D-051)
+fixed the runtime bugs the re-test found: Apply/profile-load + min-brightness now take effect immediately
+(reevaluate-fresh-baseline before reapply, G2R-F11/F12); manual override points are captured + persisted
+(OverridePointStore) and overlaid on the curve with a ≥9-point fitted curve (G2R-F13/F14); rapid-light
+override false-positives are fixed (task567 settle-wait re-read + device-exact AnimationRunner read-back,
+G2R-F26/D-049); PWM-sensitive now floors the hardware brightness at the dimming threshold
+(G2R-F27/D-050). domain/, golden vectors and ChartCanvas stayed fenced. Ladder GREEN
+(`:app:testDebugUnitTest`=104, `:platform:test :domain:test :app:assembleDebug :app:lintDebug`).
+**Next: S12.6d/e, then HUMAN GATE 2 re-test after S12.6e.**
+
+**(historical) S12.6a (IA & naming) + S12.6b (glass-box diagnostics) DONE → S12.6c/d/e remain (parallel window).**
 The AAB Menu is the home hub; Super Dimming / Circadian renames + Dashboard last-sample fix landed in
 S12.6a. **S12.6b** added the runtime glass box: a dedicated **Live Debug Info** scene in the Menu (live
 `%AAB_*` readout grouped per the Tasker debug scene, gold values) + live `DiagnosticCard`s on Reactivity
@@ -171,9 +182,9 @@ AppModule is now the real DI root.
   restore; SAF folder grant for legacy import). **S12.6a DONE** (menu-as-home reshape + Super Dimming /
   Circadian renames + Dashboard last-sample fix — landed the nav/testTag reshape b/c/d/e depend on).
   **S12.6b DONE** (Live Debug scene + per-screen diagnostic cards + global debug selector + teal toasts).
-  Remaining: **S12.6c** (reapply-uses-fresh-settings + min-bright runtime bug + override-point capture + curve
-  overlay + **override false-positives on rapid light changes, G2R-F26/D-049** + **PWM-sensitive
-  hardware-floor clamp, G2R-F27/D-050**), **S12.6d** (profile
+  **S12.6c DONE** (reapply-uses-fresh-settings + min-bright runtime fix G2R-F11/F12 + override-point
+  capture/persistence G2R-F13 + curve overlay G2R-F14 + override false-positives G2R-F26/D-049 +
+  PWM-sensitive hardware-floor clamp G2R-F27/D-050 — D-051). Remaining: **S12.6d** (profile
   save/overwrite/factory-restore + SAF legacy import + per-screen reset +
   Apply-gate), **S12.6e** (label/long-press-help audit + context Wi-Fi/location + usage-access flow +
   load toasts). b/c/d/e are a parallel window now that a is merged. Domain/ + golden vectors +
@@ -949,7 +960,49 @@ Seeded by the S0 audit (details in CLAUDE.md "Facts & corrections ledger"):
   `pwmSensitive=true` and a target below the threshold, the applied hardware brightness equals the
   threshold, not the raw (lower) target. (Affects S12.6c.)
 
-Append new entries as D-051, D-052, … with which segments they affect.
+- D-051: S12.6c PIPELINE BEHAVIOUR CORRECTNESS (UI/app/platform-glue; sanctioned by the S12.6c brief;
+  HARD FENCE honoured — domain/, golden vectors, ChartCanvas public API untouched).
+  (a) **G2R-F11/F12 stale-effective-settings → FIXED.** The pipeline's `settingsProvider` is
+  `ContextEngine.effectiveSettings()`, which served the cached `_effective` snapshot from the last
+  watcher eval; a manual Apply/profile-load edits the DataStore baseline but fires no context signal,
+  so the runtime kept using stale settings (min-bright "stuck at 10"; Apply needed a light change).
+  Fix: new `ContextEngine.reevaluate()` re-reads the FRESH baseline and re-merges the *currently
+  resolved* active profile (it does NOT re-run the watcher resolution → cannot spuriously switch
+  context, and handles the manual-context-lock case where the resolver would return a null target);
+  `AmbientMonitoringService.ACTION_REAPPLY` now `reevaluate()`s BEFORE `controller.reapply()`. Min
+  brightness already threaded correctly through the mapper→engine (`coerceIn(min,max)`), so F12 shared
+  F11's root; a controller regression test asserts a high minBrightness floors the applied target.
+  (b) **G2R-F13 override-point capture → WIRED (closes D-044c).** New `OverridePointStore`
+  (`overridePointsDataStore`, newest-first, capped at `OverridePoints.MAX_POINTS`=50 = task561) +
+  `OverridePointSink` (`fun interface`, NoOp default). `BrightnessPipelineController.handleOverride`
+  persists the de-compressed point (`history.first()` from `OverrideRules.recordOverridePoint`).
+  `AppModule` exposes the store + wires the sink. `SettingsViewModel.overridePoints` (Tools wizard)
+  and `DraftSettingsViewModel.overridePoints` (curve overlay) surface it.
+  (c) **G2R-F14 curve overlay → DONE.** `BrightnessCurveChart` gains `overridePoints: List<Offset>`
+  (rendered as scatter dots via single-point `ChartSeries` — ChartCanvas's existing <2-points→dot
+  path, NO ChartCanvas change) + `fittedCurve: BrightnessCurveConfig?`; `CurveBrightnessScreen`
+  computes the fit (CurveSuggestionEngine.suggest→applyToLiveCurve) and passes it ONLY at ≥9 points
+  (task38 threshold).
+  (d) **G2R-F26/D-049 override false-positives → FIXED (#1 + #4).** `handleOverride` is now `suspend`
+  and performs the task567 act8 settle: wait `%AAB_CycleTime` (fallback throttle), re-check the gate,
+  RE-READ, and pause ONLY if the settled value is still ≠ our last applied brightness (a rapid swing
+  that resolves to our own write no longer false-pauses). The AnimationRunner read-back is now
+  DEVICE-EXACT via new `ScreenBrightnessController.isOnScreenSelfWrite()` (compares the raw on-screen
+  device value to the last self-written device value), removing the OEM `toDomain(toDevice(x))`
+  round-trip drift that fired spurious OVERRIDDEN on `deviceMax≠255` (D-049 #4). **DECISION:** the
+  single-latest self-write marker (D-049 #2) is RETAINED as-is — D-034 deliberately chose single-latest
+  (a multi-value token set had four enumerated defects) and `ScreenBrightnessControllerTest` enforces
+  it; the settle re-check (#1) is the authoritative gate and the device-exact comparison (#4) removes
+  the actual cause, so a recent-set was judged net-negative. Regression test: a transient settling back
+  to our value does NOT pause; a value still external after the settle MUST.
+  (e) **G2R-F27/D-050 PWM hardware floor → DONE.** `BrightnessPipelineController.applyPwmFloor` clamps
+  the HARDWARE write up to `dimmingThreshold` when `settings.pwmSensitive && target < dimmingThreshold`
+  (task698 step 3), applied in `runCycle` + `setInitialBrightness` (domain space; ScreenBrightnessController
+  maps to device range). The unprivileged software overlay (task698 DC-like/653/654) stays deferred
+  (D-040); the hardware floor is independent. Regression test asserts the applied value == threshold.
+  (Affects S12.6d/e, S13, Gate 2.)
+
+Append new entries as D-052, D-053, … with which segments they affect.
 
 ## Blockers
 
@@ -1132,25 +1185,28 @@ snippets are preserved (gold `#FFC107` highlight = the AAB value colour).
 - **G2R-F10** Minor: the debug toasts should use the **characteristic teal colour**.
 
 *Pipeline behaviour correctness (→ S12.6c):*
-- **G2R-F11** Applying a profile manually **does not take effect until a light change** (the Apply/reapply
-  path isn't producing an immediate re-evaluate for a manual profile/settings apply).
-- **G2R-F12** **Min brightness is ignored in actual behaviour — appears stuck at 10** (the graph honours
-  it, G2-F4, but the runtime does not — likely the same stale-effectiveSettings root as F11).
-- **G2R-F13** **Manual override points are not recorded** (the wizard's input; D-044c capture still unwired).
+- **G2R-F11** Applying a profile manually **does not take effect until a light change**.
+  **→ FIXED by S12.6c (D-051a):** `ContextEngine.reevaluate()` re-reads the fresh baseline before
+  `controller.reapply()` so a manual Apply/profile-load re-evaluates immediately.
+- **G2R-F12** **Min brightness is ignored in actual behaviour — appears stuck at 10.**
+  **→ FIXED by S12.6c (D-051a):** same stale-effectiveSettings root as F11; min-bright threads correctly
+  through the mapper→engine; controller regression test added.
+- **G2R-F13** **Manual override points are not recorded.**
+  **→ FIXED by S12.6c (D-051b):** `OverridePointStore` persists the points the pipeline detects; the
+  wizard reads the recorded set.
 - **G2R-F14** The brightness curve used to **overlay all recorded override points**; the fitted curve only
-  appeared with **> 8 points**. Restore the point overlay + fit-only-when-≥9 behaviour.
-- **G2R-F26** (owner-reported 2026-06-14, post-S12.6a; NOT in the original re-test batch) **Manual-override
-  FALSE POSITIVES on rapid light changes** — a fast lux swing makes the pipeline pause as if the user
-  grabbed the slider, when nothing external wrote. Owner's read: a mutex issue, or new light readings are
-  allowed before the new brightness has "taken hold". **Deferred to S12.6c** (do NOT touch domain/; this is
-  controller/animation/observer glue). Code-grounded root-cause analysis + recommended fix in **D-049**.
-- **G2R-F27** (owner-reported 2026-06-14, post-S12.6a; NOT in the original re-test batch) **PWM-sensitive
-  mode does not lock the brightness floor** — with "Use software dimming (PWM-sensitive)" on, the hardware
-  brightness is not held at the dimming threshold floor when the target falls below it. **Deferred to
-  S12.6c** (S12.6b verified it; this is `app/runtime` controller/coordinator glue, NOT domain/). Root cause:
-  `pwmSensitive` is persisted + has a UI toggle but is **never read by the pipeline** — the task661 act22-26
-  PWM branch / task698 hardware-floor clamp is unimplemented. Code-grounded analysis + recommended fix in
-  **D-050**.
+  appeared with **> 8 points**.
+  **→ FIXED by S12.6c (D-051c):** `BrightnessCurveChart` overlays the points as dots + shows the fitted
+  curve only at ≥9 (ChartCanvas unchanged).
+- **G2R-F26** (owner-reported 2026-06-14, post-S12.6a) **Manual-override FALSE POSITIVES on rapid light
+  changes.**
+  **→ FIXED by S12.6c (D-051d):** task567 act8 settle-wait re-read in `handleOverride` (pause only if
+  still ≠ our last applied) + device-exact AnimationRunner read-back (`isOnScreenSelfWrite`, kills OEM
+  round-trip drift). Single-latest marker (D-049 #2) retained per D-034 (decision recorded).
+- **G2R-F27** (owner-reported 2026-06-14, post-S12.6a) **PWM-sensitive mode does not lock the brightness
+  floor.**
+  **→ FIXED by S12.6c (D-051e):** `applyPwmFloor` clamps the hardware write up to `dimmingThreshold` when
+  `pwmSensitive && target<threshold` (task698 step 3), in runCycle + setInitialBrightness.
 
 *Profiles & persistence (→ S12.6d):*
 - **G2R-F15** **Cannot save a custom profile**, and want to be able to **overwrite existing profiles** too

--- a/platform/src/main/kotlin/com/tideo/autobrightness/platform/brightness/ScreenBrightnessController.kt
+++ b/platform/src/main/kotlin/com/tideo/autobrightness/platform/brightness/ScreenBrightnessController.kt
@@ -21,6 +21,15 @@ interface ScreenBrightnessController {
      * delayed callback for frame N observes frame N+1's value.
      */
     fun isSelfWrite(rawDeviceValue: Int): Boolean
+    /**
+     * True if the value CURRENTLY on screen is our most recent self-write. Compares in DEVICE space
+     * (the raw setting value vs the last written device value), so it is immune to the
+     * domain↔device round-trip drift that [read] incurs when `config_screenBrightnessSettingMaximum
+     * != 255` (D-049 #4): `read()` is `toDomain(toDevice(x))`, which is NOT identity on such OEM
+     * ranges, so an animation read-back comparing domain values would spuriously fire OVERRIDDEN on
+     * every multi-frame transition. The animation runner uses this instead of a domain comparison.
+     */
+    fun isOnScreenSelfWrite(): Boolean
     /** Forget the self-write marker (e.g. when auto-control pauses and the user owns the slider). */
     fun clearSelfWriteMarker()
 }
@@ -108,6 +117,11 @@ class AndroidScreenBrightnessController(
     }
 
     override fun isSelfWrite(rawDeviceValue: Int): Boolean = rawDeviceValue == lastSelfWriteDevice
+
+    override fun isOnScreenSelfWrite(): Boolean {
+        val raw = Settings.System.getInt(resolver, Settings.System.SCREEN_BRIGHTNESS, -1)
+        return raw >= 0 && raw == lastSelfWriteDevice
+    }
 
     override fun clearSelfWriteMarker() {
         lastSelfWriteDevice = null


### PR DESCRIPTION
## Summary

Fixes critical runtime bugs discovered during re-testing and wires override-point capture/persistence (D-051). The pipeline now applies settings changes immediately, handles rapid light swings without false-pausing, floors PWM-sensitive hardware brightness correctly, and persists manual override points for curve fitting.

## Key Changes

**G2R-F11/F12: Stale effective-settings fix**
- Added `ContextEngine.reevaluate()` to re-read the fresh baseline and re-merge the active profile without re-running watcher resolution
- `AmbientMonitoringService.ACTION_REAPPLY` now calls `reevaluate()` before `controller.reapply()` so manual Apply/profile-load edits take effect immediately
- Min-brightness no longer "stuck at 10" after manual edit

**G2R-F13/F14: Override-point capture & curve overlay**
- New `OverridePointStore` (DataStore-backed, newest-first, capped at 50 per task561) + `OverridePointSink` interface
- `BrightnessPipelineController.handleOverride()` persists de-compressed training points
- `SettingsViewModel` / `DraftSettingsViewModel` expose `overridePoints` flow
- `BrightnessCurveChart` overlays recorded points as dots; shows fitted/suggested curve only at ≥9 points (task38 threshold)
- Closes D-044c (override points now survive restarts)

**G2R-F26/D-049: Override false-positive fix**
- `handleOverride()` now implements task567 act8 settle: waits `%AAB_CycleTime` then re-reads before committing pause
- A value that settles back to our last applied brightness during the wait is NOT paused (transient during rapid swing)
- `AnimationRunner` uses new `ScreenBrightnessController.isOnScreenSelfWrite()` (device-exact check) instead of domain-space comparison, eliminating spurious overrides on OEM ranges where `read() ≠ identity` (D-049 #4)

**G2R-F27/D-050: PWM-sensitive hardware floor**
- New `applyPwmFloor()` clamps hardware write up to `dimmingThreshold` when `pwmSensitive && target < threshold` (task698 step 3)
- Applied in `runCycle()` and `setInitialBrightness()`

**Platform API enhancement**
- `ScreenBrightnessController` gains `isOnScreenSelfWrite(): Boolean` for device-exact override detection
- Existing `isSelfWrite(rawDeviceValue)` kept for compatibility

**Test coverage**
- `BrightnessPipelineControllerTest`: minBrightness runtime honour, PWM-floor clamp, rapid-light false-positive fix (3 new tests)
- `ContextEngineTest`: reevaluate-fresh-baseline test
- `OverridePointStoreTest`: record/cap/clear (3 new tests)
- `AnimationRunnerTest`: updated to use new `isOnScreenSelfWrite()` API

## Implementation Notes

- **HARD FENCE honoured**: domain/, golden vectors, and ChartCanvas public API remain untouched
- `handleOverride()` is now `suspend` to accommodate the settle delay
- Override points are persisted via `OverridePointSink.record()` called after pause is committed
- Fitted curve suggestion requires ≥9 points (task38 constraint); `CurveBrightnessContent` computes and passes it to chart only when threshold met
- All tests green: `:platform:test :app:testDebugUnitTest`(104) `:domain:test :app:assembleDebug :app:lintDebug`

## Affected Screens

- **Curve & Brightness**: now displays recorded override points and fitted curve (when ≥9 points)
- **Tools**: passes recorded points to curve-suggestion wizard
- **Live Debug**: (no changes; diagnostic cards already in place from S12.

https://claude.ai/code/session_01DdiUEg6eFkKab8gTkqyiTw