### PR TITLE
[S13c] Fix flaky DraftSettingsViewModelTest seeding race (CI on main)

### DIFF
--- a/app/src/test/kotlin/com/tideo/autobrightness/app/state/DraftSettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/state/DraftSettingsViewModelTest.kt
@@ -47,10 +47,15 @@ class DraftSettingsViewModelTest {
 
     private fun seededVm(): DraftSettingsViewModel {
         val vm = DraftSettingsViewModel(app)
-        // Wait for the init collector to seed the draft from the committed baseline.
+        // Wait for the init collector to ACTUALLY seed the draft. The VM bumps `epoch` 0→1 on its
+        // first committed emission, so gate on that — NOT on `draft == committed()`, which is already
+        // true from construction when the committed baseline equals the AabSettings() defaults (e.g.
+        // minBrightness = 10). Returning early there left `seeded` false, so the first emission fired
+        // during a later idle() and clobbered the test's edit back to the committed value (flaky
+        // edit_marksDirty_thenDiscardReverts).
         repeat(100) {
             idle()
-            if (vm.draft.value == committed()) return vm
+            if (vm.epoch.value >= 1) return vm
             Thread.sleep(10)
         }
         return vm

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -1895,7 +1895,18 @@ Seeded by the S0 audit (details in CLAUDE.md "Facts & corrections ledger"):
   lint green. One note for S14: the knob `c(84,54) r6` reaches ≈r36 from centre, a hair past the r33 safe
   circle — fine under the standard masks in the spec mock, nudge inward only if a device clips it.
 
-Append new entries as D-080, … with which segments they affect.
+- **D-080 (S13c follow-up) — fixed a latent flaky test surfaced by CI on the post-merge `main`.** The
+  "Release Signing" workflow on the PR #60 merge commit went red on a single unrelated test,
+  `DraftSettingsViewModelTest.edit_marksDirty_thenDiscardReverts` (it had passed locally + on the branch CI).
+  **Root cause (test helper, not production):** `seededVm()` waited for `draft == committed()`, but when the
+  committed baseline equals the `AabSettings()` defaults (here `minBrightness = 10`) that is true from VM
+  construction — so the helper returned BEFORE the init collector's seed-once emission. The `idle()` after the
+  test's edit then delivered that first emission with `seeded` still false, clobbering the edit (42→10).
+  **Fix:** gate `seededVm()` on the VM's `epoch` bumping 0→1 (its real "seeded" signal) instead of value
+  equality. Test-only; the production seed-once behaviour is correct and untouched. Verified deterministic
+  (5× `--rerun-tasks` + full `:app:testDebugUnitTest`). (Affects S13c PR / `main`.)
+
+Append new entries as D-081, … with which segments they affect.
 
 ## Blockers
 


### PR DESCRIPTION
## Why

The **Release Signing** workflow on `main` went red right after PR #60 merged (merge commit `4e2ec39`), failing a single, unrelated test:

```
DraftSettingsViewModelTest > edit_marksDirty_thenDiscardReverts FAILED  (283 tests, 1 failed)
```

It passed locally and on the branch CI before the merge — a latent flake that lost the race on the runner.

## Root cause (test helper, not production)

`DraftSettingsViewModel` correctly seeds its draft **once** from the DataStore's first emission. The test's `seededVm()` helper, however, waited for `draft == committed()` — which is **already true at construction** when the committed baseline equals the `AabSettings()` defaults (the baseline here is `minBrightness = 10`, the default). So the helper returned *before* the seed-once emission fired; the `idle()` after the test's edit then delivered that first emission with `seeded` still false and clobbered the edit (`42 → 10`), failing the assertion.

## Fix

Gate `seededVm()` on the VM's `epoch` bumping `0 → 1` (its real "seeded" signal) instead of value equality. **Test-only** — the production seed-once behaviour is correct and untouched.

## Verification

- The previously-flaky test, 5× with `--rerun-tasks`: all green.
- Full `:app:testDebugUnitTest`: green.

Recorded as D-080 in `docs/rebuild/STATE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXGspAXahRjFXPQnWVZeMB

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXGspAXahRjFXPQnWVZeMB)_