### PR TITLE
Bump to 1.0.1 (versionCode 4) for F-Droid metadata-in-tag

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,10 +13,12 @@ android {
         applicationId = "com.tideo.autobrightness"
         minSdk = 31
         targetSdk = 35
-        // 1.0.0 — all three human gates passed on-device (Gate 3 signed off 2026-06-23). Feature-
-        // complete, parity-verified, release build.
-        versionCode = 3
-        versionName = "1.0.0"
+        // 1.0.0 (versionCode 3) — all three human gates passed on-device (Gate 3 signed off
+        // 2026-06-23); feature-complete, parity-verified release build. 1.0.1 (versionCode 4) is a
+        // packaging-only bump so the release tag carries the fastlane/ metadata F-Droid reads from
+        // the built commit (the 1.0.0 tag predated it); no app behaviour changed.
+        versionCode = 4
+        versionName = "1.0.1"
     }
 
     // Release signing is driven entirely by environment variables so that no

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -54,6 +54,9 @@ When in use, track stages here:
 
 One line per shipped change (newest first). Keep terse.
 
+- 2026-06-24 — F-Droid: bumped to 1.0.1 / `versionCode 4` (packaging only — gives a release tag
+  that contains `fastlane/`, which the 1.0.0 tag predated; F-Droid reads metadata from the built
+  commit). Added `changelogs/4.txt`. No app behaviour change. Owner tags `v1.0.1` after merge.
 - 2026-06-24 — F-Droid prep: added `fastlane/metadata/android/en-US/` (title, short/full
   description, `changelogs/3.txt`, 4 phoneScreenshots). Repo-side only; submission to fdroiddata
   + release tag are owner steps. No code/build change.

--- a/fastlane/metadata/android/en-US/changelogs/4.txt
+++ b/fastlane/metadata/android/en-US/changelogs/4.txt
@@ -1,0 +1,3 @@
+Packaging-only release for F-Droid: the release tag now carries the fastlane
+metadata (store description, changelog, screenshots) so the F-Droid listing is
+generated from this repository. No app behaviour changed since 1.0.0.


### PR DESCRIPTION
Packaging-only bump. The v1.0.0 tag predated the fastlane/ metadata, and F-Droid reads store metadata from the exact commit it builds — so the listing would have been empty at v1.0.0. Cutting v1.0.1 from main (which now contains fastlane/) gives F-Droid a tag it can read description, changelog, and screenshots from, so the fdroiddata recipe needs no inline Summary/Description.

No app behaviour changed since 1.0.0; only versionCode/versionName and a new changelogs/4.txt.


Claude-Session: https://claude.ai/code/session_01VCFvgPmMkJpg4QHCdbo9yM