### PR TITLE
Add release APK signing workflow and keystore configuration

### DIFF
--- a/.github/workflows/release-signing.yml
+++ b/.github/workflows/release-signing.yml
@@ -1,0 +1,71 @@
+name: Release Signing
+
+# Builds and signs a release APK when APK-affecting changes land on main.
+# The `paths` filter keeps this from running on docs-only / STATE-only merges.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'app/**'
+      - 'domain/**'
+      - 'platform/**'
+      - 'gradle/**'
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - 'gradle.properties'
+      - 'gradle/libs.versions.toml'
+      - '.github/workflows/release-signing.yml'
+  # Allow manual runs for testing the pipeline.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-signed-apk:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts', 'gradle/libs.versions.toml') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Decode keystore
+        env:
+          ANDROID_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE }}
+        run: echo "$ANDROID_KEYSTORE" | base64 --decode > "$RUNNER_TEMP/release.jks"
+
+      - name: Build signed release APK
+        env:
+          ANDROID_KEYSTORE_FILE: ${{ runner.temp }}/release.jks
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ vars.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: ./gradlew :app:assembleRelease --no-daemon
+
+      - name: Remove decoded keystore
+        if: always()
+        run: rm -f "$RUNNER_TEMP/release.jks"
+
+      - name: Upload signed APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release
+          path: app/build/outputs/apk/release/app-release.apk
+          if-no-files-found: error

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,6 +17,33 @@ android {
         versionName = "1.0"
     }
 
+    // Release signing is driven entirely by environment variables so that no
+    // keystore material ever lives in the repo. In CI (release-signing.yml) the
+    // keystore is base64-decoded from the ANDROID_KEYSTORE secret to the path in
+    // ANDROID_KEYSTORE_FILE. Locally, with the env unset, the release build is
+    // left unsigned (debug builds are unaffected).
+    val keystoreFile = System.getenv("ANDROID_KEYSTORE_FILE")
+    val hasReleaseSigning = !keystoreFile.isNullOrBlank() && file(keystoreFile).exists()
+
+    signingConfigs {
+        if (hasReleaseSigning) {
+            create("release") {
+                storeFile = file(keystoreFile)
+                storePassword = System.getenv("KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("KEY_ALIAS")
+                keyPassword = System.getenv("KEY_PASSWORD")
+            }
+        }
+    }
+
+    buildTypes {
+        getByName("release") {
+            if (hasReleaseSigning) {
+                signingConfig = signingConfigs.getByName("release")
+            }
+        }
+    }
+
     buildFeatures {
         compose = true
     }


### PR DESCRIPTION
## Summary
Adds automated release APK signing infrastructure for CI/CD, with keystore material managed entirely through environment variables to keep sensitive data out of the repository.

## Key Changes
- **New GitHub Actions workflow** (`.github/workflows/release-signing.yml`):
  - Triggers on APK-affecting changes to `main` branch (app, domain, platform, gradle configs)
  - Decodes base64-encoded keystore from `ANDROID_KEYSTORE` secret
  - Builds signed release APK using environment variables for keystore credentials
  - Cleans up decoded keystore after build (even on failure)
  - Uploads signed APK as artifact
  - Supports manual workflow dispatch for testing

- **Gradle signing configuration** (`app/build.gradle.kts`):
  - Detects release signing availability via `ANDROID_KEYSTORE_FILE` environment variable
  - Conditionally creates `release` signing config only when keystore file exists and is readable
  - Applies signing config to release build type when available
  - Leaves release builds unsigned locally (when env vars unset) without breaking the build
  - Debug builds remain unaffected

## Implementation Details
- Keystore material never persists in the repository; CI decodes it from secrets at build time
- Local development builds unsigned release APKs gracefully when signing env vars are absent
- Path filter prevents workflow runs on docs-only or STATE-only changes
- Gradle cache configured to speed up builds
- Keystore file cleaned up with `if: always()` to ensure cleanup even on build failure

https://claude.ai/code/session_01UtiydVJta2dwRX4dvPP7Wt