### PR TITLE
Fix CodeQL implicit-PendingIntent alert; harden notification/widget intents (1.1.1)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,11 +21,13 @@ android {
         // 1.0.3 (versionCode 5) realigns the version ahead of the latest tag and ships the D-098
         // rule-editor Save/Cancel fix. 1.0.4 (versionCode 6) ships the D-100 main-window nav-bar inset
         // fix (DraftApplyBar Apply/Discard + Menu "Recheck Permissions" clipped under a button/3-key
-        // nav bar). 1.1.0 (versionCode 7) bumps targetSdk to 36 (Android 16). RULE: build version must be
-        // ≥ the latest `v*` tag on main and versionCode strictly greater than every released code — see
-        // RUNBOOK "Cutting a release".
-        versionCode = 7
-        versionName = "1.1.0"
+        // nav bar). 1.1.0 (versionCode 7) bumps targetSdk to 36 (Android 16). 1.1.1 (versionCode 8) is a
+        // security-hardening patch: notification/widget PendingIntents are made un-missably explicit
+        // (D-107, CodeQL java/android/implicit-pendingintents). RULE: build version must be ≥ the latest
+        // `v*` tag on main and versionCode strictly greater than every released code — see RUNBOOK
+        // "Cutting a release".
+        versionCode = 8
+        versionName = "1.1.1"
         manifestPlaceholders["appLabel"] = "Tideo Auto Brightness"
     }
 

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
@@ -372,7 +372,14 @@ class AmbientMonitoringService : Service() {
     }
 
     private fun actionIntent(action: String): PendingIntent {
-        val intent = Intent(this, AmbientMonitoringService::class.java).setAction(action)
+        // Keep the wrapped Intent unambiguously EXPLICIT (CWE-927 / java/android/implicit-pendingintents):
+        // target our own service by component AND package, set on their own statements. The previous
+        // one-liner `Intent(this, X).setAction(action)` is explicit at runtime, but CodeQL's Kotlin
+        // dataflow does not carry the constructor component through the chained `.setAction()` and
+        // flagged it as an implicit PendingIntent. FLAG_IMMUTABLE already prevents tampering.
+        val intent = Intent(this, AmbientMonitoringService::class.java)
+        intent.setPackage(packageName)
+        intent.action = action
         return PendingIntent.getService(
             this,
             action.hashCode(),

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/widget/DashboardWidgetProvider.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/widget/DashboardWidgetProvider.kt
@@ -140,8 +140,11 @@ class DashboardWidgetProvider : AppWidgetProvider() {
         }
 
         private fun openAppIntent(context: Context): PendingIntent {
+            // Explicit target (component + package) on their own statements — see actionIntent in
+            // AmbientMonitoringService for why the chained form trips java/android/implicit-pendingintents.
             val intent = Intent(context, MainActivity::class.java)
-                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            intent.setPackage(context.packageName)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
             return PendingIntent.getActivity(
                 context, REQ_OPEN, intent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
@@ -149,7 +152,9 @@ class DashboardWidgetProvider : AppWidgetProvider() {
         }
 
         private fun broadcast(context: Context, action: String, requestCode: Int): PendingIntent {
-            val intent = Intent(context, DashboardWidgetProvider::class.java).setAction(action)
+            val intent = Intent(context, DashboardWidgetProvider::class.java)
+            intent.setPackage(context.packageName)
+            intent.action = action
             return PendingIntent.getBroadcast(
                 context, requestCode, intent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,

--- a/docs/rebuild/DEVIATIONS_LEDGER.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER.md
@@ -1819,3 +1819,20 @@ the permanent registry — never compress or remove them.
   test-round artifact: future debug/sideload builds always carry it. (The temporary `dist/` debug-APK
   drop used for the 1.1.0 on-device pass was removed before merge; this build-config preference stays.)
 
+
+- **D-107: notification/widget PendingIntents made un-missably explicit (security hardening;
+  CodeQL CWE-927).** CodeQL's first `main` scan after the 1.1.0 merge flagged
+  `java/android/implicit-pendingintents` (High) at `AmbientMonitoringService.actionIntent` (the
+  notification Pause/Resume/Reset/Disable actions) and the same chained pattern in
+  `DashboardWidgetProvider` (open-app + TOGGLE/RESET). The intents were already explicit at runtime
+  (`Intent(this, AmbientMonitoringService::class.java).setAction(action)`) and immutable
+  (`FLAG_IMMUTABLE`), so functionally safe — but CodeQL's Kotlin dataflow does **not** carry the
+  constructor component through the chained `.setAction()`/`.addFlags()` return value, so it saw the
+  wrapped Intent as implicit (the reported path: `new Intent(...)` → `setAction(...)` → "implicit not
+  null" → `getService(...)` → notification → `notify`). **Fix:** build each Intent on separate
+  statements and set the target explicitly — component (`Intent(ctx, Class)`) **and**
+  `setPackage(packageName)`, with `action`/`addFlags` assigned afterward — so the explicit target
+  survives dataflow and the PendingIntent can never resolve to another app. Behaviour is unchanged
+  (same component targeted, still `FLAG_IMMUTABLE`). Ships as 1.1.1 / versionCode 8. **Lesson:** for
+  CodeQL-Kotlin, prefer non-chained Intent construction + an explicit `setPackage` on PendingIntents;
+  the fluent one-liner reads as implicit even when it is not.

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -47,12 +47,20 @@ When in use, track stages here:
 > Write new deviations straight into the permanent registry `DEVIATIONS_LEDGER.md` (its
 > "Maintenance deviations" section), not here — this slot is only a transient staging note
 > during an in-flight change. Numbering is **one continuous sequence**: next free number is
-> **D-107** (historical high-water mark D-106); never restart at D-001. A deviation, once
+> **D-108** (historical high-water mark D-107); never restart at D-001. A deviation, once
 > numbered, lives in the registry forever — it is never compressed out.
 
 ## Changelog
 
 One line per shipped change (newest first). Keep terse.
+
+- 2026-06-28 — 1.1.1 / `versionCode 8`: (D-107) security hardening — notification (`actionIntent`)
+  and home-widget (`DashboardWidgetProvider`) PendingIntents made un-missably explicit (separate
+  statements + `setPackage`, still `FLAG_IMMUTABLE`) to clear CodeQL `java/android/implicit-pendingintents`
+  (High). The first post-1.1.0 CodeQL scan of `main` flagged the chained `Intent(this, X).setAction()`
+  one-liner as implicit (Kotlin dataflow drops the constructor component through `.setAction()`); intents
+  were already explicit + immutable at runtime, so no behaviour change. Added `changelogs/8.txt`. Owner
+  tags `v1.1.1`.
 
 - 2026-06-26 — 1.1.0 / `versionCode 7`: bumped **targetSdk 35 → 36** (Android 16), `compileSdk`
   36 in app + platform. Android 16 impact review found zero required platform code changes (edge-to-edge

--- a/fastlane/metadata/android/en-US/changelogs/8.txt
+++ b/fastlane/metadata/android/en-US/changelogs/8.txt
@@ -1,0 +1,3 @@
+Security hardening: the notification and home-screen-widget action buttons now
+use strictly explicit, immutable PendingIntents, so their intents can only ever
+target this app. No change to how the app looks or behaves.


### PR DESCRIPTION
## What

Clears the High-severity CodeQL alert **`java/android/implicit-pendingintents`** (CWE-927) raised on `main` after the 1.1.0 merge, and proactively hardens the same pattern in the widget.

- `AmbientMonitoringService.actionIntent` — notification Pause/Resume/Reset/Disable actions (the flagged site).
- `DashboardWidgetProvider` — open-app + TOGGLE/RESET widget actions (same chained pattern; fixed to prevent a sibling alert).

## Why

The intents were **already explicit and immutable at runtime** — `Intent(this, AmbientMonitoringService::class.java).setAction(action)` targets our own service, with `FLAG_IMMUTABLE`. But CodeQL's Kotlin dataflow does **not** carry the constructor's component through the chained `.setAction()` / `.addFlags()` return value, so it reads the wrapped Intent as implicit. The reported path was: `new Intent(...)` → `setAction(...)` → "implicit not null" → `getService(...)` → notification → `notify`.

So this is a true hardening even though the original was functionally safe: a notification/widget PendingIntent that could ever resolve outside the app is a real risk in a privileged app, and making the target un-missable is recommended practice.

## Fix

Build each Intent on **separate statements** with an explicit target — **component** (`Intent(ctx, Class)`) **and** `setPackage(packageName)` — then assign `action`/`addFlags`. The explicit target now survives dataflow; behaviour is unchanged (same component targeted, still `FLAG_IMMUTABLE`).

## Release

- Bumps **1.1.0 → 1.1.1** / `versionCode 8` (security patch, no behaviour change); adds `changelogs/8.txt`.
- Recorded as **D-107** in `DEVIATIONS_LEDGER.md` (with the CodeQL-Kotlin lesson) + `STATE.md` changelog line.

## Verification

Full acceptance ladder green (`:app:testDebugUnitTest`, `:app:lintDebug`, `:app:assembleDebug`). On-device behaviour is unchanged — the notification actions and widget buttons target the same components as before. CodeQL on this PR should now come back clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQfxQx55RUpE4DAUBDb6wi)_