### PR TITLE
CI: make release-signing on-demand (drop per-merge push trigger)

### DIFF
--- a/.github/workflows/release-signing.yml
+++ b/.github/workflows/release-signing.yml
@@ -1,23 +1,11 @@
 name: Release Signing
 
-# Builds, tests, and signs a release APK on every APK-affecting push to main,
-# uploading it as a downloadable artifact so any merge can be side-loaded and
-# tested. This does NOT create a GitHub Release — that's release.yml, triggered
-# by pushing a v* tag. The `paths` filter skips docs-only / STATE-only merges.
+# Builds, tests, and signs a release APK ON DEMAND, uploading it as a downloadable artifact so a
+# specific build can be side-loaded and tested. Triggered manually (Actions tab) — NOT on every push
+# to main, which used to re-run build.yml's exact test+lint ladder in parallel and spend signing
+# secrets on non-release merges. Routine per-merge validation lives in build.yml (tests + lint + debug
+# APK); a tagged GitHub Release (build + sign + publish) lives in release.yml on a v* tag.
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'app/**'
-      - 'domain/**'
-      - 'platform/**'
-      - 'gradle/**'
-      - 'build.gradle.kts'
-      - 'settings.gradle.kts'
-      - 'gradle.properties'
-      - 'gradle/libs.versions.toml'
-      - '.github/workflows/release-signing.yml'
-  # Allow manual runs for testing the pipeline.
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What

Trim `release-signing.yml` to a `workflow_dispatch`-only trigger, removing the `push: branches: [main]` (+ APK-path filter) trigger.

## Why

Right now **every** APK-affecting push to `main` fires two workflows in parallel on the same commit:

- **`build.yml`** — `:domain:test :platform:test :app:testDebugUnitTest :app:lintDebug :app:assembleDebug` (no secrets)
- **`release-signing.yml`** — the *same* `:domain:test :platform:test :app:testDebugUnitTest :app:lintDebug` ladder, **then** decodes the keystore and produces a **signed** release APK

So routine, non-release merges re-ran the full test/lint ladder twice and spent signing secrets to sign a build nobody asked to release. That's the "two GitHub Actions on merge — overkill?" you flagged.

## After this change

One workflow per merge, clean separation of concerns:

| Trigger | Workflow | Does |
|---|---|---|
| every PR + push to `main` | `build.yml` | tests + lint + **debug** APK (no secrets) |
| `v*` tag | `release.yml` | build + sign + publish a GitHub Release |
| manual (Actions tab) | `release-signing.yml` | on-demand **signed** APK artifact for side-loading |

No behavioural loss: you can still get a signed test build any time via the **Run workflow** button; tagged releases are unaffected.

Diff is `+5 / −17` in one file (the `on:` block + its header comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Crm7dVvkpDm11DzVWQxt3m)_