### PR TITLE
[S-infra] Auto-flag pre-releases for hyphenated tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,3 +72,6 @@ jobs:
           files: app/build/outputs/apk/release/app-release.apk
           fail_on_unmatched_files: true
           generate_release_notes: true
+          # Tags with a pre-release suffix (a hyphen, e.g. v0.1.0-rc1) are
+          # published as pre-releases; clean semver tags (v1.0.0) are full releases.
+          prerelease: ${{ contains(github.ref_name, '-') }}


### PR DESCRIPTION
Set prerelease based on whether the pushed tag contains a hyphen, so v0.1.0-rc1 publishes as a GitHub pre-release while v1.0.0 is a full release.


Claude-Session: https://claude.ai/code/session_01UtiydVJta2dwRX4dvPP7Wt