### PR TITLE
Fix nav-bar clipping of bottom controls on Android 15+ (D-100)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,10 +19,12 @@ android {
         // the built commit (the 1.0.0 tag predated it); no app behaviour changed.
         // 1.0.2 (tag v1.0.2) was cut WITHOUT bumping these — the in-app version drifted behind the tag.
         // 1.0.3 (versionCode 5) realigns the version ahead of the latest tag and ships the D-098
-        // rule-editor Save/Cancel fix. RULE: build version must be ≥ the latest `v*` tag on main and
-        // versionCode strictly greater than every released code — see RUNBOOK "Cutting a release".
-        versionCode = 5
-        versionName = "1.0.3"
+        // rule-editor Save/Cancel fix. 1.0.4 (versionCode 6) ships the D-100 main-window nav-bar inset
+        // fix (DraftApplyBar Apply/Discard + Menu "Recheck Permissions" clipped under a button/3-key
+        // nav bar). RULE: build version must be ≥ the latest `v*` tag on main and versionCode strictly
+        // greater than every released code — see RUNBOOK "Cutting a release".
+        versionCode = 6
+        versionName = "1.0.4"
     }
 
     // Release signing is driven entirely by environment variables so that no

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/components/SettingsControls.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/components/SettingsControls.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -250,7 +252,20 @@ fun DraftApplyBar(
 ) {
     val toast = rememberToaster()
     Surface(tonalElevation = 3.dp) {
-        Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
+        // Edge-to-edge (targetSdk 35, enforced on Android 15+): this sticky bottomBar draws behind the
+        // system navigation bar, so pad its content up clear of it — otherwise Discard/Apply sit under
+        // the nav bar (worst with 3-button navigation, which is taller than the gesture pill). Unlike
+        // the per-rule editor Dialog (D-098, where the nav-bar inset is never delivered to the dialog
+        // window), this bar lives in the MainActivity window, so navigationBarsPadding() resolves
+        // correctly; it reads 0 on pre-15 non-edge-to-edge windows, so no double padding. imePadding()
+        // lifts the bar above the keyboard while a field is being edited.
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .imePadding()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+        ) {
             if (criticalError) {
                 Text(
                     "Fix the highlighted curve error before applying.",

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/MenuScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/MenuScreen.kt
@@ -3,6 +3,7 @@ package com.tideo.autobrightness.app.ui.screens
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -73,10 +74,17 @@ fun MenuContent(
     ) {
         AabMenuBanner()
         Column(
-            modifier = Modifier.padding(
-                horizontal = Dimens.screenPaddingHorizontal,
-                vertical = Dimens.screenPaddingVertical,
-            ),
+            // Edge-to-edge (targetSdk 35, enforced on Android 15+): this hub has no Scaffold to apply
+            // the system-bar inset, so its scrolling content drew under the nav bar — the last row,
+            // "Recheck Permissions", was buried (worst with 3-button navigation). navigationBarsPadding()
+            // sits inside the scroll, giving the final row clearance to scroll fully into view; it reads
+            // 0 on pre-15 non-edge-to-edge windows, so no extra gap there.
+            modifier = Modifier
+                .navigationBarsPadding()
+                .padding(
+                    horizontal = Dimens.screenPaddingHorizontal,
+                    vertical = Dimens.screenPaddingVertical,
+                ),
             verticalArrangement = Arrangement.spacedBy(Dimens.sectionSpacing),
         ) {
             // Live status — the former start destination, now reached from the hub.

--- a/docs/rebuild/DEVIATIONS_LEDGER.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER.md
@@ -1725,3 +1725,23 @@ the permanent registry — never compress or remove them.
   changelog filename is the **versionCode**; owner still owns tagging. No app behaviour change from the bump
   itself (it ships alongside the D-098 fix).
 
+- **D-100: main-window bottom controls clipped under the nav bar with button/3-key navigation (bug
+  fix; UI only).** Reported on a device using 3-button navigation (taller than the gesture pill): the
+  draft-settings screens' **Discard/Apply** bar and the Menu's final **"Recheck Permissions"** row sat
+  buried under the system navigation bar. Root cause: `targetSdk 35` → Android 15+ **enforces
+  edge-to-edge** (the legacy auto-inset opt-out is gone), so content draws behind the system bars.
+  Most screens are fine because their M3 `Scaffold` feeds the nav-bar inset into the content
+  `PaddingValues` (`SettingsScaffold`, no `bottomBar`) — but two spots didn't: (1) `DraftApplyBar` is a
+  custom `Surface` used as `DraftSettingsScaffold`'s `bottomBar`, and a `Scaffold` does **not** auto-pad
+  a custom bottom bar for the nav bar (M3 nav bars do it themselves; a plain `Surface` must); (2)
+  `MenuContent` is a scaffold-less scrolling `Column` with no inset padding at all. **Fix:** added
+  `navigationBarsPadding()` to both (DraftApplyBar's inner content `Column`, plus `imePadding()` so it
+  rides above the keyboard; MenuContent's inner padded `Column`, inside the scroll so the last row
+  scrolls fully into view). **Why this differs from D-098:** D-097/D-098 were a `Dialog` window, which
+  never delivers the *bottom* (nav-bar/ime) inset to its content — so there scrolling-with-clearance was
+  the only fix. These two live in the **MainActivity window**, where the bottom inset *is* delivered, so
+  `navigationBarsPadding()` resolves correctly; it reads 0 on pre-15 / non-edge-to-edge windows, so
+  there's no double padding. Inset behavior isn't exercisable under Robolectric (zero insets) → owner
+  device-verified; existing `SettingsScreensTest` (Apply/Discard) and `UiShellTest` (`performScrollTo`
+  the recheck row) are the render-regression guard. Ships as 1.0.4 / versionCode 6.
+

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -47,13 +47,21 @@ When in use, track stages here:
 > Write new deviations straight into the permanent registry `DEVIATIONS_LEDGER.md` (its
 > "Maintenance deviations" section), not here — this slot is only a transient staging note
 > during an in-flight change. Numbering is **one continuous sequence**: next free number is
-> **D-100** (historical high-water mark D-099); never restart at D-001. A deviation, once
+> **D-101** (historical high-water mark D-100); never restart at D-001. A deviation, once
 > numbered, lives in the registry forever — it is never compressed out.
 
 ## Changelog
 
 One line per shipped change (newest first). Keep terse.
 
+- 2026-06-25 — 1.0.4 / `versionCode 6`: (D-100) main-window bottom controls clipped under the nav bar
+  with button/3-key navigation — the draft-settings `DraftApplyBar` (Discard/Apply) and the Menu's
+  final "Recheck Permissions" row drew behind the system nav bar (targetSdk 35 enforces edge-to-edge on
+  Android 15+). Fix: `navigationBarsPadding()` (+`imePadding()` on the bar) on the two spots not covered
+  by an M3 `Scaffold`'s content insets. Unlike D-098's `Dialog` (no bottom inset delivered), these are
+  in the MainActivity window where the inset resolves correctly (0 on pre-15, so no double padding).
+  UI + version only; bottom-inset behavior is owner device-verified (not Robolectric-testable). Added
+  `changelogs/6.txt`. Next free deviation: **D-101**.
 - 2026-06-24 — 1.0.3 / `versionCode 5`: (D-098) rule-editor Save/Cancel STILL clipped after D-097 and a
   follow-up that drove the dialog `Window` edge-to-edge — this Compose `Dialog` never delivers a bottom
   (nav-bar/ime) inset to its content, only the top. Stopped fighting insets: dropped the sticky bottom bar,

--- a/fastlane/metadata/android/en-US/changelogs/6.txt
+++ b/fastlane/metadata/android/en-US/changelogs/6.txt
@@ -1,0 +1,4 @@
+Bug fix: settings screens' Discard / Apply buttons and the Menu's "Recheck
+Permissions" row are no longer clipped under the system navigation bar. The fix
+pads them clear of the bar, so they're fully visible with button (3-key)
+navigation as well as the gesture pill.


### PR DESCRIPTION
## Summary

Fixes clipping of bottom UI controls under the system navigation bar on Android 15+ with button/3-key navigation. The draft-settings `DraftApplyBar` (Discard/Apply buttons) and the Menu's "Recheck Permissions" row were drawn behind the nav bar because `targetSdk 35` enforces edge-to-edge rendering, but these two components weren't applying the system inset padding.

## Changes

- **`SettingsControls.kt` (`DraftApplyBar`)**: Added `navigationBarsPadding()` and `imePadding()` to the inner `Column`. The bar is a custom `Surface` used as a `bottomBar` in `DraftSettingsScaffold`, so it doesn't receive automatic nav-bar inset padding from the `Scaffold` (unlike M3 nav bars, which handle it themselves). `imePadding()` lifts the bar above the keyboard when editing.

- **`MenuScreen.kt` (`MenuContent`)**: Added `navigationBarsPadding()` to the inner padded `Column` (inside the scroll). The Menu is a scaffold-less scrolling column with no inset padding, so the last row couldn't scroll fully into view. Placing the padding inside the scroll ensures the final row clears the nav bar.

- **`app/build.gradle.kts`**: Bumped `versionCode` to 6 and `versionName` to "1.0.4".

- **`docs/rebuild/DEVIATIONS_LEDGER.md`**: Added D-100 entry documenting the root cause (edge-to-edge enforcement on Android 15+), the two affected spots, and why the fix differs from D-098 (Dialog vs. MainActivity window inset delivery).

- **`docs/rebuild/STATE.md`**: Updated next free deviation number to D-101 and added changelog entry.

- **`fastlane/metadata/android/en-US/changelogs/6.txt`**: Added user-facing changelog for the release.

## Implementation notes

- `navigationBarsPadding()` reads 0 on pre-15 or non-edge-to-edge windows, so there's no double padding on older devices.
- Unlike D-098 (Dialog, which never delivers bottom inset to content), these components live in the MainActivity window where the inset is correctly delivered.
- Inset behavior is not exercisable under Robolectric (zero insets) → owner device-verified. Existing `SettingsScreensTest` and `UiShellTest` provide render-regression coverage.

https://claude.ai/code/session_01DzgSei5h8V6uDkmBDeUq23