### PR TITLE
S12.7a: Port task696 band+debounce override logic and post-init settle window

### DIFF
--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 /**
@@ -111,12 +112,17 @@ class AmbientMonitoringService : Service() {
         controller.start()
         contextEngine.start(scope)
         if (notificationJob?.isActive == true) return
+        val manualOverrideFlow = applicationContext.settingsDataStore.data
+            .map { it.contextOverride }
+            .distinctUntilChanged()
         notificationJob = scope.launch {
-            combine(controller.state, contextEngine.activeContext) { state, ctx ->
+            combine(controller.state, contextEngine.activeContext, manualOverrideFlow) { state, ctx, manualOverride ->
                 // Each accepted cycle drives time-window re-evaluation (contexts_spec — prof764).
                 contextEngine.onPipelineTick()
-                // Republish the live snapshot so the in-app Dashboard can render it (S11).
-                LiveRuntimeState.publish(state, ctx)
+                // Republish the live snapshot so the in-app Dashboard / Menu can render it (S11). The
+                // manual-load override lock (%AAB_ContextOverride) is surfaced separately from the
+                // active context rule (F46) so the Menu can distinguish them.
+                LiveRuntimeState.publish(state, ctx, manualOverride)
                 NotificationModel(state.smoothedLux, state.targetBrightness, state.paused, state.serviceOn, ctx)
             }
                 .distinctUntilChanged()

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AnimationRunner.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AnimationRunner.kt
@@ -4,17 +4,32 @@ import com.tideo.autobrightness.platform.brightness.ScreenBrightnessController
 import kotlinx.coroutines.delay
 
 /**
- * Executes an animated brightness transition with per-frame read-back override detection.
+ * Executes an animated brightness transition with per-frame band-checked override detection.
  *
- * Tasker: task696 "Smooth Brightness Transition" (XML, java/task696_1) and the DC-like dimming
- * variant task698. Steps `loops` times writing an intermediate brightness with `wait` ms between
- * frames; before each frame it re-reads the system value and, if it drifted away from our last
- * self-write while override detection is on, aborts and signals a manual override
- * (→ prof755/task567). Our own writes are expected (suppress-echo); an unexpected external write
- * is an override.
+ * Tasker: task696 "Smooth Brightness Transition V5 (Java)" (XML L35734-L35886, java/task696_1) and
+ * the DC-like dimming variant task698. Steps `loops` times writing an intermediate brightness with
+ * `wait` ms between frames; while [detectOverrides] is on it re-reads the system value and aborts
+ * with [Result.OVERRIDDEN] when the observed brightness leaves our animation band.
  *
- * Super-dimming (task698) writes are wired in S9b; this S9a runner handles the brightness-only
- * path (task696). It is a plain suspend function with no Android dependencies beyond the
+ * **Override band (S12.7a, F34 — the *real* task696 logic, not the old exact-match self-write
+ * check).** The legacy `isOnScreenSelfWrite()` equality test produced false positives (any OEM
+ * round-trip drift / a delayed callback for an adjacent frame looked like an override). task696
+ * instead defines a tolerance band spanning the whole sweep and only fires after the observed value
+ * stays out of it for [OVERRIDE_TRIGGER_THRESHOLD] consecutive checks:
+ *   - `minTarget = from < to ? from : to - 1`, `maxTarget = from < to ? to + 1 : from` (java L49-56).
+ *   - an override is `actual > maxTarget + 2 || actual < minTarget - 2`, i.e. a value in the *wrong
+ *     direction* or *overshooting beyond our step* (java L126); a value consistent with our in-flight
+ *     interpolation is ours. The ±2 tolerance also absorbs the domain↔device round-trip drift that
+ *     made the equality check fire on every multi-frame transition (D-049 #4).
+ *   - the trigger requires two consecutive out-of-band reads (java L129) so a single transient does
+ *     not pause the loop.
+ *
+ * Tasker checked only every 5th frame purely to dodge per-frame IPC cost (java L98-101, an explicit
+ * optimization comment); that is a *how*, not a *what*, so the Kotlin port checks every frame — the
+ * band + 2-consecutive-read debounce is the behaviour that matters.
+ *
+ * Super-dimming (task698) writes are wired in S9b; this runner handles the brightness-only path
+ * (task696). It is a plain suspend function with no Android dependencies beyond the
  * ScreenBrightnessController interface, so it is unit-testable with a fake controller.
  */
 class AnimationRunner(
@@ -36,7 +51,7 @@ class AnimationRunner(
      * @param to      Target brightness (domain 0–255).
      * @param steps   Frame count (task543 %loops, ≥1).
      * @param waitMs  Per-frame delay (task543 %wait).
-     * @param detectOverrides %AAB_DetectOverrides — when false, read-back checks are skipped.
+     * @param detectOverrides %AAB_DetectOverrides — when false, the band checks are skipped.
      * @return COMPLETED, or OVERRIDDEN if an external write was detected mid-animation.
      */
     suspend fun animate(
@@ -47,23 +62,40 @@ class AnimationRunner(
         detectOverrides: Boolean,
     ): Result {
         val frames = steps.coerceAtLeast(1)
+        // task696 java L49-56: the band the on-screen value is expected to stay within as we sweep.
+        val minTarget = if (from < to) from else to - 1
+        val maxTarget = if (from < to) to + 1 else from
+        var consecutiveOutOfBounds = 0
         for (i in 1..frames) {
-            // task696: re-read before writing the next frame; if the on-screen value is no longer
-            // our last self-write, an external app/user changed it → abort + override. The check is
-            // device-exact ([isOnScreenSelfWrite]) so OEM ranges where read() ≠ identity do not fire
-            // a spurious override on every frame (D-049 #4).
+            // Re-read before writing the next frame; an out-of-band value for two consecutive checks
+            // is a genuine external override (task696 java L121-137). Skipped on the first frame —
+            // our own write has not landed yet, so there is nothing of ours to compare against.
             if (detectOverrides && i > 1) {
-                if (!controller.isOnScreenSelfWrite()) return Result.OVERRIDDEN
+                consecutiveOutOfBounds = if (isOutOfBand(minTarget, maxTarget)) consecutiveOutOfBounds + 1 else 0
+                if (consecutiveOutOfBounds >= OVERRIDE_TRIGGER_THRESHOLD) return Result.OVERRIDDEN
             }
             // Linear interpolation; the final frame lands exactly on `to`.
             val frame = if (i == frames) to else from + ((to - from) * i) / frames
             controller.write(frame)
             if (waitMs > 0) sleep(waitMs)
         }
-        // Final read-back: catch an override that landed during the last frame's wait.
-        if (detectOverrides) {
-            if (!controller.isOnScreenSelfWrite()) return Result.OVERRIDDEN
+        // Final read-back: catch an override that landed during the last frame's wait. The settled
+        // value sitting out of band counts as the next consecutive read.
+        if (detectOverrides && isOutOfBand(minTarget, maxTarget)) {
+            consecutiveOutOfBounds += 1
+            if (consecutiveOutOfBounds >= OVERRIDE_TRIGGER_THRESHOLD) return Result.OVERRIDDEN
         }
         return Result.COMPLETED
+    }
+
+    // task696 java L126: the observed brightness is out of band when it overshoots either end of the
+    // sweep by more than the ±2 tolerance (wrong direction, or beyond our current step).
+    private fun isOutOfBand(minTarget: Int, maxTarget: Int): Boolean {
+        val actual = controller.read()
+        return actual > maxTarget + 2 || actual < minTarget - 2
+    }
+
+    private companion object {
+        const val OVERRIDE_TRIGGER_THRESHOLD = 2
     }
 }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineController.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineController.kt
@@ -64,6 +64,12 @@ class BrightnessPipelineController(
     @Volatile private var autoRunning = false
     @Volatile private var initializing = false
 
+    // Post-init override-suppression deadline (S12.7a, F64): override detection is suppressed until
+    // `clock() >= this`. Armed after every Set Initial Brightness self-write (service start / screen-on
+    // reinit / resume / context swap) so the ContentObserver echo of our own write — delivered after
+    // `initializing` resets — cannot spuriously pause/override on start. 0 = no window open.
+    @Volatile private var suppressOverrideUntilMs = 0L
+
     // %AAB_MainLoop re-entry mutex: true while a sensor cycle is claimed or running.
     private val inCycle = AtomicBoolean(false)
 
@@ -80,6 +86,7 @@ class BrightnessPipelineController(
             paused = s.paused,
             initializing = initializing,
             detectOverrides = cachedSettings?.detectOverrides ?: false,
+            suppressed = clock() < suppressOverrideUntilMs,
         )
     }
 
@@ -403,6 +410,10 @@ class BrightnessPipelineController(
             brightness.forceManualMode()
             brightness.write(target)
             dimming.apply(target, settings)
+            // F64: arm the post-init settle window so the ContentObserver echo of THIS self-write
+            // (and any AUTO→MANUAL mode-flip recompute) — delivered after `initializing` clears below
+            // — is not flagged as a manual override on start/reinit/resume/context swap.
+            suppressOverrideUntilMs = clock() + INITIAL_SETTLE_MS
             _state.update {
                 it.copy(
                     lastAppliedBrightness = target,
@@ -434,6 +445,11 @@ class BrightnessPipelineController(
 
     private companion object {
         const val PANIC_BRIGHTNESS = 255
+
+        // F64 settle window: long enough to outlast the async ContentObserver delivery of our own
+        // initial write + the mode-flip recompute, short enough that a real user override moments
+        // after a reinit is still caught by the next observer event.
+        const val INITIAL_SETTLE_MS = 1500L
     }
 }
 

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/LiveRuntimeState.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/LiveRuntimeState.kt
@@ -22,19 +22,29 @@ object LiveRuntimeState {
     private val _activeContext = MutableStateFlow<String?>(null)
     val activeContext: StateFlow<String?> = _activeContext.asStateFlow()
 
+    /**
+     * `%AAB_ContextOverride` — true while a MANUAL profile load has latched the override lock
+     * (S12.7a, F46). This is distinct from [activeContext]: a context *rule* being active is NOT an
+     * override (it is automation working as configured); only a manual load is. Resume clears it.
+     */
+    private val _manualOverride = MutableStateFlow(false)
+    val manualOverride: StateFlow<Boolean> = _manualOverride.asStateFlow()
+
     /** True while a foreground service instance is publishing (i.e. the loop is alive). */
     private val _serviceRunning = MutableStateFlow(false)
     val serviceRunning: StateFlow<Boolean> = _serviceRunning.asStateFlow()
 
-    fun publish(state: PipelineState, activeContext: String?) {
+    fun publish(state: PipelineState, activeContext: String?, manualOverride: Boolean = false) {
         _pipeline.value = state
         _activeContext.value = activeContext
+        _manualOverride.value = manualOverride
         _serviceRunning.value = true
     }
 
     fun reset() {
         _pipeline.value = PipelineState()
         _activeContext.value = null
+        _manualOverride.value = false
         _serviceRunning.value = false
     }
 }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/OverrideMonitor.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/OverrideMonitor.kt
@@ -25,11 +25,21 @@ class OverrideMonitor(
         val paused: Boolean,
         val initializing: Boolean,
         val detectOverrides: Boolean,
+        /**
+         * True while the post-init settle window is open (S12.7a, F64). Set Initial Brightness writes
+         * synchronously under `initializing`, but the ContentObserver callback for that write — and for
+         * any system brightness recompute the AUTO→MANUAL mode flip triggers — can be delivered *after*
+         * `initializing` has reset, racing the observer into flagging our own start/reinit/resume/QS-on
+         * write as a manual override. The controller holds this true for a short settle after each
+         * initial write so that trailing self-write echo is ignored.
+         */
+        val suppressed: Boolean = false,
     )
 
     /** Emits observed brightness values that qualify as manual overrides. */
     fun overrides(): Flow<Int> = observer.externalChanges().mapNotNull { observed ->
         val g = gateProvider()
+        if (g.suppressed) return@mapNotNull null
         val isOverride = OverrideRules.isManualOverride(
             isServiceOn = g.serviceOn,
             isAutoRunning = g.autoRunning,

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/MenuScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/MenuScreen.kt
@@ -56,8 +56,10 @@ import com.tideo.autobrightness.app.ui.theme.AabGold
 @Composable
 fun MenuScreen(navController: NavHostController) {
     val activeContext by LiveRuntimeState.activeContext.collectAsStateWithLifecycle()
+    val manualOverride by LiveRuntimeState.manualOverride.collectAsStateWithLifecycle()
     MenuContent(
         activeContext = activeContext,
+        manualOverride = manualOverride,
         onNavigate = { route -> navController.navigateTopLevel(route) },
         onRecheckPermissions = { navController.navigateTopLevel(AppRoute.Onboarding) },
     )
@@ -66,6 +68,7 @@ fun MenuScreen(navController: NavHostController) {
 @Composable
 fun MenuContent(
     activeContext: String?,
+    manualOverride: Boolean = false,
     onNavigate: (AppRoute) -> Unit,
     onRecheckPermissions: () -> Unit,
 ) {
@@ -93,7 +96,14 @@ fun MenuContent(
             MenuHeroCard(
                 icon = Icons.Filled.Place,
                 title = "Contexts",
-                subtitle = activeContext?.let { "Active: $it" } ?: "No context override active",
+                // F46 semantics: a manual profile load IS the override (latched %AAB_ContextOverride —
+                // shown here, cleared by Resume on the Profiles screen). A context *rule* being active
+                // is automation working as intended and must NOT be labelled an override.
+                subtitle = when {
+                    manualOverride -> "Manual override active — Resume on Profiles"
+                    activeContext != null -> "Context active: $activeContext"
+                    else -> "No active context"
+                },
                 testTag = "hero_contexts",
                 onClick = { onNavigate(AppRoute.Contexts) },
             )

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/AnimationRunnerTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/AnimationRunnerTest.kt
@@ -63,4 +63,45 @@ class AnimationRunnerTest {
         assertEquals(AnimationRunner.Result.COMPLETED, result)
         assertEquals(5, fake.writes.size)
     }
+
+    // S12.7a/F34: with detection ON but only our own in-flight writes on screen, the band check
+    // (task696 java L121-137) sees every read inside [minTarget-2, maxTarget+2] → no override. This
+    // is the case the old exact-match self-write check could fire spuriously on (OEM round-trip drift).
+    @Test
+    fun animate_withDetection_selfWritesOnly_completes() = runTest {
+        val fake = FakeBrightness()
+        val runner = AnimationRunner(fake, sleep = {})
+        val result = runner.animate(from = 0, to = 100, steps = 4, waitMs = 5, detectOverrides = true)
+        assertEquals(AnimationRunner.Result.COMPLETED, result)
+        assertEquals(4, fake.writes.size)
+        assertEquals(100, fake.writes.last())
+    }
+
+    // S12.7a/F34: an opposing-direction external write (rising while we dim) sustained past the
+    // 2-consecutive-read debounce aborts as OVERRIDDEN.
+    @Test
+    fun animate_opposingDirectionWrite_returnsOverridden() = runTest {
+        val fake = FakeBrightness()
+        // Dimming 200 -> 50; an external app yanks brightness UP to 255 (above maxTarget+2).
+        val runner = AnimationRunner(fake, sleep = { if (fake.writes.size >= 1) fake.overrideRead = 255 })
+        val result = runner.animate(from = 200, to = 50, steps = 6, waitMs = 5, detectOverrides = true)
+        assertEquals(AnimationRunner.Result.OVERRIDDEN, result)
+        assertTrue(fake.writes.size < 6)
+    }
+
+    // S12.7a/F34: a SINGLE out-of-band transient (one delayed/coalesced read) does not trip the
+    // override — the 2-consecutive-read debounce (task696 java L129) absorbs it.
+    @Test
+    fun animate_singleOutOfBandTransient_completes() = runTest {
+        val fake = FakeBrightness()
+        var sleeps = 0
+        val runner = AnimationRunner(fake, sleep = {
+            sleeps++
+            // Inject one out-of-band read for exactly the next check, then clear it.
+            fake.overrideRead = if (sleeps == 1) 250 else null
+        })
+        val result = runner.animate(from = 0, to = 100, steps = 5, waitMs = 5, detectOverrides = true)
+        assertEquals(AnimationRunner.Result.COMPLETED, result)
+        assertEquals(5, fake.writes.size)
+    }
 }

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineControllerTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineControllerTest.kt
@@ -274,6 +274,46 @@ class BrightnessPipelineControllerTest {
         scope.cancel()
     }
 
+    // S12.7a/F64: after a Set Initial Brightness self-write (context swap / reinit / resume), the
+    // ContentObserver echo of our OWN write must NOT be flagged as an override during the settle
+    // window — but a genuine external write after the window still pauses.
+    @Test
+    fun initialWrite_suppressesOverrideEcho_thenPausesAfterWindow() = runTest {
+        val sensor = FakeSensor()
+        val observer = FakeObserver()
+        val brightness = FakeBrightness()
+        var now = 1000L
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val controller = BrightnessPipelineController(
+            lightSensor = sensor, brightness = brightness, brightnessObserver = observer,
+            settingsProvider = { settings }, scope = scope, clock = { now },
+        )
+        controller.start()
+
+        // Seed a reading so Set Initial Brightness has a lux to act on; runCycle does NOT arm the window.
+        sensor.flow.emit(sample(lux = 50.0))
+        advanceUntilIdle()
+
+        // A context swap re-runs Set Initial Brightness → arms the settle window (now=1000 → 2500).
+        controller.onContextChanged()
+        advanceUntilIdle()
+        val applied = controller.state.value.lastAppliedBrightness!!
+
+        // A divergent value on screen (e.g. the AUTO→MANUAL mode-flip recompute) echoes through the
+        // observer DURING the settle window → must be suppressed even though it differs from ours.
+        brightness.current = applied + 80
+        observer.flow.emit(applied + 80)
+        advanceUntilIdle()
+        assertTrue(!controller.state.value.paused, "own init-time echo must not pause during the window (F64)")
+
+        // Past the settle window the same divergent external value still pauses.
+        now = 4000L
+        observer.flow.emit(applied + 80)
+        advanceUntilIdle()
+        assertTrue(controller.state.value.paused, "a real external write after the window must pause")
+        scope.cancel()
+    }
+
     @Test
     fun screenOff_hibernatesRuntimeState() = runTest {
         val sensor = FakeSensor()

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/ui/UiShellTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/ui/UiShellTest.kt
@@ -71,6 +71,29 @@ class UiShellTest {
     }
 
     @Test
+    fun menuContexts_distinguishesManualOverrideFromActiveContextRule() {
+        // S12.7a/F46: a manual profile load IS the override; a context rule being active is NOT.
+        compose.setContent {
+            MaterialTheme {
+                MenuContent(activeContext = "Evening", manualOverride = false, onNavigate = {}, onRecheckPermissions = {})
+            }
+        }
+        // A context rule active is surfaced as automation, never as an "override".
+        compose.onNodeWithText("Context active: Evening").assertExists()
+    }
+
+    @Test
+    fun menuContexts_showsManualOverrideWhenLatched() {
+        // S12.7a/F46: with the manual-load lock latched, the card says override + Resume.
+        compose.setContent {
+            MaterialTheme {
+                MenuContent(activeContext = null, manualOverride = true, onNavigate = {}, onRecheckPermissions = {})
+            }
+        }
+        compose.onNodeWithText("Manual override active — Resume on Profiles").assertExists()
+    }
+
+    @Test
     fun renamedRoutes_resolveToTaskerNames() {
         // S12.6a (G2R-F3/F4): the routes carry the Tasker names.
         assertEquals("super_dimming", AppRoute.SuperDimming.route)

--- a/docs/rebuild/PARITY_CHECKLIST.md
+++ b/docs/rebuild/PARITY_CHECKLIST.md
@@ -13,7 +13,7 @@ filled by S1/S2 during extraction.
 |---|---|---|---|
 | prof753 Hibernate (Display Off) → task585 | L3 | runtime/BrightnessPipelineController.hibernate (S9a) | ported |
 | prof754 Throttle Reinitialization → task566 | L16 | runtime/BrightnessPipelineController.reinit (S9a) | ported |
-| prof755 Allow Override → task567 | L56 | runtime/OverrideMonitor + ProfileGates.allowOverrideGate (S9a) | ported |
+| prof755 Allow Override → task567 | L56 | runtime/OverrideMonitor + ProfileGates.allowOverrideGate (S9a); S12.7a adds post-init settle-suppression (F64) + corrected override/context-rule semantics (F46, D-054) | ported |
 | prof756 Repost Paused Notification → task567 | L111 | runtime/AmbientMonitoringService paused notification (S9a) | ported |
 | prof757 Repost Foreground Notification → task584 | L156 | runtime/AmbientMonitoringService live notification (S9a) | ported |
 | prof758 Dynamic Scale Engine → task90 | L195 | gate transcribed: ProfileGates.dynamicScaleGate + truth-table test (S9a); task90 scheduling S9b/S12 | partial (gate S9a) |
@@ -125,7 +125,7 @@ filled by S1/S2 during extraction.
 | task655 L32591 · _SetSuggestedVariables | ✓ S1 | ✓ S6 (delegate) | CurveSuggestionEngine.applyToLiveCurve (S6) | ported |
 | task657 L32986 · _GenerateCompressionGraph | ✓ S1 | | | pending |
 | task663 L33944+L34370 · _GenerateGraph (×2) | ✓ S1 | ✓ S4 (cross-validation oracle, D-002) | chart render = S13 BrightnessCurveChart | reference (chart S13) |
-| task696 L35733 · Smooth Brightness Transition | ✓ S1 | ✓ S4 | runtime/AnimationRunner (S9a) | ported |
+| task696 L35733 · Smooth Brightness Transition | ✓ S1 | ✓ S4 | runtime/AnimationRunner (S9a); S12.7a ports the REAL band+2-read-debounce override detector (java L49-56/L121-137) replacing the exact-match self-write check (F34, D-054) | ported |
 | task698 L36043 · Smooth DC-Like Transition | ✓ S1 | ✓ S4 | runtime/AnimationRunner brightness path (S9a); S9b wires the ELEVATED secure-dimming layer (task646/650/645 via SuperDimmingCoordinator); S12.6c adds the **PWM-sensitive hardware floor** (step 3: clamp hardware up to dimmingThreshold, G2R-F27/D-050); DC-like unprivileged overlay still deferred (D-040) | ported (brightness + secure dimming + PWM hardware floor; overlay deferred) |
 | task703 L36847 · _GenerateReactivityGraph | ✓ S1 | | | pending |
 | task705 L37517 · _GenerateCircadianDimmingGraph | ✓ S1 | | | pending |

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -34,11 +34,20 @@ next session does not know it.
 | S12.6c pipeline behaviour correctness | 2026-06-14 | Opus/high | DONE | (see push) | Fixed the runtime bugs the re-test found + wired override-point capture (D-051; G2R-F11/F12/F13/F14/F26/F27). **G2R-F11/F12** (Apply/profile-load + min-brightness ignored until a light change): root = the pipeline's `settingsProvider`=`ContextEngine.effectiveSettings()` served the STALE cached `_effective` snapshot. Added `ContextEngine.reevaluate()` (re-reads the FRESH baseline + re-merges the active profile, no watcher re-resolution) and the service's `ACTION_REAPPLY` now calls it BEFORE `controller.reapply()` → manual edits take effect immediately (min-bright no longer "stuck at 10"). **G2R-F13** override-point capture (closes D-044c): new `OverridePointStore` (DataStore, newest-first cap 50) + `OverridePointSink`; `handleOverride` persists the de-compressed point; `SettingsViewModel`/`DraftSettingsViewModel` expose `overridePoints`; Tools wizard reads the recorded set. **G2R-F14** `BrightnessCurveChart` overlays the recorded points as dots + shows the fitted/suggested curve only at ≥9 points (ChartCanvas unchanged). **G2R-F26/D-049** override false-positives: `handleOverride` now does the task567 act8 settle (wait %AAB_CycleTime → re-read → only pause if still ≠ our last applied) + the AnimationRunner read-back is now device-exact (`ScreenBrightnessController.isOnScreenSelfWrite`, kills OEM round-trip drift, D-049 #4). **G2R-F27/D-050** PWM-sensitive hardware floor: `applyPwmFloor` clamps the hardware write up to `dimmingThreshold` when `pwmSensitive && target<threshold` (task698 step3) in runCycle + setInitialBrightness. **HARD FENCE honoured: domain/, golden vectors, ChartCanvas API untouched.** New tests: controller minBrightness/PWM-floor/override-false-positive (3), ContextEngine reevaluate-fresh-baseline, OverridePointStore (3). Full ladder GREEN: `:platform:test :app:testDebugUnitTest`(104) `:domain:test :app:assembleDebug :app:lintDebug`. No compaction. |
 | S12.6e labels/help audit + context editor + onboarding | 2026-06-14 | Opus/high | DONE | (this push) | Last S12.6 sub-segment (D-053; G2R-F19…F25 + F28/F29). **Label + verbatim long-press-help audit** (G2R-F19/F20/F21): new `TaskerHelp.kt` holds the 30 verbatim Flash help strings (decoded from the reactivity/brightness/misc/superdimming scene `longclick` tasks via XML_RECIPES R2); `NumberSettingField`/`IntSliderSettingField`/`SwitchSettingRow` gained a `help=` param surfaced via an "ⓘ" reveal (Tasker longtap → tap, `helptext_<tag>`); every control on Reactivity/Curve/Misc/SuperDimming relabelled to the Tasker scene labels + the verbatim help wired. **WIRING AUDIT (G2R-F20): the owner-flagged "delta factor" was MIS-LABELLED/MIS-HELPED, not mis-wired** — `%AAB_DeltaFactor` IS the sensor-smoothing alpha factor (`luxAlpha=1-exp(-deltaFactor·effectiveDelta)`, BrightnessEngine); relabelled "Smoothing Δ" + verbatim help. No other binding bug found; all field→`%AAB_*` bindings cross-checked vs AabSettingsContract. **Context Wi-Fi/location (G2R-F22):** `WifiInfoReader.currentSsid()` is now a `suspend` returning a typed `SsidResult` (one-shot `NetworkCallback` w/ `FLAG_INCLUDE_LOCATION_INFO`+2s timeout; targeted NotOnWifi/NeedsLocationPermission/LocationServicesOff/Unknown messages — fixes the API-29+ `<unknown ssid>` redaction); rule editor gained lat/lon/radius fields + "Use current location" (AndroidLocationReader). **Time picker (G2R-F28):** From/To open the M3 `TimePicker` modal (SUNRISE/SUNSET tokens kept). **Usage access (G2R-F23/F24):** onboarding always shows the usage step, labelled "(optional)" by default / "(needed for per-app rules)" once an app rule exists; the rule-editor grant prompt was already present. **Toast on load (G2R-F25):** new `ContextLoadSink`/`ToastContextLoadSink` → unconditional teal-less toast when a runtime context rule loads its profile; Profiles-screen apply already toasted. **Live Debug Performance & Timings (G2R-F29):** `PipelineState` gains `luxAlpha`/`animationSteps`/`animationWaitMs`/`throttleMs`/`lastUpdateMs` (populated in runCycle from existing engine output, no domain change) → Live Debug card now shows LuxAlpha / cycle / reactivity-cooldown / last-animation (steps×wait) / last-update. **HARD FENCE honoured: domain/, golden vectors, ChartCanvas untouched.** Tests: SettingsScreens +5 (delta-factor verbatim help reveal, time-picker modal, use-current-SSID fills field, location fields, Live Debug timings) + ContextEngine contextLoad-fires-sink (1). Full ladder GREEN (`:app:testDebugUnitTest`=122 `:app:assembleDebug :app:lintDebug :domain:test :platform:test`). No compaction. **GATE 2 RE-TEST (again) READY.** |
 | S12.6d profiles + legacy import + reset + Apply-gate | 2026-06-14 | Opus/high | DONE | (see push) | Real user-profile management + legacy import + validation gate (D-052; G2R-F15/F16/F17/F18/F30 + owner findings F31/F32). **G2R-F15** user-editable profiles: new `UserProfileStore` (DataStore `SavedProfiles`: built-ins seeded once, Save-current-as, overwrite-in-place [keeps built-in flag], delete, **Restore factory profiles**); `AppProfileCatalog` converted object→class reading the store (built-in fallback) so context rules target user profiles too (closes D-042c); `SettingsViewModel` gains saveCurrentAs/deleteProfile/restoreFactoryProfiles/profiles flow; ContextsViewModel.profileNames now a StateFlow off the store. **G2R-F16** legacy SAF import: `LegacyConfigImporter` (OpenDocumentTree grant→takePersistableUriPermission, list `*.json` via DocumentsContract — no MANAGE_EXTERNAL_STORAGE/no new dep) wired into the rewritten ProfilesScreen (link-folder + per-file Load) alongside the single-file picker. **G2R-F17** per-screen reset: `DraftSettingsScaffold` gains an `onReset` TopAppBar action; each of the 5 draft screens resets only its own fields to the task570 baseline + toast. **G2R-F18/D-052** block-Apply: `FieldError` gains `Severity`; the 3 task583 form errors (form2A/3A<0, form2C>zone1End) are CRITICAL; `DraftSettingsViewModel.hasCriticalError` disables `DraftApplyBar` Apply (+ hint) while one stands — sanctioned deviation from Tasker's advisory model. **G2R-F30** manual-load context lock: applyProfile/replaceAll latch `contextOverride=true`; `ContextEngine.reevaluate()` honours the lock (drops active context, runs the manual baseline); Profiles screen shows a Resume banner → `resumeContextAutomation()` clears it + reapplies. **Owner findings during S12.6d:** **G2R-F31** battery % from/to added to the context rule editor (BatteryTrigger min/max; resolver already supported it); **G2R-F32** curve-wizard report was too terse — Tools now shows + copies the FULL `diagnosticsLog` (the engine already produced it; app-layer only). **HARD FENCE honoured: domain/, golden vectors, ChartCanvas untouched.** Tests: UserProfileStoreTest(5), SettingsValidator severity(1), SettingsScreens criticalError-gate/reset/profiles/context-lock/battery(5), ContextEngine reevaluate-lock(1). Full ladder GREEN: `:app:testDebugUnitTest`(116) `:app:assembleDebug :app:lintDebug :domain:test :platform:test`. No compaction. |
+| S12.7a manual-override engine correctness | 2026-06-14 | Opus/high | DONE | (this push) | Ported the REAL task567/task696 override logic (D-054; G2R-F34/F64/F46). **F34:** `AnimationRunner` replaced the exact-match `isOnScreenSelfWrite()` (false-fired on OEM round-trip drift) with task696's band+debounce — band `[minTarget-2, maxTarget+2]` spanning the sweep, override only after **2 consecutive** out-of-band reads (every-frame, since the every-5th was a Tasker IPC optimization). **F64:** `OverrideMonitor` gained a settle-suppression gate; `setInitialBrightness` arms a 1500ms window after each initial self-write so the start/reinit/resume/QS-on observer echo (incl. the AUTO→MANUAL mode-flip recompute) is not flagged as an override; the S12.6c idle-path settle-wait kept. **F46:** manual profile load = override (`LiveRuntimeState.manualOverride` published from `%AAB_ContextOverride` via the service) shown in the Menu; a context rule active is no longer labelled an override (Menu Contexts card relabelled). Tests: AnimationRunner +3 (self-writes complete / opposing-write overridden / single-transient debounced), controller +1 (init-echo suppressed then real-write pauses post-window), UiShell +2 (Menu label semantics). **Fence: domain/ + golden vectors untouched.** Full ladder GREEN: `:app:testDebugUnitTest`(128) `:domain:test :platform:test :app:assembleDebug :app:lintDebug`. No compaction. |
 Status values: DONE · PARTIAL · BLOCKED (see failure protocol in CLAUDE.md).
 
 ## Current state
 
-**ALL of S12.6 (a–e) DONE; GATE 2 RE-RE-TESTED (2026-06-14) → 36 new findings G2R-F33…F68 → S12.7 (a–h) is
+**S12.7a DONE (2026-06-14) → S12.7 b–h remain.** S12.7a ported the real task567/task696 manual-override
+logic (D-054): the band+debounce override detector (F34, was an exact-match self-write check that false-
+fired on OEM drift), a post-init settle-suppression window (F64, kills the start/reinit/resume/QS-on echo
+race), and the F46 override-vs-context-rule semantics (manual profile load = override surfaced in the Menu;
+a context rule active is no longer labelled one). domain/ + golden vectors stayed fenced. Ladder GREEN
+(`:app:testDebugUnitTest`=128). **Next: S12.7 b–h (b–h largely disjoint; rebase before push), then owner
+re-tests Gate 2 a 4th time after S12.7h.**
+
+**(historical) ALL of S12.6 (a–e) DONE; GATE 2 RE-RE-TESTED (2026-06-14) → 36 new findings G2R-F33…F68 → S12.7 (a–h) is
 the next work (planned in RUNBOOK, all Opus/high).** The owner re-tested the S12.6e dist/ APK on-device:
 "definitely going in the right direction" but a further batch of parity/behaviour gaps remains (see "Gate 2
 RE-RE-TEST" below) — manual-override false-positives + spurious instant-override-on-start race (need the real
@@ -218,9 +227,11 @@ AppModule is now the real DI root.
   D-053). **ALL S12.6 sub-segments complete.** Domain/ + golden vectors + ChartCanvas API stayed fenced.
 - **GATE 2 RE-RE-TEST DONE (2026-06-14) → 36 findings G2R-F33…F68** (see "Gate 2 RE-RE-TEST"). Gate 2
   still NOT signed off.
-- **S12.7 — Gate-2 re-re-test salvage (a–h, all Opus/high)** is the NEXT work (brief in RUNBOOK). Split:
+- **S12.7 — Gate-2 re-re-test salvage (a–h, all Opus/high)** (brief in RUNBOOK). **a DONE** (D-054:
+  band+debounce override detector from task696 + post-init settle-suppression window + F46 override/
+  context-rule semantics). **b–h remain.** Split:
   **a** manual-override engine (transcribe task567: anim mutex + target-vs-actual delta) + instant-override
-  race + override semantics (F34/F64/F46); **b** runtime feedback surfaces — override notification+vibration
+  race + override semantics (F34/F64/F46) — DONE; **b** runtime feedback surfaces — override notification+vibration
   +toast, notification Resume, QS tile live refresh, super-dimming Extra-Dim fix (F35/F40/F63/F65); **c**
   context system — location listener lifecycle/0.0,0.0/debounce, use-current-location perm recheck, priority
   ordering, legacy-profile rule targets, context-automation debug toasts, day-of-week rules+midnight wrap,
@@ -1069,7 +1080,31 @@ Seeded by the S0 audit (details in CLAUDE.md "Facts & corrections ledger"):
   fence honoured). (Affects S12.6e; Gate 2 re-test; S13 inherits the help-reveal pattern + the
   Experiment-scene help gap.)
 
-Append new entries as D-054, D-055, … with which segments they affect.
+- D-054: S12.7a MANUAL-OVERRIDE ENGINE — the REAL task567/task696 transcription (G2R-F34/F64/F46).
+  **The override DELTA check is NOT in task567** (task567 `_DetectManualOverride`, XML L20525-L20885, is
+  the *pause/notify/stop-other-tasks* handler: act0 gates `%caller1 = *Allow Override*|*Smooth Brightness
+  Transition*`; acts 1-6 are code-137 **Stop** naming the SIX pipeline tasks to abort — "Process Sensor
+  Event", "Evaluate Light Change V2", "Lux Smoothing", etc.; act7 Wait `%AAB_CycleTime`; act8 re-check
+  Stop). **The actual detection lives in task696 "Smooth Brightness Transition V5 (Java)"** (java/task696_1,
+  XML L35734-L35886): it computes a band `minTarget = from<to ? from : to-1`, `maxTarget = from<to ? to+1 :
+  from` (L49-56) and flags an override only when `actual > maxTarget+2 || actual < minTarget-2` for
+  **2 consecutive** reads (`overrideTriggerThreshold`, L126-134) — i.e. wrong-direction / overshoot-beyond-
+  step. The mutex is **`%AutoBrightRunning`** (prof755 con1/c1 `=0` gate + task696 sets it `0` only at the
+  very end, L160), so per-frame self-writes never fire prof755. Tasker checked every 5th frame **purely as
+  an IPC optimization** (explicit comment L98-101) → the Kotlin port checks every frame (a *how*, the band+
+  2-read debounce is the *what*). FIX: `AnimationRunner` now uses this band+debounce (replaces the old
+  exact-match `isOnScreenSelfWrite()` that false-fired on OEM round-trip drift); `OverrideMonitor` gains a
+  post-init **settle-suppression** gate and `BrightnessPipelineController.setInitialBrightness` arms a 1500ms
+  window after each initial self-write (F64 — kills the start/reinit/resume/QS-on echo race where the
+  AUTO→MANUAL mode-flip recompute looked external). The S12.6c handleOverride settle-wait (D-049/D-051d) is
+  KEPT for the idle-observer path (complements, not conflicts). **F46 semantics:** a manual profile load IS
+  the override (`%AAB_ContextOverride` latch, surfaced in the Menu via `LiveRuntimeState.manualOverride`,
+  Resume clears it); a context *rule* being active is NOT an override and is no longer labelled one (Menu
+  Contexts card: "Context active: X" / "Manual override active — Resume on Profiles" / "No active context").
+  **Fence honoured: domain/ + golden vectors untouched** (band logic is app-layer; `OverrideRules` unchanged).
+  (Affects S12.7a; S12.7b reuses the override→notification path; S12.7c/h depend on the F46 lock semantics.)
+
+Append new entries as D-055, D-056, … with which segments they affect.
 
 ## Blockers
 
@@ -1394,12 +1429,13 @@ at the end).
   location-based SSID path + context location. (With Location enabled via Android app settings it works.)
 
 *Manual override detection & feedback:*
-- **G2R-F34** Manual-override **false positives persist** — the app can't tell a true override from a new
-  sensor reading. Owner spec: while an animation is **mid-flight there must be a mutex lock**, plus a
-  **target-vs-actual delta check** — if target is e.g. −20 from current and the observed value is +1 or −21
-  (i.e. wrong direction / overshoot beyond our step) that's an override; a value consistent with our own
-  in-flight step is not. The owner is fairly sure the Tasker version does exactly this. (Refines G2R-F26/
-  D-049 — the S12.6c settle-wait was insufficient.)
+- **G2R-F34** ✅ RESOLVED S12.7a (D-054). Manual-override **false positives persist** — the app can't tell a
+  true override from a new sensor reading. Owner spec: while an animation is **mid-flight there must be a
+  mutex lock**, plus a **target-vs-actual delta check** — if target is e.g. −20 from current and the observed
+  value is +1 or −21 (i.e. wrong direction / overshoot beyond our step) that's an override; a value
+  consistent with our own in-flight step is not. The owner is fairly sure the Tasker version does exactly
+  this. (Refines G2R-F26/D-049 — the S12.6c settle-wait was insufficient.) → Ported task696's band+2-read
+  debounce in `AnimationRunner`; mutex = `%AutoBrightRunning`.
 - **G2R-F35** A manual override should post a **high-priority notification (with vibration) + a toast**,
   same as Tasker.
 
@@ -1452,7 +1488,7 @@ at the end).
   guarded location listener** (Tasker's "super smart location listener"), and the **0.0,0.0** read is a
   bug. Also the context-location debug toasts are **not debounced to ≥100 m** changes and are near-constant,
   **blocking text input**.
-- **G2R-F46 (semantics)** **"Manual profile load = override" misunderstanding.** After a manual profile
+- **G2R-F46 (semantics)** ✅ RESOLVED S12.7a (D-054). **"Manual profile load = override" misunderstanding.** After a manual profile
   load the Menu says **no context override active** — but a manual load IS the override (it should latch +
   display it, smoother Resume). Conversely, **a context rule being active is NOT an "override"** and must
   not be labelled one. Fix the override/lock semantics + the Menu/label wording (refines G2R-F30/D-038a).
@@ -1503,7 +1539,7 @@ at the end).
 - **G2R-F63** **QS tile state is not live** — Off→Starting "hangs" until the QS panel is closed+reopened;
   state transitions only render when not being watched. Needs `TileService.requestListeningState` /
   `Tile.updateTile` on every state change (and a refresh on `onStartListening`).
-- **G2R-F64** **Spurious "instant override" on service start / display-on (race).** QS Off→On sometimes
+- **G2R-F64** ✅ RESOLVED S12.7a (D-054). **Spurious "instant override" on service start / display-on (race).** QS Off→On sometimes
   lands in *override* instead of resuming; a display off→on cycle sometimes leaves it *paused*. Both point
   to a manual-override being detected at start/reinit (the observer firing on our own initial write).
   Confirmed in the Dashboard; hard to reproduce once cleared. Likely a race in OverrideMonitor vs the

--- a/docs/rebuild/extraction/tasks/task567_manual-override.md
+++ b/docs/rebuild/extraction/tasks/task567_manual-override.md
@@ -45,3 +45,26 @@
 **Variables written:** `%AAB_DimmingStatus`, `%AAB_Manual_Override`, `%AAB_ResumeTapped`
 
 **Variables read:** (none)
+
+## S12.7a transcription note (D-054) — where the override DELTA actually lives
+
+task567 is the **handler**, not the **detector**. It runs when something has *already decided* an override
+happened (its act0 gate only proceeds for `%caller1 = *Allow Override*` (prof755) or `*Smooth Brightness
+Transition*` (task696)). Its job: **abort the in-flight pipeline** (acts 1-6 are code-137 **Stop** naming the
+six pipeline tasks — *Process Sensor Event (Java)*, *Evaluate Light Change (Java) V2*, *Lux Smoothing*, … —
+to kill the running animation/loop), wait `%AAB_CycleTime` (act7), re-check the gate (act8 Stop on
+`Service=Off ∨ AutoBrightRunning=1 ∨ Manual_Override=true ∨ Initializing=true`), then pause + notify +
+`%AAB_Manual_Override=true` + disengage dimming.
+
+The actual **target-vs-actual delta check** is in **task696 "Smooth Brightness Transition V5 (Java)"**
+(`java/task696_1`, XML L35734-L35886):
+- band: `minTarget = from<to ? from : to-1`, `maxTarget = from<to ? to+1 : from` (L49-56);
+- override iff `actual > maxTarget+2 || actual < minTarget-2` for **2 consecutive** reads
+  (`overrideTriggerThreshold`, L126-134) → sets `%AAB_Manual_Override=true`, calls this task567;
+- mutex: `%AutoBrightRunning` (prof755 con1 c1 `=0` gate; task696 writes it `0` only at L160, the very end),
+  so per-frame self-writes never fire prof755;
+- the every-5th-frame cadence (L98-101) is an explicit **IPC optimization comment**, not behaviour.
+
+The Kotlin rebuild ports the band+debounce into `app/runtime/AnimationRunner.kt` (checks every frame; the
+band + 2-read debounce is the behaviour that matters) and adds a post-init settle-suppression window in
+`BrightnessPipelineController` for the start/reinit/resume/QS-on echo race (F64). See D-054.


### PR DESCRIPTION
## Summary

Ported the real task567/task696 manual-override detection logic from Tasker (D-054), replacing the exact-match `isOnScreenSelfWrite()` check that false-fired on OEM round-trip drift. Implements task696's band+debounce override detector and adds a post-init settle-suppression window to prevent ContentObserver echo races from spuriously pausing the pipeline on start/reinit/resume/context-swap.

## Key Changes

**AnimationRunner (F34 — band+debounce override detector)**
- Replaced exact-match `isOnScreenSelfWrite()` with task696's tolerance band: `[minTarget-2, maxTarget+2]` spanning the brightness sweep
- Override only triggers after **2 consecutive** out-of-band reads (every-frame check; Tasker's every-5th was an IPC optimization, not behavior)
- Band detects opposing-direction writes (rising while dimming) and overshoots beyond the current step, absorbing OEM round-trip drift that made the equality check fire on every multi-frame transition
- Added `isOutOfBand()` helper and `OVERRIDE_TRIGGER_THRESHOLD` constant
- Updated javadoc with full task696 logic explanation (S12.7a, F34 — the *real* task696 logic, not the old exact-match self-write check)

**BrightnessPipelineController (F64 — post-init settle-suppression window)**
- Added `suppressOverrideUntilMs` volatile field to gate override detection for 1500ms after each Set Initial Brightness self-write
- Arms the window in `setInitialBrightness()` after writing the target brightness
- Prevents ContentObserver echo of our own write — delivered after `initializing` resets — from being flagged as a manual override during start/reinit/resume/context-swap
- Real external writes after the window still pause the pipeline normally

**OverrideMonitor (F64 — suppress gate)**
- Added `suppressed: Boolean` field to `Gate` data class
- Early-return null in `overrides()` flow when suppression window is active, preventing false-positive override signals

**LiveRuntimeState & MenuScreen (F46 — override vs. context-rule semantics)**
- Added `manualOverride` StateFlow to track `%AAB_ContextOverride` (manual profile load lock)
- Updated `publish()` to accept and propagate manual override state from the service
- Distinguished manual profile load (IS an override) from context rule being active (is NOT an override)
- Menu Contexts card now shows "Manual override active — Resume on Profiles" when latched, or "Context active: <name>" when a rule is active

**AmbientMonitoringService**
- Wired `%AAB_ContextOverride` from settings DataStore into the live state flow
- Passes manual override flag to `LiveRuntimeState.publish()` alongside active context

**Tests**
- AnimationRunner: +3 tests covering self-writes-only completion, opposing-direction override, and single-transient debounce absorption
- BrightnessPipelineController: +1 test verifying init-echo suppression during window and real-write pause after
- UiShell: +2 tests distinguishing manual override from active context rule in Menu display

## Implementation Details

- The band calculation matches task696 java L49-56: `minTarget = from<to ? from : to-1`, `maxTarget = from<to ? to+1 : from`
- Override condition: `actual > maxTarget+2 || actual < minTarget-2` (java L126) — detects wrong-direction or overshoot
- 2-consecutive-read debounce (java L129) absorbs single transients from delayed/coalesced observer callbacks
- Settle window (1500ms) outlasts async ContentObserver delivery + AUTO→MANUAL mode-flip recompute, short enough to catch real user overrides moments after reinit
- Javadoc extensively documents the real task696 logic vs. the legacy exact-match check, with references to Tasker source line numbers

**Fence:** domain

https://claude.ai/code/session_01K3tkiNQYv9YTTVQU1U4gZj