### PR TITLE
1.2.0: runtime bug fixes, circadian staleness UX, Node-24 CI, design-coherence runbook

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,12 @@ name: Build
 # Secret-free validation: the full acceptance ladder (all module tests + lint + the debug APK) on every
 # pull request and on pushes to main. release-signing.yml handles the SIGNED release artifact on main;
 # this one needs no secrets, so it gates PRs from any branch.
+#
+# Node 24 runtime policy (all workflows): GitHub deprecated the Node 20 action runtime — runners default
+# to Node 24 from 2026-06-16 and remove Node 20 on 2026-09-16. Every action pinned here is a major that
+# declares `runs.using: node24` (checkout@v5, setup-java@v5, setup-android@v4, cache@v5, upload-artifact@v6;
+# codeql-action@v4, github-script@v8, action-gh-release@v3 in the sibling workflows). Do NOT downgrade any
+# of these to a Node 20 major — it reintroduces the deprecation warning and will hard-break after 2026-09-16.
 on:
   pull_request:
   push:
@@ -32,7 +38,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
         with:
           # Skip the default `tools platform-tools` install: the obsolete `tools` package drags in the
           # Android Emulator (a large, flaky download — it failed CI with "Error on ZipFile unknown
@@ -42,7 +48,7 @@ jobs:
           packages: ''
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -55,7 +61,7 @@ jobs:
         run: ./gradlew :domain:test :platform:test :app:testDebugUnitTest :app:lintDebug :app:assembleDebug --no-daemon
 
       - name: Upload debug APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: app-debug
           path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/clean-dist.yml
+++ b/.github/workflows/clean-dist.yml
@@ -1,0 +1,52 @@
+name: Clean dist on main
+
+# dist/ holds TEMPORARY debug sideload APKs (RUNBOOK §7) that are meant to be removed before/at merge.
+# If one is forgotten and lands on main, this auto-removes it so the binary never persists in history.
+#
+# How it behaves:
+#  - dist/ empty on main        → no-op.
+#  - dist/ has tracked files    → commit their removal and push back to main (`[skip ci]` so the
+#                                 removal commit does not re-trigger CI). This is the "auto-clean".
+#  - push rejected (main is a    → the job FAILS with a clear message, doubling as a guard so the
+#    protected branch / bot       leftover is surfaced immediately and can be removed by hand. To get
+#    can't push)                  true silent auto-clean, allow github-actions[bot] to bypass the
+#                                 pull-request requirement on main (Settings → Branches → bypass list).
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write  # needed to push the removal commit
+
+concurrency:
+  group: clean-dist-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  clean:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5  # node24 runtime (see build.yml node24 policy)
+        with:
+          fetch-depth: 0
+
+      - name: Remove leftover dist/ sideload artifacts
+        run: |
+          tracked="$(git ls-files dist/)"
+          if [ -z "$tracked" ]; then
+            echo "dist/ is clean on main — nothing to remove."
+            exit 0
+          fi
+          echo "Found committed dist/ sideload artifacts on main:"
+          echo "$tracked"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git rm -r --quiet dist
+          git commit -m "chore: auto-remove leftover dist/ sideload artifacts [skip ci]"
+          if git push; then
+            echo "Auto-removed dist/ from main."
+          else
+            echo "::error::dist/ sideload artifacts are on main but the auto-remove push was rejected (protected branch). Remove them manually: git rm -r dist && commit. Or allow github-actions[bot] to bypass the PR requirement on main for silent auto-clean."
+            exit 1
+          fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,12 +48,12 @@ jobs:
           java-version: '21'
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
         with:
           packages: ''
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -62,7 +62,7 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle-
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: java-kotlin
           build-mode: manual
@@ -75,6 +75,6 @@ jobs:
         run: ./gradlew :app:assembleDebug --no-daemon --no-build-cache --rerun-tasks
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:java-kotlin"

--- a/.github/workflows/redirect-external-prs.yml
+++ b/.github/workflows/redirect-external-prs.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment and label for triage
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/release-signing.yml
+++ b/.github/workflows/release-signing.yml
@@ -26,10 +26,10 @@ jobs:
           java-version: '21'
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -66,7 +66,7 @@ jobs:
             app/build/outputs/apk/release/app-release.apk
 
       - name: Upload signed APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: app-release
           path: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,10 @@ jobs:
           java-version: '21'
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -67,7 +67,7 @@ jobs:
             app/build/outputs/apk/release/app-release.apk
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           # tag_name / name default to the pushed tag (github.ref_name).
           files: app/build/outputs/apk/release/app-release.apk

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ captures/
 .cxx/
 *.hprof
 
+# Temporary debug sideload APKs (RUNBOOK §7) — never committed. Send the build to the owner via the
+# file tool, or grab the build.yml `app-debug` CI artifact. `clean-dist.yml` is a backstop for a forced add.
+/dist/
+
 # Tasker source project — kept out of the tree (1.6 MB); owner picks LFS-vs-ignore at PR review (S12.9a).
 # Reference recipes live in docs/rebuild/XML_RECIPES.md.
 docs/rebuild/extraction/_source/Advanced_Auto_Brightness_V3.3.prj_9.xml

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The grant is detected the next time the screen turns on or when the app is opene
 Tideo is local first and has no analytics, ads, or accounts. It makes **one** outbound network
 request, and only as a last resort:
 
-- **IP-geolocation fallback (optional, cleartext).** Circadian scaling needs an approximate location to compute local sunrise/sunset. Tideo tries, in order: a fixed latitude/longitude you pin → the device's
+- **IP-geolocation fallback (optional, requires opt-in, cleartext).** Circadian scaling needs an approximate location to compute local sunrise/sunset. Tideo tries, in order: a fixed latitude/longitude you pin → the device's
   last-known location → a fresh GPS/network fix. Only if *all* of those are unavailable does it fall
   back to a single `GET http://ip-api.com/json` to estimate your city
   from your public IP. This call is **cleartext HTTP** (ip-api.com's free tier has no HTTPS) and is

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,11 +23,15 @@ android {
         // fix (DraftApplyBar Apply/Discard + Menu "Recheck Permissions" clipped under a button/3-key
         // nav bar). 1.1.0 (versionCode 7) bumps targetSdk to 36 (Android 16). 1.1.1 (versionCode 8) is a
         // security-hardening patch: notification/widget PendingIntents are made un-missably explicit
-        // (D-107, CodeQL java/android/implicit-pendingintents). RULE: build version must be ≥ the latest
+        // (D-107, CodeQL java/android/implicit-pendingintents). 1.2.0 (versionCode 9) ships runtime
+        // bug fixes + UX: D-108 service-start battery-saver flash, D-109 PWM-sensitive read-out tracks
+        // perceived brightness, D-110 circadian stale-location fallback + staleness hints (new
+        // user-facing surface → minor bump), D-111 golden "resume context automation" banner; plus the
+        // GitHub Actions Node-24 migration (CI only). RULE: build version must be ≥ the latest
         // `v*` tag on main and versionCode strictly greater than every released code — see RUNBOOK
         // "Cutting a release".
-        versionCode = 8
-        versionName = "1.1.1"
+        versionCode = 9
+        versionName = "1.2.0"
         manifestPlaceholders["appLabel"] = "Tideo Auto Brightness"
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,11 +25,18 @@ android {
         // security-hardening patch: notification/widget PendingIntents are made un-missably explicit
         // (D-107, CodeQL java/android/implicit-pendingintents). 1.2.0 (versionCode 9) ships runtime
         // bug fixes + UX: D-108 service-start battery-saver flash, D-109 PWM-sensitive read-out tracks
-        // perceived brightness, D-110 circadian stale-location fallback + staleness hints (new
-        // user-facing surface → minor bump), D-111 golden "resume context automation" banner; plus the
-        // GitHub Actions Node-24 migration (CI only). RULE: build version must be ≥ the latest
-        // `v*` tag on main and versionCode strictly greater than every released code — see RUNBOOK
-        // "Cutting a release".
+        // perceived brightness, D-110 circadian stale-location fallback + staleness hints, D-111 golden
+        // "resume context automation" banner + Tasker-style sticky Load/Save/Contexts action bar;
+        // plus the GitHub Actions Node-24 migration (CI only).
+        //   SEMVER — why MINOR (1.1.1 → 1.2.0), not a patch (would have been 1.1.2): the three core
+        //   defect fixes (D-108/109/110a) are patch-grade on their own, BUT the same release ADDS new
+        //   user-facing surfaces — the circadian staleness hints on the Circadian screen + dashboard
+        //   (D-110) and the redesigned Profiles & Contexts screen (sticky action bar + load/save/contexts
+        //   modals, D-111). RUNBOOK §6: a new user-facing feature/surface is a MINOR, and when a release
+        //   spans categories you pick the HIGHEST that applies — so new-surface (minor) wins over
+        //   bug-fix (patch). No settings-schema break (round-trips), so it is not a major. RULE: build
+        //   version must be ≥ the latest `v*` tag on main and versionCode strictly greater than every
+        //   released code — see RUNBOOK "Cutting a release".
         versionCode = 9
         versionName = "1.2.0"
         manifestPlaceholders["appLabel"] = "Tideo Auto Brightness"

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/AppModule.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/AppModule.kt
@@ -129,6 +129,11 @@ class AppModule(context: Context) {
         )
         // Wire the late-bound hook now that the controller exists (replaces the lateinit cycle).
         controllerHook.hook = controller
+        // D-110: when the circadian location resolves late (cache seed / async geo-IP or GPS fix),
+        // recompute brightness so the modifier updates even in steady light (where prof760 drops cycles
+        // and the initial brightness was set with the default windows). Wired post-construction because
+        // the provider feeds `current` into the controller above.
+        circadianWindows.onWindowsRefreshed = { controller.reapply() }
 
         // prof769/task528 panic: upside-down + shake (display on) → SOS + restore + full stop (F77).
         val panicSensor = AndroidPanicSensorSource(appContext)

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/CircadianWindowProvider.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/CircadianWindowProvider.kt
@@ -35,6 +35,29 @@ data class CircadianWindows(
 )
 
 /**
+ * D-110: freshness of the location backing the live circadian modifier, for the UI staleness hint.
+ *
+ * @param latitude/longitude the active location (null = none resolved yet → modifier uses defaults).
+ * @param resolvedForDay epoch-day the active location was acquired for (null when none).
+ * @param today epoch-day "now".
+ * @param fixed true when a manual fixed lat/lon override is pinned (never "stale").
+ */
+data class CircadianLocationStatus(
+    val latitude: Double? = null,
+    val longitude: Double? = null,
+    val resolvedForDay: Long? = null,
+    val today: Long = 0L,
+    val fixed: Boolean = false,
+) {
+    /** A location (fresh or cached) is available — the modifier tracks the real sun, not the defaults. */
+    val hasLocation: Boolean get() = latitude != null && longitude != null
+    /** Whole days between the active location's acquisition day and today (0 = acquired today). */
+    val ageDays: Long? get() = resolvedForDay?.let { (today - it).coerceAtLeast(0L) }
+    /** The cached location is from a previous day and isn't a pinned fixed location → show "stale". */
+    val isStale: Boolean get() = !fixed && hasLocation && (ageDays ?: 0L) > 0L
+}
+
+/**
  * Supplies live [CircadianWindows] to the pipeline (G2R-F73). Before this, the pipeline fed
  * `TimeContext`'s **defaults** (a fixed 6–8am / 18–20pm UTC morning/evening) whenever no location was
  * known — and `lastKnownLocation()` is frequently null on a device that has not actively used GPS, so
@@ -85,6 +108,32 @@ class CircadianWindowProvider(
     @Volatile private var resolvedDay: Long = Long.MIN_VALUE
     private val acquiring = AtomicBoolean(false)
 
+    // D-110: fired when a location resolves AFTER construction (cache seed or a fresh acquire) so the
+    // pipeline recomputes immediately. Without this, a cold start in STABLE light set the initial
+    // brightness with the TimeContext defaults (scaleDynamic ≈ 0.85) BEFORE the async cache/geo-IP fix
+    // landed, and prof760 then dropped every steady-light cycle — so the circadian modifier stayed stuck
+    // at the default all morning while the chart (which reads last-known/representative location directly)
+    // looked correct. AppModule wires this to controller.reapply().
+    //
+    // Settable because the controller is built after this provider (the provider feeds it `current`), so
+    // the wiring is post-construction. The cache-seed launch is async and may resolve BEFORE the callback
+    // is wired; the setter therefore fires once immediately when a location already resolved, so the
+    // recompute is never lost to construction-vs-wiring ordering (either path triggers exactly one
+    // reapply).
+    @Volatile private var _onWindowsRefreshed: () -> Unit = {}
+    var onWindowsRefreshed: () -> Unit
+        get() = _onWindowsRefreshed
+        set(value) {
+            _onWindowsRefreshed = value
+            if (resolvedLoc != null) value()
+        }
+
+    /** D-110: the location backing the live circadian modifier + its freshness, for the UI staleness
+     *  hint. `resolvedForDay` is the epoch-day the active location was acquired for (null = no fix yet);
+     *  compare to today to show "cached N days ago". Updated on every [current] call. */
+    @Volatile var status: CircadianLocationStatus = CircadianLocationStatus()
+        private set
+
     init {
         // F39 override drives the windows; invalidate the cache (and force a re-acquire) when it changes.
         scope.launch {
@@ -104,6 +153,9 @@ class CircadianWindowProvider(
                 resolvedLoc = LocationSnapshot(cached.latitude, cached.longitude)
                 resolvedDay = cached.day
                 cacheKey = null
+                // D-110: recompute now that a (possibly day-old) cached location is available — the
+                // initial brightness may already have been set with the default windows in stable light.
+                onWindowsRefreshed()
             }
         }
     }
@@ -118,13 +170,25 @@ class CircadianWindowProvider(
         val tz = tzOffsetForDate(dateEpochSec)
         val day = dateEpochSec / 86_400L
 
+        val todayDay = nowSec / 86_400L
         val loc: LocationSnapshot = if (ov.latitude != null && ov.longitude != null) {
             // F83: fixed lat/lon → use it directly, skip all acquisition.
+            status = CircadianLocationStatus(ov.latitude, ov.longitude, resolvedForDay = day, today = todayDay, fixed = true)
             LocationSnapshot(ov.latitude!!, ov.longitude!!)
         } else {
             // F83: acquire (once a day, async) when we have no fix or the day rolled over.
             if (resolvedLoc == null || resolvedDay != day) triggerAcquire(day)
-            resolvedLoc ?: return null
+            // D-110: fall back to the last resolved location even when the day has rolled over and no
+            // fresh fix is available (location + geo-IP off) — recompute TODAY's windows with the cached
+            // coordinates instead of returning null → the default-window 0.85. status records the age so
+            // the UI can show "cached N days ago" until the user refreshes the fix.
+            val cachedLoc = resolvedLoc
+            if (cachedLoc == null) {
+                status = CircadianLocationStatus(today = todayDay)
+                return null
+            }
+            status = CircadianLocationStatus(cachedLoc.latitude, cachedLoc.longitude, resolvedForDay = resolvedDay, today = todayDay, fixed = false)
+            cachedLoc
         }
 
         val key = "$day|${round4(loc.latitude)}|${round4(loc.longitude)}|$transitionFactor|$tz"
@@ -149,6 +213,9 @@ class CircadianWindowProvider(
                     cacheKey = null // recompute windows with the freshly acquired location
                     // D-103: persist so the next cold start reuses it before re-acquiring.
                     runCatching { persistLocation(snap.latitude, snap.longitude, day) }
+                    // D-110: a fresh fix landed asynchronously — recompute so the modifier updates even
+                    // if the light is steady (no sensor cycle would otherwise call current() again).
+                    onWindowsRefreshed()
                 }
             } finally {
                 acquiring.set(false)

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/ContextEngine.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/ContextEngine.kt
@@ -316,7 +316,11 @@ class ContextEngine(
             }
             ContextCaller.LOCATION -> tokens.usesLocation
             ContextCaller.BATTERY ->
-                tokens.usesBattery && (signals.plugged != (lastPlug == 1) || abs(signals.batteryPercent - lastBatt) >= BATTERY_DELTA_THRESHOLD)
+                // lastBatt < 0 = first real reading after the unknown seed (D-108): always evaluate it
+                // (a low real battery, e.g. 2%, is within BATTERY_DELTA_THRESHOLD of the -1 sentinel and
+                // would otherwise be vetoed, suppressing a legitimate saver match at start-up).
+                tokens.usesBattery && (lastBatt < 0 || signals.plugged != (lastPlug == 1) ||
+                    abs(signals.batteryPercent - lastBatt) >= BATTERY_DELTA_THRESHOLD)
             ContextCaller.WIFI -> tokens.usesWifi && signals.wifi != lastWifi
             ContextCaller.TIME, ContextCaller.GENERAL, ContextCaller.RESUME -> true
         }
@@ -435,7 +439,12 @@ enum class ContextCaller(val cooldownMs: Long) {
  */
 data class SignalSnapshot(
     val app: String = "",
-    val batteryPercent: Int = 0,
+    // -1 = no battery reading yet (D-108). The seed GENERAL evaluation at start() runs before the
+    // battery callbackFlow delivers its first (sticky) value; a 0 placeholder would satisfy a
+    // "battery <= max" saver rule and flash the Battery Saver profile for one cycle before the real
+    // reading (e.g. 80%) reverts it. ContextOverrideResolver treats a negative percent as "unknown →
+    // battery rules don't match", so the seed eval picks the correct (time-based) profile directly.
+    val batteryPercent: Int = -1,
     val plugged: Boolean = false,
     val wifi: String = "",
     val lat: Double = 0.0,

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/PipelineCycleRunner.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/PipelineCycleRunner.kt
@@ -91,7 +91,12 @@ internal class PipelineCycleRunner(
             val output = engine.evaluate(buildInput(rawLux, settings, s))
             val from = brightness.read()
             // task661 act22-26 / task698 step 3: hold the hardware floor in PWM-sensitive mode (D-050).
+            // `target` is the HARDWARE write (floored up to the PWM threshold); `perceived` is the engine's
+            // un-floored brightness — what the user actually sees once the secure/overlay layer darkens
+            // below the floor. The read-out tracks `perceived` (D-109): with PWM-sensitive on, the hero
+            // brightness number must follow the calculated brightness as in Tasker, not stick at the floor.
             val target = applyPwmFloor(output.targetBrightness, settings)
+            val perceived = output.targetBrightness
 
             // %AAB_Debug 3/4: Flash the light-evaluation + dynamic-scale figures (D-023, G2-F15).
             debug.emit(DebugCategory.LIGHT_EVAL, settings.debugLevel) {
@@ -111,7 +116,9 @@ internal class PipelineCycleRunner(
                 // so the Dashboard instrument stayed frozen during the transition and then snapped. With
                 // the target out early the instrument's animateIntAsState rolls toward it DURING the
                 // sweep; the final update below lands lastAppliedBrightness on it (no jump).
-                ctx.update { it.copy(targetBrightness = target) }
+                // Publish the PERCEIVED destination (D-109) so the instrument rolls toward the calculated
+                // brightness, not the PWM hardware floor.
+                ctx.update { it.copy(targetBrightness = perceived) }
                 // %AAB_Debug 1 "Skip Animations": jump straight to the target (Tasker debug mode).
                 if (settings.debugLevel == DebugCategory.SKIP_ANIMATIONS.level) {
                     brightness.write(target)
@@ -170,8 +177,11 @@ internal class PipelineCycleRunner(
                     scaleDynamic = output.scaleDynamic,
                     scaleDynamicCompress = output.scaleDynamicCompress,
                     scalingUse = settings.scalingEnabled,
+                    // lastAppliedBrightness = the actual HARDWARE value (floored) — override-detection
+                    // baseline + Live Debug "current"; targetBrightness = the PERCEIVED engine value the
+                    // read-out follows (D-109). They coincide unless PWM-sensitive floors the hardware.
                     lastAppliedBrightness = target,
-                    targetBrightness = target,
+                    targetBrightness = perceived,
                     dimmingCurrent = dimCurrent,
                     dimmingDS = dimDS,
                     // Live Debug "Performance & Timings" parity (G2R-F29).
@@ -331,6 +341,7 @@ internal class PipelineCycleRunner(
             // previous = null → engine's first-run path maps the reading straight to a target.
             val output = engine.evaluate(buildInput(lux, settings, PipelineState()))
             val target = applyPwmFloor(output.targetBrightness, settings)
+            val perceived = output.targetBrightness
             brightness.forceManualMode()
             brightness.write(target)
             // F65: dimming decides off the un-floored engine target, not the PWM-floored write (above).
@@ -341,8 +352,8 @@ internal class PipelineCycleRunner(
             ctx.armInitialSettle(clock() + INITIAL_SETTLE_MS)
             ctx.update {
                 it.copy(
-                    lastAppliedBrightness = target,
-                    targetBrightness = target,
+                    lastAppliedBrightness = target,    // actual hardware write (floored)
+                    targetBrightness = perceived,      // perceived read-out (D-109)
                     lastAcceptedMs = clock(),
                 )
             }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/PipelineState.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/PipelineState.kt
@@ -68,9 +68,13 @@ data class PipelineState(
     /** %AAB_DimmingDS — absolute reduce_bright_colors level now (dim_shell, task650 act28); 0 when not
      *  engaged. The "abs" half of the Super Dimming live readout (G2R-F58). */
     val dimmingDS: Double = 0.0,
-    /** Last brightness this pipeline applied (domain 0–255); null before the first write. */
+    /** Last brightness this pipeline wrote to HARDWARE (domain 0–255); null before the first write. In
+     *  PWM-sensitive mode this is the floored value (held at %AAB_DimmingThreshold) — the override-detection
+     *  baseline and the Live Debug "current brightness". Distinct from [targetBrightness] (D-109). */
     val lastAppliedBrightness: Int? = null,
-    /** Last target the engine produced (for the notification "target" readout). */
+    /** Last PERCEIVED brightness the engine produced (un-floored calculated brightness) — the value the
+     *  hero read-out / notification / widget track. Equals [lastAppliedBrightness] unless PWM-sensitive
+     *  floors the hardware above it; then the secure/overlay layer darkens the panel down to this (D-109). */
     val targetBrightness: Int? = null,
     /** Recorded manual-override points (newest first), %AAB_Overrides (cap 50). */
     val overrideHistory: List<Pair<Double, Double>> = emptyList(),

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ExperimentPrefsStore.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ExperimentPrefsStore.kt
@@ -71,12 +71,15 @@ class ExperimentPrefsStore(private val dataStore: DataStore<Preferences>) {
      * to the fixed `TimeContext` defaults until the async re-acquire lands. Mirrors Tasker's persisted
      * `%AAB_SunLat`/`%AAB_SunLon` + `%AAB_SunLastDate`. [day] is epoch-days the fix was acquired for.
      */
-    suspend fun readCachedSunLocation(): CachedSunLocation? {
-        val prefs = dataStore.data.first()
-        val lat = prefs[SUN_LAT] ?: return null
-        val lon = prefs[SUN_LON] ?: return null
-        val day = prefs[SUN_DAY] ?: return null
-        return CachedSunLocation(lat, lon, day)
+    suspend fun readCachedSunLocation(): CachedSunLocation? = cachedSunLocation.first()
+
+    /** D-110: the persisted once-a-day location as a reactive flow, so the UI staleness hint (Circadian
+     *  screen + dashboard) updates when a fresh fix is acquired. null when no fix has ever been cached. */
+    val cachedSunLocation: Flow<CachedSunLocation?> = dataStore.data.map { prefs ->
+        val lat = prefs[SUN_LAT]
+        val lon = prefs[SUN_LON]
+        val day = prefs[SUN_DAY]
+        if (lat != null && lon != null && day != null) CachedSunLocation(lat, lon, day) else null
     }
 
     /** Persist the daily-resolved location (D-103). */

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/state/CircadianExtrasViewModel.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/state/CircadianExtrasViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.tideo.autobrightness.app.runtime.AutoBrightnessRuntime
+import com.tideo.autobrightness.app.runtime.CircadianLocationStatus
 import com.tideo.autobrightness.app.settings.ExperimentDateLocation
 import com.tideo.autobrightness.app.settings.ExperimentPrefsStore
 import com.tideo.autobrightness.app.storage.experimentPrefsDataStore
@@ -12,6 +13,7 @@ import com.tideo.autobrightness.platform.context.AndroidLocationReader
 import com.tideo.autobrightness.platform.context.LocationResult
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -35,6 +37,25 @@ class CircadianExtrasViewModel(application: Application) : AndroidViewModel(appl
     /** G3-F12 / D-105: whether the ip-api.com geo-IP fallback may run (privacy opt-IN, default off). */
     val geoIpEnabled: StateFlow<Boolean> = store.geoIpEnabled
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    /**
+     * D-110: freshness of the location backing the live circadian modifier, for the staleness hint. A
+     * pinned fixed location is never stale; a cached fix from a previous day is stale (with its age in
+     * days); no cached fix at all → the modifier is on the default windows (≈0.85) until a fix lands.
+     * Mirrors [com.tideo.autobrightness.app.runtime.CircadianWindowProvider.current]'s fallback chain so
+     * the UI hint matches what the pipeline actually uses.
+     */
+    val circadianLocationStatus: StateFlow<CircadianLocationStatus> =
+        store.dateLocation.combine(store.cachedSunLocation) { ov, cache ->
+            val today = System.currentTimeMillis() / 1000L / 86_400L
+            when {
+                ov.latitude != null && ov.longitude != null ->
+                    CircadianLocationStatus(ov.latitude, ov.longitude, resolvedForDay = today, today = today, fixed = true)
+                cache != null ->
+                    CircadianLocationStatus(cache.latitude, cache.longitude, resolvedForDay = cache.day, today = today, fixed = false)
+                else -> CircadianLocationStatus(today = today)
+            }
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), CircadianLocationStatus())
 
     fun setGeoIpEnabled(enabled: Boolean) {
         viewModelScope.launch { store.setGeoIpEnabled(enabled) }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/state/DashboardState.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/state/DashboardState.kt
@@ -1,5 +1,6 @@
 package com.tideo.autobrightness.app.state
 
+import com.tideo.autobrightness.app.runtime.CircadianLocationStatus
 import com.tideo.autobrightness.platform.privilege.Tier
 
 /**
@@ -35,6 +36,10 @@ data class DashboardUiState(
      *  Drives the amber "live data may be stale" banner, shown only while [serviceRunning] (S12.9d). */
     val stale: Boolean = false,
     val health: ServiceHealthUiState = ServiceHealthUiState(),
+    /** D-110: freshness of the location backing the live circadian modifier; null when dynamic scaling
+     *  is off (no hint). When [CircadianLocationStatus.isStale] or no location, the dashboard shows a
+     *  hint to turn Location on briefly so the modifier stops running on a stale/default sun position. */
+    val circadianLocation: CircadianLocationStatus? = null,
 )
 
 data class ServiceHealthUiState(

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/state/DashboardViewModel.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/state/DashboardViewModel.kt
@@ -14,9 +14,12 @@ import com.tideo.autobrightness.app.runtime.AutoBrightnessRuntime
 import com.tideo.autobrightness.app.runtime.BrightnessTileService
 import com.tideo.autobrightness.app.runtime.LiveRuntimeState
 import com.tideo.autobrightness.app.widget.DashboardWidgetProvider
+import com.tideo.autobrightness.app.runtime.CircadianLocationStatus
 import com.tideo.autobrightness.app.runtime.ServiceHealthStore
 import com.tideo.autobrightness.app.runtime.Staleness
+import com.tideo.autobrightness.app.settings.ExperimentPrefsStore
 import com.tideo.autobrightness.app.settings.validate
+import com.tideo.autobrightness.app.storage.experimentPrefsDataStore
 import com.tideo.autobrightness.app.storage.serviceHealthDataStore
 import com.tideo.autobrightness.app.storage.settingsDataStore
 import com.tideo.autobrightness.platform.privilege.PrivilegeManager
@@ -42,6 +45,26 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
     private val serviceEnabledFlow = app.settingsDataStore.data
         .map { it.validate().serviceEnabled }
         .distinctUntilChanged()
+
+    // D-110: circadian location freshness for the dashboard hint. Surfaced only when dynamic scaling is
+    // on (otherwise the location is irrelevant). Mirrors CircadianWindowProvider.current()'s fallback so
+    // the dashboard agrees with the live modifier; null = scaling off → no hint.
+    private val experimentPrefs = ExperimentPrefsStore(application.experimentPrefsDataStore)
+    private val circadianStatusFlow = combine(
+        app.settingsDataStore.data.map { it.validate().scalingEnabled }.distinctUntilChanged(),
+        experimentPrefs.dateLocation,
+        experimentPrefs.cachedSunLocation,
+    ) { scalingOn, ov, cache ->
+        if (!scalingOn) return@combine null
+        val today = System.currentTimeMillis() / 1000L / 86_400L
+        when {
+            ov.latitude != null && ov.longitude != null ->
+                CircadianLocationStatus(ov.latitude, ov.longitude, resolvedForDay = today, today = today, fixed = true)
+            cache != null ->
+                CircadianLocationStatus(cache.latitude, cache.longitude, resolvedForDay = cache.day, today = today, fixed = false)
+            else -> CircadianLocationStatus(today = today)
+        }
+    }
 
     private data class Live(
         val running: Boolean,
@@ -88,7 +111,8 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
         liveFlow,
         privilegeManager.tierFlow(),
         healthFlow,
-    ) { enabled, live, tier, health ->
+        circadianStatusFlow,
+    ) { enabled, live, tier, health, circadian ->
         DashboardUiState(
             serviceEnabled = enabled,
             tier = tier,
@@ -107,6 +131,7 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
             lastSampleMs = live.lastSampleMs,
             stale = live.stale,
             health = health,
+            circadianLocation = circadian,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), DashboardUiState())
 

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/components/GraphScaffold.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/components/GraphScaffold.kt
@@ -10,6 +10,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Surface
@@ -60,7 +65,7 @@ fun ChartPager(slots: List<ChartSlot>, modifier: Modifier = Modifier) {
             verticalAlignment = Alignment.CenterVertically,
         ) {
             if (multi) {
-                PagerArrow("‹", "chart_pager_prev") {
+                PagerArrow(Icons.AutoMirrored.Filled.KeyboardArrowLeft, "Previous chart", "chart_pager_prev") {
                     val target = (pagerState.currentPage - 1 + slots.size) % slots.size
                     scope.launch { pagerState.animateScrollToPage(target) }
                 }
@@ -73,7 +78,7 @@ fun ChartPager(slots: List<ChartSlot>, modifier: Modifier = Modifier) {
                 textAlign = TextAlign.Center,
             )
             if (multi) {
-                PagerArrow("›", "chart_pager_next") {
+                PagerArrow(Icons.AutoMirrored.Filled.KeyboardArrowRight, "Next chart", "chart_pager_next") {
                     val target = (pagerState.currentPage + 1) % slots.size
                     scope.launch { pagerState.animateScrollToPage(target) }
                 }
@@ -107,19 +112,13 @@ fun ChartPager(slots: List<ChartSlot>, modifier: Modifier = Modifier) {
     }
 }
 
-/** A tappable ‹ / › page-step affordance for the [ChartPager] (swipe is consumed by the chart scrub). */
+/** A tappable page-step affordance for the [ChartPager] (swipe is consumed by the chart scrub).
+ *  Uses a real Material chevron icon rather than a ‹ / › text glyph (UI-consistency: icons, not glyphs). */
 @Composable
-private fun PagerArrow(glyph: String, testTag: String, onClick: () -> Unit) {
-    Text(
-        glyph,
-        style = MaterialTheme.typography.titleLarge,
-        color = MaterialTheme.colorScheme.primary,
-        modifier = Modifier
-            .clip(CircleShape)
-            .clickable(onClick = onClick)
-            .padding(horizontal = 12.dp, vertical = 2.dp)
-            .testTag(testTag),
-    )
+private fun PagerArrow(icon: androidx.compose.ui.graphics.vector.ImageVector, contentDescription: String, testTag: String, onClick: () -> Unit) {
+    IconButton(onClick = onClick, modifier = Modifier.testTag(testTag)) {
+        Icon(icon, contentDescription = contentDescription, tint = MaterialTheme.colorScheme.primary)
+    }
 }
 
 /**

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/components/SettingsControls.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/components/SettingsControls.kt
@@ -9,10 +9,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -321,8 +324,8 @@ fun DraftSettingsScaffold(
             TopAppBar(
                 title = { Text(title) },
                 navigationIcon = {
-                    TextButton(onClick = attemptBack, modifier = Modifier.testTag("back_button")) {
-                        Text("‹ Back")
+                    IconButton(onClick = attemptBack, modifier = Modifier.testTag("back_button")) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 },
                 actions = {

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/components/SettingsScaffold.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/components/SettingsScaffold.kt
@@ -7,10 +7,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.testTag
@@ -34,8 +37,8 @@ fun SettingsScaffold(
             TopAppBar(
                 title = { Text(title) },
                 navigationIcon = {
-                    TextButton(onClick = onBack, modifier = Modifier.testTag("back_button")) {
-                        Text("‹ Back")
+                    IconButton(onClick = onBack, modifier = Modifier.testTag("back_button")) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 },
             )

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/CircadianScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/CircadianScreen.kt
@@ -5,7 +5,10 @@ import com.tideo.autobrightness.R
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -76,6 +79,7 @@ fun CircadianScreen(
     // F39: the Circadian fixed date/location override + its live-data defaults (today + location).
     val dateLocation by extras.dateLocation.collectAsStateWithLifecycle()
     val geoIpEnabled by extras.geoIpEnabled.collectAsStateWithLifecycle() // G3-F12 / D-105 privacy opt-in
+    val locationStatus by extras.circadianLocationStatus.collectAsStateWithLifecycle() // D-110 staleness hint
     var defaultLatLon by remember { mutableStateOf<Pair<Double, Double>?>(null) }
     androidx.compose.runtime.LaunchedEffect(Unit) {
         defaultLatLon = runCatching { extras.defaultLatLon() }.getOrNull()
@@ -87,6 +91,7 @@ fun CircadianScreen(
         onBack = { navController.popBackStack() },
         criticalError = criticalError,
         live = live,
+        locationStatus = locationStatus,
         dateLocation = dateLocation,
         todayDate = extras.today(),
         defaultLatLon = defaultLatLon,
@@ -129,6 +134,8 @@ fun CircadianContent(
     criticalError: Boolean = false,
     onReset: (() -> Unit)? = null,
     live: PipelineState = PipelineState(),
+    locationStatus: com.tideo.autobrightness.app.runtime.CircadianLocationStatus =
+        com.tideo.autobrightness.app.runtime.CircadianLocationStatus(),
     dateLocation: ExperimentDateLocation = ExperimentDateLocation(),
     todayDate: String = "",
     defaultLatLon: Pair<Double, Double>? = null,
@@ -177,6 +184,13 @@ fun CircadianContent(
                     },
                 ),
             )
+
+            // D-110: when dynamic scaling is on but the live location is stale or missing, the modifier
+            // is running on a day-old cached sun position (or the default windows) — surface that, with
+            // the cache age, and point the user at turning Location on briefly (or the IP fallback below).
+            if (draft.scalingEnabled && (locationStatus.isStale || !locationStatus.hasLocation)) {
+                CircadianStaleBanner(locationStatus)
+            }
 
             // Live glass-box readout: uncompressed vs true (taper-compressed) circadian scale (G2R-F8).
             CircadianDiagnosticCard(
@@ -369,6 +383,33 @@ fun CircadianDateLocationCard(
             dismissButton = { TextButton(onClick = { showDatePicker = false }) { Text("Cancel") } },
         ) { DatePicker(state = state) }
     }
+    }
+}
+
+/**
+ * D-110: amber hint shown on the Circadian screen when dynamic scaling is active but the location
+ * backing the live modifier is stale (a cached fix from a previous day) or missing (default sun times).
+ *
+ * Coherent with the M3 audit (design/m3_audit.md §3 row 2): colour-semantic banners (stale/override) are
+ * intentionally tinted `Card`s — NOT `AabCard` section containers — using the gold `secondary`-family
+ * accent reserved for warnings/emphasis. Same `AabGold`/`AabOnGold` convention as the dashboard
+ * `StaleBanner`/`CircadianStaleHint`, so the two staleness surfaces read identically.
+ */
+@Composable
+private fun CircadianStaleBanner(status: com.tideo.autobrightness.app.runtime.CircadianLocationStatus) {
+    val text = if (status.isStale) {
+        stringResource(R.string.circadian_stale_banner, status.ageDays ?: 0L)
+    } else {
+        stringResource(R.string.circadian_no_location_banner)
+    }
+    Card(
+        modifier = Modifier.fillMaxWidth().testTag("circadian_stale_banner"),
+        colors = CardDefaults.cardColors(
+            containerColor = com.tideo.autobrightness.app.ui.theme.AabGold,
+            contentColor = com.tideo.autobrightness.app.ui.theme.AabOnGold,
+        ),
+    ) {
+        Text(text, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.padding(12.dp))
     }
 }
 

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ContextsScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ContextsScreen.kt
@@ -401,13 +401,18 @@ private fun RuleEditor(
             Text("Switch to profile:", style = MaterialTheme.typography.labelMedium)
             // D-114b: emphasise the selected profile — gold + titleSmall (matching the rule card's
             // "Loads <profile>") with a dropdown caret, so the chosen target stands out in the editor.
-            OutlinedButton(onClick = { profileMenu = true }, modifier = Modifier.testTag("rule_profile")) {
-                Text(profile, style = MaterialTheme.typography.titleSmall, color = AabGold)
-                Icon(Icons.Filled.ArrowDropDown, contentDescription = null)
-            }
-            DropdownMenu(expanded = profileMenu, onDismissRequest = { profileMenu = false }) {
-                profileNames.forEach { p ->
-                    DropdownMenuItem(text = { Text(p) }, onClick = { profile = p; profileMenu = false })
+            // The DropdownMenu MUST be wrapped in a Box with its anchor button (like ProfileCard's
+            // overflow): a bare DropdownMenu sibling in the scrolling Column has no anchor and floats
+            // down over the Triggers ("disconnected" menu, owner screenshot).
+            Box {
+                OutlinedButton(onClick = { profileMenu = true }, modifier = Modifier.testTag("rule_profile")) {
+                    Text(profile, style = MaterialTheme.typography.titleSmall, color = AabGold)
+                    Icon(Icons.Filled.ArrowDropDown, contentDescription = null)
+                }
+                DropdownMenu(expanded = profileMenu, onDismissRequest = { profileMenu = false }) {
+                    profileNames.forEach { p ->
+                        DropdownMenuItem(text = { Text(p) }, onClick = { profile = p; profileMenu = false })
+                    }
                 }
             }
 

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ContextsScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ContextsScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -34,6 +36,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -291,9 +294,11 @@ private fun RuleEditor(
 ) {
     var name by remember { mutableStateOf(rule.name) }
     var profile by remember { mutableStateOf(rule.profile) }
-    // D-113: priority is a 1–100 scale (higher wins), not 0..∞. Seed from the rule, coercing a legacy/
-    // unset 0 up to 1 so the field always shows a valid value; clamped again on save.
-    var priorityText by remember { mutableStateOf(rule.priority.coerceIn(1, 100).toString()) }
+    // D-113: priority is a 1–100 scale (higher wins), not 0..∞. Seed with the rule's REAL stored value
+    // (a legacy/unset 0 shows as 1) so a pre-existing out-of-range value — e.g. an old 150 — is shown
+    // truthfully rather than silently pre-capped; it is clamped to 1..100 only when the user saves.
+    var priorityText by remember { mutableStateOf(rule.priority.takeIf { it >= 1 }?.toString() ?: "1") }
+    val priorityOverMax = (priorityText.trim().toIntOrNull() ?: 0) > 100
     var wifi by remember { mutableStateOf(rule.triggers.wifi?.joinToString(", ") ?: "") }
     var startTime by remember { mutableStateOf(rule.triggers.timeRange?.getOrNull(0) ?: "") }
     var endTime by remember { mutableStateOf(rule.triggers.timeRange?.getOrNull(1) ?: "") }
@@ -394,7 +399,12 @@ private fun RuleEditor(
             )
 
             Text("Switch to profile:", style = MaterialTheme.typography.labelMedium)
-            OutlinedButton(onClick = { profileMenu = true }, modifier = Modifier.testTag("rule_profile")) { Text(profile) }
+            // D-114b: emphasise the selected profile — gold + titleSmall (matching the rule card's
+            // "Loads <profile>") with a dropdown caret, so the chosen target stands out in the editor.
+            OutlinedButton(onClick = { profileMenu = true }, modifier = Modifier.testTag("rule_profile")) {
+                Text(profile, style = MaterialTheme.typography.titleSmall, color = AabGold)
+                Icon(Icons.Filled.ArrowDropDown, contentDescription = null)
+            }
             DropdownMenu(expanded = profileMenu, onDismissRequest = { profileMenu = false }) {
                 profileNames.forEach { p ->
                     DropdownMenuItem(text = { Text(p) }, onClick = { profile = p; profileMenu = false })
@@ -407,9 +417,18 @@ private fun RuleEditor(
                 onValueChange = { priorityText = it.filter(Char::isDigit).take(3) },
                 label = { Text("Priority (1–100, higher wins)") },
                 singleLine = true,
+                isError = priorityOverMax,
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 modifier = Modifier.fillMaxWidth().testTag("rule_priority"),
             )
+            if (priorityOverMax) {
+                Text(
+                    stringResource(R.string.rule_priority_over_max),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.testTag("rule_priority_clamp_hint"),
+                )
+            }
 
             SectionHeader("Triggers", divider = true)
             Text(

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ContextsScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ContextsScreen.kt
@@ -3,6 +3,7 @@ package com.tideo.autobrightness.app.ui.screens
 import androidx.compose.ui.res.stringResource
 import com.tideo.autobrightness.R
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,6 +22,7 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -49,6 +51,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -124,6 +127,8 @@ fun ContextRulesSection(
     onUseCurrentLocation: ((Double, Double) -> Unit) -> Unit = {},
     hasUsageAccess: () -> Boolean = { true },
     onRequestUsageAccess: () -> Unit = {},
+    /** D-113: the winning rule's name (%AAB_ActiveContext) — highlighted in the list. */
+    activeContext: String? = null,
 ) {
     var editing by remember { mutableStateOf<ContextRule?>(null) }
 
@@ -164,7 +169,12 @@ fun ContextRulesSection(
         EmptyState("No rules yet.", testTag = "empty_rules")
     }
     rules.forEach { rule ->
-        RuleCard(rule, onEdit = { editing = rule }, onDelete = { onDelete(rule.id) })
+        RuleCard(
+            rule,
+            onEdit = { editing = rule },
+            onDelete = { onDelete(rule.id) },
+            isActive = rule.name.isNotBlank() && rule.name == activeContext,
+        )
     }
 
     // S12.9f: edit/add opens the per-rule editor in a modal. The editor owns its own scroll; Save/Cancel
@@ -198,14 +208,38 @@ fun ContextRulesSection(
 }
 
 @Composable
-private fun RuleCard(rule: ContextRule, onEdit: () -> Unit, onDelete: () -> Unit) {
-    // S13c restyle (m3_audit §3 row 10): rule rows are elevated `AabCard`s.
+private fun RuleCard(rule: ContextRule, onEdit: () -> Unit, onDelete: () -> Unit, isActive: Boolean = false) {
+    // S13c restyle (m3_audit §3 row 10): rule rows are elevated `AabCard`s. D-113: the rule currently
+    // in force gets a gold edge + "Active" tag (mirrors the Profiles list), and the target profile —
+    // the thing the rule switches TO — is rendered prominently in gold rather than buried in grey text.
+    val cardModifier = Modifier.testTag("rule_${rule.id}").let {
+        if (isActive) it.border(1.5.dp, AabGold, MaterialTheme.shapes.medium) else it
+    }
     AabCard(
-        Modifier.testTag("rule_${rule.id}"),
+        cardModifier,
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        Text(rule.name.ifBlank { "(unnamed)" }, style = MaterialTheme.typography.titleMedium)
-        Text("→ ${rule.profile}  ·  priority ${rule.priority}", style = MaterialTheme.typography.bodyMedium)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(rule.name.ifBlank { "(unnamed)" }, style = MaterialTheme.typography.titleMedium, modifier = Modifier.weight(1f))
+            if (isActive) {
+                Text(
+                    stringResource(R.string.profiles_active_tag),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = AabGold,
+                    modifier = Modifier.testTag("rule_active_${rule.id}"),
+                )
+            }
+        }
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text("Loads", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(
+                rule.profile,
+                style = MaterialTheme.typography.titleSmall,
+                color = AabGold,
+                modifier = Modifier.testTag("rule_target_${rule.id}"),
+            )
+            Text("· priority ${rule.priority}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
         Text(rule.triggers.summary(), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             OutlinedButton(onClick = onEdit, modifier = Modifier.testTag("edit_${rule.id}")) { Text("Edit") }
@@ -244,7 +278,9 @@ private fun RuleEditor(
 ) {
     var name by remember { mutableStateOf(rule.name) }
     var profile by remember { mutableStateOf(rule.profile) }
-    var priorityText by remember { mutableStateOf(rule.priority.toString()) }
+    // D-113: priority is a 1–100 scale (higher wins), not 0..∞. Seed from the rule, coercing a legacy/
+    // unset 0 up to 1 so the field always shows a valid value; clamped again on save.
+    var priorityText by remember { mutableStateOf(rule.priority.coerceIn(1, 100).toString()) }
     var wifi by remember { mutableStateOf(rule.triggers.wifi?.joinToString(", ") ?: "") }
     var startTime by remember { mutableStateOf(rule.triggers.timeRange?.getOrNull(0) ?: "") }
     var endTime by remember { mutableStateOf(rule.triggers.timeRange?.getOrNull(1) ?: "") }
@@ -310,7 +346,8 @@ private fun RuleEditor(
             rule.copy(
                 name = name,
                 profile = profile,
-                priority = priorityText.trim().toIntOrNull() ?: 0,
+                // D-113: clamp to the 1–100 scale (blank/invalid → 1, the lowest priority).
+                priority = priorityText.trim().toIntOrNull()?.coerceIn(1, 100) ?: 1,
                 triggers = triggers,
             ),
         )
@@ -352,8 +389,13 @@ private fun RuleEditor(
             }
 
             OutlinedTextField(
-                value = priorityText, onValueChange = { priorityText = it }, label = { Text("Priority (higher wins)") },
-                singleLine = true, modifier = Modifier.fillMaxWidth().testTag("rule_priority"),
+                value = priorityText,
+                // 1–100 scale: digits only, max 3 chars; the value is clamped to 1..100 on save.
+                onValueChange = { priorityText = it.filter(Char::isDigit).take(3) },
+                label = { Text("Priority (1–100, higher wins)") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth().testTag("rule_priority"),
             )
 
             SectionHeader("Triggers", divider = true)
@@ -370,7 +412,16 @@ private fun RuleEditor(
                     modifier = Modifier.fillMaxWidth().testTag("rule_wifi"),
                 )
                 TextButton(
-                    onClick = { onUseCurrentSsid { ssid -> wifi = ssid } },
+                    // D-113: APPEND the current SSID to the comma-separated list (like Tasker), don't
+                    // replace it — a rule can match several networks. De-duped, case-sensitively.
+                    onClick = {
+                        onUseCurrentSsid { ssid ->
+                            val existing = wifi.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+                            if (ssid.isNotBlank() && ssid !in existing) {
+                                wifi = (existing + ssid).joinToString(", ")
+                            }
+                        }
+                    },
                     modifier = Modifier.testTag("use_current_ssid"),
                 ) { Text("Use current Wi-Fi") }
             }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ContextsScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ContextsScreen.kt
@@ -215,6 +215,8 @@ private fun RuleCard(rule: ContextRule, onEdit: () -> Unit, onDelete: () -> Unit
     val cardModifier = Modifier.testTag("rule_${rule.id}").let {
         if (isActive) it.border(1.5.dp, AabGold, MaterialTheme.shapes.medium) else it
     }
+    // D-114: confirm before deleting a rule (Tasker prompted first).
+    var confirmDelete by remember { mutableStateOf(false) }
     AabCard(
         cardModifier,
         verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -243,8 +245,19 @@ private fun RuleCard(rule: ContextRule, onEdit: () -> Unit, onDelete: () -> Unit
         Text(rule.triggers.summary(), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             OutlinedButton(onClick = onEdit, modifier = Modifier.testTag("edit_${rule.id}")) { Text("Edit") }
-            TextButton(onClick = onDelete, modifier = Modifier.testTag("delete_${rule.id}")) { Text("Delete") }
+            TextButton(onClick = { confirmDelete = true }, modifier = Modifier.testTag("delete_${rule.id}")) { Text("Delete") }
         }
+    }
+
+    if (confirmDelete) {
+        ConfirmDialog(
+            title = stringResource(R.string.confirm_delete_rule_title),
+            message = stringResource(R.string.confirm_delete_rule_msg, rule.name.ifBlank { "(unnamed)" }),
+            confirmLabel = stringResource(R.string.confirm_delete),
+            confirmTag = "confirm_delete_${rule.id}",
+            onConfirm = { confirmDelete = false; onDelete() },
+            onDismiss = { confirmDelete = false },
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/DashboardScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/DashboardScreen.kt
@@ -12,7 +12,13 @@ import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.ui.unit.dp
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
@@ -243,12 +249,14 @@ private fun TierBadge(tier: Tier, onClick: () -> Unit) {
     )
 }
 
-/** Shown only while [pausedByOverride]: explains the pause and offers the one Resume control. */
+/** Shown only while [pausedByOverride]: explains the pause and offers the one Resume control. Styled as
+ *  Tasker's gold "Automation Paused" bar — vivid brand gold (not the muted dark `secondaryContainer`)
+ *  with a high-contrast dark RESUME button carrying a ▶ icon (D-111). */
 @Composable
 private fun OverrideCard(serviceRunning: Boolean, onResume: () -> Unit) {
     Card(
-        modifier = Modifier.testTag("override_card"),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
+        modifier = Modifier.fillMaxWidth().testTag("override_card"),
+        colors = CardDefaults.cardColors(containerColor = AabGold, contentColor = AabOnGold),
     ) {
         Column(
             Modifier.padding(Dimens.cardPadding),
@@ -259,11 +267,15 @@ private fun OverrideCard(serviceRunning: Boolean, onResume: () -> Unit) {
                 stringResource(R.string.dashboard_override_explain),
                 style = MaterialTheme.typography.bodyMedium,
             )
-            FilledTonalButton(
+            Button(
                 onClick = onResume,
                 enabled = serviceRunning,
+                colors = ButtonDefaults.buttonColors(containerColor = AabOnGold, contentColor = AabGold),
                 modifier = Modifier.testTag("resume_button"),
-            ) { Text(stringResource(R.string.dashboard_resume_button)) }
+            ) {
+                Icon(Icons.Filled.PlayArrow, contentDescription = null, modifier = Modifier.padding(end = 8.dp))
+                Text(stringResource(R.string.dashboard_resume_button))
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/DashboardScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/DashboardScreen.kt
@@ -37,6 +37,7 @@ import com.tideo.autobrightness.app.ui.components.AabTopBar
 import com.tideo.autobrightness.app.ui.components.BrightnessInstrument
 import com.tideo.autobrightness.app.ui.theme.AabDataCaption
 import com.tideo.autobrightness.app.ui.theme.AabDataDisplay
+import com.tideo.autobrightness.app.runtime.CircadianLocationStatus
 import com.tideo.autobrightness.app.ui.theme.AabGold
 import com.tideo.autobrightness.app.ui.theme.AabOnGold
 import com.tideo.autobrightness.app.ui.theme.Dimens
@@ -129,6 +130,11 @@ fun DashboardContent(
                 OverrideCard(state.serviceRunning, onResume)
             }
             ReadoutStrip(state)
+            // D-110: dynamic scaling is on but the live modifier is running on a stale (day-old) or
+            // missing location — a quiet hint to turn Location on briefly so circadian tracks the real sun.
+            state.circadianLocation?.let { cl ->
+                if (cl.isStale || !cl.hasLocation) CircadianStaleHint(cl)
+            }
             QuickActionsCard(
                 serviceRunning = state.serviceRunning,
                 canAddTile = canAddTile,
@@ -184,6 +190,23 @@ private fun QuickActionsCard(
                 modifier = Modifier.fillMaxWidth().testTag("dashboard_add_widget"),
             ) { Text(stringResource(R.string.dashboard_add_widget)) }
         }
+    }
+}
+
+/** D-110: amber circadian staleness hint — the live modifier is on a day-old cached or default sun
+ *  position. Same gold convention as [StaleBanner]; tapping the Circadian screen lets the user refresh. */
+@Composable
+private fun CircadianStaleHint(status: CircadianLocationStatus) {
+    val text = if (status.isStale) {
+        stringResource(R.string.dashboard_circadian_stale, status.ageDays ?: 0L)
+    } else {
+        stringResource(R.string.dashboard_circadian_no_location)
+    }
+    Card(
+        modifier = Modifier.fillMaxWidth().testTag("circadian_stale_hint"),
+        colors = CardDefaults.cardColors(containerColor = AabGold, contentColor = AabOnGold),
+    ) {
+        Text(text, modifier = Modifier.padding(Dimens.cardPadding), style = MaterialTheme.typography.bodyMedium)
     }
 }
 

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/LiveDebugScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/LiveDebugScreen.kt
@@ -3,6 +3,7 @@ package com.tideo.autobrightness.app.ui.screens
 import androidx.compose.ui.res.stringResource
 import com.tideo.autobrightness.R
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -209,18 +210,22 @@ private fun lastSampleLabel(ms: Long?, now: Long = System.currentTimeMillis()): 
 @Composable
 fun DebugLevelSelector(current: Int, onSelect: (Int) -> Unit) {
     var expanded by remember { mutableStateOf(false) }
-    OutlinedButton(
-        onClick = { expanded = true },
-        modifier = Modifier.fillMaxWidth().testTag("debug_selector"),
-    ) {
-        Text("Debug: ${DEBUG_LABELS.getOrElse(current) { "Off" }}")
-    }
-    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-        DEBUG_LABELS.forEachIndexed { level, label ->
-            DropdownMenuItem(
-                text = { Text(label) },
-                onClick = { onSelect(level); expanded = false },
-            )
+    // Anchor the menu to the button (Box wrapper) — a bare DropdownMenu sibling has no anchor and
+    // floats away from its trigger (D-114b, same fix as the rule-editor profile selector).
+    Box {
+        OutlinedButton(
+            onClick = { expanded = true },
+            modifier = Modifier.fillMaxWidth().testTag("debug_selector"),
+        ) {
+            Text("Debug: ${DEBUG_LABELS.getOrElse(current) { "Off" }}")
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            DEBUG_LABELS.forEachIndexed { level, label ->
+                DropdownMenuItem(
+                    text = { Text(label) },
+                    onClick = { onSelect(level); expanded = false },
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ProfilesContextsScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ProfilesContextsScreen.kt
@@ -3,12 +3,17 @@ package com.tideo.autobrightness.app.ui.screens
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -35,7 +40,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -85,6 +92,9 @@ fun ProfilesContextsScreen(
     // --- Profiles side (SettingsViewModel) ---
     val settings by settingsVm.settings.collectAsStateWithLifecycle()
     val profiles by settingsVm.profiles.collectAsStateWithLifecycle()
+    // %AAB_CurrentActiveProfile — highlight the in-force profile in the list (owner: "seeing the active
+    // profile here is useful"), mirroring Tasker's "Active Profile: …" readout.
+    val activeProfile by com.tideo.autobrightness.app.runtime.LiveRuntimeState.activeProfile.collectAsStateWithLifecycle()
     val manager = remember { ProfileImportExportManager(context.applicationContext) }
     var status by remember { mutableStateOf<String?>(null) }
     // S12.9c #3: a user-visible error card for an unreadable profile file (ProfileLoadResult.TotalFailure).
@@ -210,6 +220,7 @@ fun ProfilesContextsScreen(
                 profiles.forEach { entry ->
                     ProfileCard(
                         entry,
+                        isActive = entry.name == activeProfile,
                         onApply = { previewProfile = entry },
                         onOverwrite = { name -> settingsVm.saveCurrentAs(name); toast("Overwrote: $name") },
                         onDelete = { name -> settingsVm.deleteProfile(name); toast("Deleted: $name") },
@@ -324,28 +335,48 @@ fun ProfilesContextsScreen(
 }
 
 /**
- * D-111: the pinned Load / Save / Contexts action bar (m3_audit B5 `ActionButtonBar` pattern —
- * equal-weight tonal buttons). Sits outside the scroll so it stays reachable while the profile list
- * scrolls; each button opens its own modal.
+ * D-111: the pinned Load / Save / Contexts action bar (m3_audit B5 `ActionButtonBar` pattern), matched
+ * to the Tasker original — each action carries a leading icon and the three are visually distinct:
+ * **Load** filled teal (primary, high-emphasis), **Save** tonal grey, **Contexts** teal-outlined. Sits
+ * outside the scroll so it stays reachable while the profile list scrolls; each opens its own modal.
+ *
+ * The compact `contentPadding` (8 dp vs the M3 default 24 dp) + single-line labels keep "Contexts" on
+ * one line at equal thirds — the default padding squeezed it onto two lines.
  */
 @Composable
 private fun ProfilesActionBar(onLoad: () -> Unit, onSave: () -> Unit, onContexts: () -> Unit) {
+    val pad = PaddingValues(horizontal = 8.dp, vertical = 8.dp)
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = Dimens.screenPaddingHorizontal, vertical = Dimens.sectionSpacing),
         horizontalArrangement = Arrangement.spacedBy(Dimens.rowGap),
     ) {
-        FilledTonalButton(onClick = onLoad, modifier = Modifier.weight(1f).testTag("action_load")) {
-            Text(stringResource(R.string.profiles_action_load))
-        }
-        FilledTonalButton(onClick = onSave, modifier = Modifier.weight(1f).testTag("action_save")) {
-            Text(stringResource(R.string.profiles_action_save))
-        }
-        FilledTonalButton(onClick = onContexts, modifier = Modifier.weight(1f).testTag("action_contexts")) {
-            Text(stringResource(R.string.profiles_action_contexts))
-        }
+        Button(
+            onClick = onLoad,
+            modifier = Modifier.weight(1f).testTag("action_load"),
+            contentPadding = pad,
+        ) { ActionButtonContent(R.drawable.ic_folder, R.string.profiles_action_load) }
+        FilledTonalButton(
+            onClick = onSave,
+            modifier = Modifier.weight(1f).testTag("action_save"),
+            contentPadding = pad,
+        ) { ActionButtonContent(R.drawable.ic_save, R.string.profiles_action_save) }
+        OutlinedButton(
+            onClick = onContexts,
+            modifier = Modifier.weight(1f).testTag("action_contexts"),
+            contentPadding = pad,
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary),
+        ) { ActionButtonContent(R.drawable.ic_tune, R.string.profiles_action_contexts) }
     }
+}
+
+/** A leading 18 dp icon + single-line label, shared by the three action-bar buttons. */
+@Composable
+private fun ActionButtonContent(icon: Int, label: Int) {
+    Icon(painterResource(icon), contentDescription = null, modifier = Modifier.size(18.dp))
+    Spacer(Modifier.width(6.dp))
+    Text(stringResource(label), maxLines = 1, softWrap = false)
 }
 
 /**

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ProfilesContextsScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ProfilesContextsScreen.kt
@@ -95,6 +95,8 @@ fun ProfilesContextsScreen(
     // %AAB_CurrentActiveProfile — highlight the in-force profile in the list (owner: "seeing the active
     // profile here is useful"), mirroring Tasker's "Active Profile: …" readout.
     val activeProfile by com.tideo.autobrightness.app.runtime.LiveRuntimeState.activeProfile.collectAsStateWithLifecycle()
+    // %AAB_ActiveContext — the winning rule's name, to emphasise the active rule in the Contexts modal.
+    val activeContext by com.tideo.autobrightness.app.runtime.LiveRuntimeState.activeContext.collectAsStateWithLifecycle()
     val manager = remember { ProfileImportExportManager(context.applicationContext) }
     var status by remember { mutableStateOf<String?>(null) }
     // S12.9c #3: a user-visible error card for an unreadable profile file (ProfileLoadResult.TotalFailure).
@@ -292,6 +294,7 @@ fun ProfilesContextsScreen(
                 profileNames = profileNames.ifEmpty { listOf("Default") },
                 apps = apps,
                 solarLabel = solarLabel,
+                activeContext = activeContext,
                 onSave = { toast("Rule saved"); contextsVm.save(it) },
                 onDelete = { contextsVm.delete(it); toast("Rule deleted") },
                 onUseCurrentSsid = { setSsid ->

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ProfilesContextsScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ProfilesContextsScreen.kt
@@ -3,12 +3,28 @@ package com.tideo.autobrightness.app.ui.screens
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -20,6 +36,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
@@ -29,12 +47,15 @@ import com.tideo.autobrightness.app.settings.LegacyConfigEntry
 import com.tideo.autobrightness.app.settings.LegacyConfigImporter
 import com.tideo.autobrightness.app.settings.ProfileImportExportManager
 import com.tideo.autobrightness.app.settings.ProfileLoadResult
+import com.tideo.autobrightness.app.settings.SavedProfile
 import com.tideo.autobrightness.app.state.AppEntry
 import com.tideo.autobrightness.app.state.ContextsViewModel
 import com.tideo.autobrightness.app.state.SettingsViewModel
-import com.tideo.autobrightness.app.ui.components.SettingsColumn
+import com.tideo.autobrightness.app.ui.components.EmptyState
+import com.tideo.autobrightness.app.ui.components.SectionHeader
 import com.tideo.autobrightness.app.ui.components.SettingsScaffold
 import com.tideo.autobrightness.app.ui.components.rememberToaster
+import com.tideo.autobrightness.app.ui.theme.Dimens
 import com.tideo.autobrightness.platform.context.LocationResult
 import com.tideo.autobrightness.platform.context.SsidResult
 import kotlinx.coroutines.launch
@@ -138,63 +159,124 @@ fun ProfilesContextsScreen(
     var solarLabel by remember { mutableStateOf<Pair<String, String>?>(null) }
     LaunchedEffect(Unit) { solarLabel = runCatching { contextsVm.solarTimes() }.getOrNull() }
 
-    // S13c' §07 declutter: the screen stacked a profile library ON TOP of the automation-rules list in
-    // one endless scroll. Split the two jobs behind a SegmentedButton so only one is shown at a time
-    // (half the scroll), while keeping the single destination (a rule targets a profile).
-    var tab by remember { mutableStateOf(0) }
+    // D-111 (owner): the Tasker information architecture — a STICKY Load / Save / Contexts action bar
+    // pinned under the app bar (it stays put while the list scrolls), with the built-in/saved profiles
+    // listed directly below it (no longer hidden behind a tab). Each top action opens its own modal,
+    // the way the rule editor already does. Replaces the scrolling Profiles/Rules SegmentedButton.
+    var showLoad by remember { mutableStateOf(false) }
+    var showSave by remember { mutableStateOf(false) }
+    var showContexts by remember { mutableStateOf(false) }
+    // G2R-F38 "Load Anyway" preview before applying a saved profile from the visible list.
+    var previewProfile by remember { mutableStateOf<SavedProfile?>(null) }
+    var showCurrentSettings by remember { mutableStateOf(false) }
+
+    fun loadLegacy(entry: LegacyConfigEntry) {
+        scope.launch {
+            status = runCatching {
+                handleLoad(manager.importFromDocument(entry.uri), "Loaded ${entry.name}") { imported ->
+                    // G2R-F44: register the legacy profile under its file name so it's selectable as a
+                    // context-rule target without a manual re-save, then apply it live.
+                    val profileName = entry.name.removeSuffix(".json").removeSuffix(".JSON")
+                    settingsVm.saveImportedProfile(profileName, imported)
+                    settingsVm.replaceAll(imported)
+                }
+            }.getOrElse { loadError = it.message; "Load failed: ${it.message}" }
+            status?.let(toast)
+        }
+    }
 
     SettingsScaffold(stringResource(R.string.title_profiles_contexts), { navController.popBackStack() }) { padding ->
-        SettingsColumn(padding) {
-            SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
-                SegmentedButton(
-                    selected = tab == 0,
-                    onClick = { tab = 0 },
-                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
-                    modifier = Modifier.testTag("seg_profiles"),
-                ) { Text(stringResource(R.string.seg_profiles)) }
-                SegmentedButton(
-                    selected = tab == 1,
-                    onClick = { tab = 1 },
-                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
-                    modifier = Modifier.testTag("seg_rules"),
-                ) { Text(stringResource(R.string.seg_rules)) }
-            }
-
-            if (tab == 0) ProfilesBody(
-                profiles = profiles,
-                legacyEntries = legacyEntries,
-                contextLocked = settings.contextOverride,
-                currentSettings = settings,
-                status = status,
-                onApplyProfile = { name -> settingsVm.applyProfile(name); toast("Applied profile: $name") },
-                onOverwriteProfile = { name -> settingsVm.saveCurrentAs(name); toast("Overwrote: $name") },
-                onDeleteProfile = { name -> settingsVm.deleteProfile(name); toast("Deleted: $name") },
-                onSaveCurrentAs = { name -> settingsVm.saveCurrentAs(name); toast("Saved profile: $name") },
-                onRestoreFactory = { settingsVm.restoreFactoryProfiles(); toast("Factory profiles restored") },
-                onResumeContext = { settingsVm.resumeContextAutomation(); toast("Context automation resumed") },
-                onReset = { settingsVm.resetDefaults(); toast("Reset to defaults") },
-                onExport = { exportLauncher.launch("tideo-profile.json") },
-                onImport = { importLauncher.launch(arrayOf("application/json", "text/plain", "*/*")) },
-                onChooseLegacyFolder = { folderLauncher.launch(null) },
-                onLoadLegacy = { entry ->
-                    scope.launch {
-                        status = runCatching {
-                            handleLoad(manager.importFromDocument(entry.uri), "Loaded ${entry.name}") { imported ->
-                                // G2R-F44: register the legacy profile under its file name so it's selectable
-                                // as a context-rule target without a manual re-save, then apply it live.
-                                val profileName = entry.name.removeSuffix(".json").removeSuffix(".JSON")
-                                settingsVm.saveImportedProfile(profileName, imported)
-                                settingsVm.replaceAll(imported)
-                            }
-                        }.getOrElse { loadError = it.message; "Load failed: ${it.message}" }
-                        status?.let(toast)
-                    }
-                },
-                loadError = loadError,
-                onDismissLoadError = { loadError = null },
+        Column(Modifier.fillMaxSize().padding(padding)) {
+            // STICKY action bar — pinned outside the scroll so Load/Save/Contexts stay reachable.
+            ProfilesActionBar(
+                onLoad = { showLoad = true },
+                onSave = { showSave = true },
+                onContexts = { showContexts = true },
             )
+            // SCROLLING content: the resume banner + the saved/built-in profiles, directly visible.
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = Dimens.screenPaddingHorizontal),
+                verticalArrangement = Arrangement.spacedBy(Dimens.fieldSpacing),
+            ) {
+                if (settings.contextOverride) {
+                    ContextLockBanner { settingsVm.resumeContextAutomation(); toast("Context automation resumed") }
+                }
+                SectionHeader(stringResource(R.string.seg_profiles), divider = true)
+                if (profiles.isEmpty()) EmptyState(stringResource(R.string.profiles_no_saved), testTag = "empty_profiles")
+                profiles.forEach { entry ->
+                    ProfileCard(
+                        entry,
+                        onApply = { previewProfile = entry },
+                        onOverwrite = { name -> settingsVm.saveCurrentAs(name); toast("Overwrote: $name") },
+                        onDelete = { name -> settingsVm.deleteProfile(name); toast("Deleted: $name") },
+                    )
+                }
+                status?.let { Text(it, color = MaterialTheme.colorScheme.secondary) }
+            }
+        }
+    }
 
-            if (tab == 1) ContextRulesSection(
+    // --- Modals (each top action opens its own, like the rule editor) ---
+
+    // Save: name the current settings as a new profile (gold changed-vs-default diff inside).
+    if (showSave) {
+        SaveProfileDialog(
+            currentSettings = settings,
+            onDismiss = { showSave = false },
+            onConfirm = { name -> showSave = false; settingsVm.saveCurrentAs(name); toast("Saved profile: $name") },
+        )
+    }
+
+    // Load & manage: import/legacy/restore/reset/export/view — the "load from elsewhere" + housekeeping.
+    if (showLoad) {
+        LoadManageDialog(
+            legacyEntries = legacyEntries,
+            onImport = { showLoad = false; importLauncher.launch(arrayOf("application/json", "text/plain", "*/*")) },
+            onChooseLegacyFolder = { folderLauncher.launch(null) },
+            onLoadLegacy = { entry -> showLoad = false; loadLegacy(entry) },
+            onRestoreFactory = { showLoad = false; settingsVm.restoreFactoryProfiles(); toast("Factory profiles restored") },
+            onReset = { showLoad = false; settingsVm.resetDefaults(); toast("Reset to defaults") },
+            onExport = { showLoad = false; exportLauncher.launch("tideo-profile.json") },
+            onViewCurrent = { showLoad = false; showCurrentSettings = true },
+            onDismiss = { showLoad = false },
+        )
+    }
+
+    // Apply a saved profile picked from the visible list (preview then apply).
+    previewProfile?.let { entry ->
+        LoadProfileDialog(
+            profile = entry,
+            onDismiss = { previewProfile = null },
+            onConfirm = { previewProfile = null; settingsVm.applyProfile(entry.name); toast("Applied profile: ${entry.name}") },
+        )
+    }
+
+    if (showCurrentSettings) {
+        CurrentSettingsDialog(settings = settings, onDismiss = { showCurrentSettings = false })
+    }
+
+    // An unreadable-profile failure (ProfileLoadResult.TotalFailure).
+    loadError?.let { msg ->
+        AlertDialog(
+            onDismissRequest = { loadError = null },
+            title = { Text(stringResource(R.string.profiles_load_failed_title)) },
+            text = { Text(msg) },
+            confirmButton = {
+                TextButton(onClick = { loadError = null }, modifier = Modifier.testTag("dismiss_load_error")) {
+                    Text(stringResource(R.string.profiles_close))
+                }
+            },
+        )
+    }
+
+    // Contexts: the full rule list + editor, in a full-screen modal (like the rule editor already is).
+    if (showContexts) {
+        ContextsModal(onClose = { showContexts = false }) {
+            ContextRulesSection(
                 rules = rules,
                 profileNames = profileNames.ifEmpty { listOf("Default") },
                 apps = apps,
@@ -237,6 +319,130 @@ fun ProfilesContextsScreen(
                     runCatching { context.startActivity(contextsVm.usageAccessIntent()) }
                 },
             )
+        }
+    }
+}
+
+/**
+ * D-111: the pinned Load / Save / Contexts action bar (m3_audit B5 `ActionButtonBar` pattern —
+ * equal-weight tonal buttons). Sits outside the scroll so it stays reachable while the profile list
+ * scrolls; each button opens its own modal.
+ */
+@Composable
+private fun ProfilesActionBar(onLoad: () -> Unit, onSave: () -> Unit, onContexts: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Dimens.screenPaddingHorizontal, vertical = Dimens.sectionSpacing),
+        horizontalArrangement = Arrangement.spacedBy(Dimens.rowGap),
+    ) {
+        FilledTonalButton(onClick = onLoad, modifier = Modifier.weight(1f).testTag("action_load")) {
+            Text(stringResource(R.string.profiles_action_load))
+        }
+        FilledTonalButton(onClick = onSave, modifier = Modifier.weight(1f).testTag("action_save")) {
+            Text(stringResource(R.string.profiles_action_save))
+        }
+        FilledTonalButton(onClick = onContexts, modifier = Modifier.weight(1f).testTag("action_contexts")) {
+            Text(stringResource(R.string.profiles_action_contexts))
+        }
+    }
+}
+
+/**
+ * D-111: the "Load & manage" modal opened by the action bar's Load button — import a profile from a
+ * file, (re)link the legacy Tasker folder and load its configs, plus the housekeeping actions
+ * (restore factory / reset / export / view current). Saving lives in its own dialog (the Save button);
+ * applying a saved profile is done from the visible list.
+ */
+@Composable
+private fun LoadManageDialog(
+    legacyEntries: List<LegacyConfigEntry>,
+    onImport: () -> Unit,
+    onChooseLegacyFolder: () -> Unit,
+    onLoadLegacy: (LegacyConfigEntry) -> Unit,
+    onRestoreFactory: () -> Unit,
+    onReset: () -> Unit,
+    onExport: () -> Unit,
+    onViewCurrent: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.profiles_load_title)) },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(Dimens.sectionSpacing),
+            ) {
+                Button(onClick = onImport, modifier = Modifier.fillMaxWidth().testTag("import_profile")) {
+                    Text(stringResource(R.string.profiles_import_file))
+                }
+                OutlinedButton(
+                    onClick = onChooseLegacyFolder,
+                    modifier = Modifier.fillMaxWidth().testTag("choose_legacy_folder"),
+                ) {
+                    Text(
+                        stringResource(
+                            if (legacyEntries.isEmpty()) R.string.profiles_link_legacy else R.string.profiles_relink_legacy,
+                        ),
+                    )
+                }
+                legacyEntries.forEach { entry ->
+                    OutlinedButton(
+                        onClick = { onLoadLegacy(entry) },
+                        modifier = Modifier.fillMaxWidth().testTag("load_${entry.name}"),
+                    ) { Text(stringResource(R.string.profiles_load_legacy_entry, entry.name)) }
+                }
+                OutlinedButton(onClick = onRestoreFactory, modifier = Modifier.fillMaxWidth().testTag("restore_factory")) {
+                    Text(stringResource(R.string.profiles_restore_factory))
+                }
+                OutlinedButton(onClick = onReset, modifier = Modifier.fillMaxWidth().testTag("reset_defaults")) {
+                    Text(stringResource(R.string.profiles_reset_defaults))
+                }
+                Button(onClick = onExport, modifier = Modifier.fillMaxWidth().testTag("export_profile")) {
+                    Text(stringResource(R.string.profiles_export))
+                }
+                OutlinedButton(onClick = onViewCurrent, modifier = Modifier.fillMaxWidth().testTag("view_current_settings")) {
+                    Text(stringResource(R.string.profiles_view_current))
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.profiles_close)) }
+        },
+    )
+}
+
+/**
+ * D-111: a full-screen modal host for the context-rules editor opened by the action bar's Contexts
+ * button — a top bar (title + close) over the scrolling [ContextRulesSection]. Full-screen because the
+ * rule list + editor is too tall for an AlertDialog.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ContextsModal(onClose: () -> Unit, content: @Composable () -> Unit) {
+    Dialog(onDismissRequest = onClose, properties = DialogProperties(usePlatformDefaultWidth = false)) {
+        Surface(modifier = Modifier.fillMaxSize()) {
+            Column(Modifier.fillMaxSize()) {
+                TopAppBar(
+                    title = { Text(stringResource(R.string.profiles_contexts_title)) },
+                    navigationIcon = {
+                        IconButton(onClick = onClose, modifier = Modifier.testTag("contexts_close")) {
+                            Icon(Icons.Filled.Close, contentDescription = stringResource(R.string.profiles_close))
+                        }
+                    },
+                )
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .verticalScroll(rememberScrollState())
+                        .padding(horizontal = Dimens.screenPaddingHorizontal),
+                    verticalArrangement = Arrangement.spacedBy(Dimens.fieldSpacing),
+                ) {
+                    content()
+                }
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ProfilesScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ProfilesScreen.kt
@@ -2,13 +2,16 @@ package com.tideo.autobrightness.app.ui.screens
 
 import androidx.compose.ui.res.stringResource
 import com.tideo.autobrightness.R
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
@@ -16,11 +19,11 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -47,6 +50,8 @@ import com.tideo.autobrightness.app.ui.components.SectionHeader
 import com.tideo.autobrightness.app.ui.components.SettingsColumn
 import com.tideo.autobrightness.app.ui.components.SettingsDiffList
 import com.tideo.autobrightness.app.ui.components.SettingsScaffold
+import com.tideo.autobrightness.app.ui.theme.AabGold
+import com.tideo.autobrightness.app.ui.theme.AabOnGold
 
 /**
  * Profiles & Import/Export content (Tasker AAB Profile — task592/637/622), the saved-profiles surface
@@ -277,15 +282,21 @@ fun ProfilesBody(
 internal fun ContextLockBanner(onResumeContext: () -> Unit) {
     Card(
         Modifier.fillMaxWidth().testTag("context_lock_banner"),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
+        // Vivid brand gold (like the dashboard StaleBanner / Tasker's "Automation Paused" bar), not the
+        // muted dark-theme `secondaryContainer` — the owner wanted the Tasker golden banner.
+        colors = CardDefaults.cardColors(containerColor = AabGold, contentColor = AabOnGold),
     ) {
-        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Text(
                 "Context automation is paused after a manual profile load.",
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSecondaryContainer,
             )
-            FilledTonalButton(onClick = onResumeContext, modifier = Modifier.testTag("resume_context")) {
+            // High-contrast resume — Tasker's black RESUME on gold: dark container, gold label + ▶ icon.
+            Button(
+                onClick = onResumeContext,
+                colors = ButtonDefaults.buttonColors(containerColor = AabOnGold, contentColor = AabGold),
+                modifier = Modifier.testTag("resume_context"),
+            ) {
                 Icon(Icons.Filled.PlayArrow, contentDescription = null, modifier = Modifier.padding(end = 8.dp))
                 Text("Resume context automation")
             }
@@ -299,11 +310,17 @@ internal fun ProfileCard(
     onApply: () -> Unit,
     onOverwrite: (String) -> Unit,
     onDelete: (String) -> Unit,
+    isActive: Boolean = false,
 ) {
     val changed = entry.settings.changedCount()
     var menu by remember { mutableStateOf(false) }
+    // D-111 (owner): highlight the in-force profile with a gold edge + an "Active" tag, so the list
+    // answers "which profile is loaded right now?" the way Tasker's "Active Profile: …" readout does.
+    val cardModifier = Modifier.testTag("profile_${entry.name}").let {
+        if (isActive) it.border(1.5.dp, AabGold, MaterialTheme.shapes.medium) else it
+    }
     AabCard(
-        Modifier.testTag("profile_${entry.name}"),
+        cardModifier,
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         // S13c' §07-B: the row shows the name + the PRIMARY action (Apply); secondary actions
@@ -314,10 +331,21 @@ internal fun ProfileCard(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Column(Modifier.weight(1f)) {
-                Text(
-                    entry.name + if (entry.builtIn) "  (built-in)" else "",
-                    style = MaterialTheme.typography.titleMedium,
-                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        entry.name + if (entry.builtIn) "  (built-in)" else "",
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    if (isActive) {
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            stringResource(R.string.profiles_active_tag),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = AabGold,
+                            modifier = Modifier.testTag("profile_active_${entry.name}"),
+                        )
+                    }
+                }
                 Text(
                     if (changed == 0) "Factory defaults" else "$changed changed from default",
                     style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ProfilesScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ProfilesScreen.kt
@@ -304,6 +304,42 @@ internal fun ContextLockBanner(onResumeContext: () -> Unit) {
     }
 }
 
+/**
+ * D-114: a reusable confirmation dialog for destructive profile/rule actions (Tasker prompted before
+ * delete/overwrite). Shared across the Profiles list and the Contexts rule list (same package). The
+ * confirm action is tinted [error] red when [destructive] so a delete reads as dangerous.
+ */
+@Composable
+internal fun ConfirmDialog(
+    title: String,
+    message: String,
+    confirmLabel: String,
+    confirmTag: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    destructive: Boolean = true,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = { Text(message) },
+        confirmButton = {
+            TextButton(
+                onClick = onConfirm,
+                modifier = Modifier.testTag(confirmTag),
+                colors = if (destructive) {
+                    ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
+                } else {
+                    ButtonDefaults.textButtonColors()
+                },
+            ) { Text(confirmLabel) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.confirm_cancel)) }
+        },
+    )
+}
+
 @Composable
 internal fun ProfileCard(
     entry: SavedProfile,
@@ -314,6 +350,9 @@ internal fun ProfileCard(
 ) {
     val changed = entry.settings.changedCount()
     var menu by remember { mutableStateOf(false) }
+    // D-114: confirm before overwriting or deleting a saved profile (Tasker did this).
+    var confirmOverwrite by remember { mutableStateOf(false) }
+    var confirmDelete by remember { mutableStateOf(false) }
     // D-111 (owner): highlight the in-force profile with a gold edge + an "Active" tag, so the list
     // answers "which profile is loaded right now?" the way Tasker's "Active Profile: …" readout does.
     val cardModifier = Modifier.testTag("profile_${entry.name}").let {
@@ -365,12 +404,12 @@ internal fun ProfileCard(
                 DropdownMenu(expanded = menu, onDismissRequest = { menu = false }) {
                     DropdownMenuItem(
                         text = { Text("Overwrite") },
-                        onClick = { menu = false; onOverwrite(entry.name) },
+                        onClick = { menu = false; confirmOverwrite = true },
                         modifier = Modifier.testTag("overwrite_profile_${entry.name}"),
                     )
                     DropdownMenuItem(
                         text = { Text("Delete") },
-                        onClick = { menu = false; onDelete(entry.name) },
+                        onClick = { menu = false; confirmDelete = true },
                         modifier = Modifier.testTag("delete_profile_${entry.name}"),
                     )
                 }
@@ -380,6 +419,28 @@ internal fun ProfileCard(
             onClick = onApply,
             modifier = Modifier.fillMaxWidth().testTag("apply_profile_${entry.name}"),
         ) { Text("Apply") }
+    }
+
+    if (confirmOverwrite) {
+        ConfirmDialog(
+            title = stringResource(R.string.confirm_overwrite_profile_title),
+            message = stringResource(R.string.confirm_overwrite_profile_msg, entry.name),
+            confirmLabel = stringResource(R.string.confirm_overwrite),
+            confirmTag = "confirm_overwrite_${entry.name}",
+            destructive = false,
+            onConfirm = { confirmOverwrite = false; onOverwrite(entry.name) },
+            onDismiss = { confirmOverwrite = false },
+        )
+    }
+    if (confirmDelete) {
+        ConfirmDialog(
+            title = stringResource(R.string.confirm_delete_profile_title),
+            message = stringResource(R.string.confirm_delete_profile_msg, entry.name),
+            confirmLabel = stringResource(R.string.confirm_delete),
+            confirmTag = "confirm_delete_${entry.name}",
+            onConfirm = { confirmDelete = false; onDelete(entry.name) },
+            onDismiss = { confirmDelete = false },
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ProfilesScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ProfilesScreen.kt
@@ -13,12 +13,14 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -156,19 +158,28 @@ fun ProfilesBody(
             }
         }
     }
-    // G2R-F30: a manual profile load pauses context automation; offer a Resume control.
+    // G2R-F30 / D-111: a manual profile load pauses context automation; offer a Resume control. Styled
+    // as the Tasker "golden banner with a play button" — the gold `secondaryContainer` + leading ▶ icon,
+    // coherent with the dashboard's `OverrideCard` resume affordance and the M3 audit's gold-emphasis
+    // role (design/m3_audit.md §2.4: `secondary`/gold = emphasis/warnings). Was a teal `tertiaryContainer`
+    // card with a plain text button.
     if (contextLocked) {
         Card(
             Modifier.fillMaxWidth().testTag("context_lock_banner"),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
         ) {
             Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
                 Text(
                     "Context automation is paused after a manual profile load.",
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
                 )
-                OutlinedButton(onClick = onResumeContext, modifier = Modifier.testTag("resume_context")) {
+                FilledTonalButton(onClick = onResumeContext, modifier = Modifier.testTag("resume_context")) {
+                    Icon(
+                        Icons.Filled.PlayArrow,
+                        contentDescription = null,
+                        modifier = Modifier.padding(end = 8.dp),
+                    )
                     Text("Resume context automation")
                 }
             }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ProfilesScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ProfilesScreen.kt
@@ -158,33 +158,7 @@ fun ProfilesBody(
             }
         }
     }
-    // G2R-F30 / D-111: a manual profile load pauses context automation; offer a Resume control. Styled
-    // as the Tasker "golden banner with a play button" — the gold `secondaryContainer` + leading ▶ icon,
-    // coherent with the dashboard's `OverrideCard` resume affordance and the M3 audit's gold-emphasis
-    // role (design/m3_audit.md §2.4: `secondary`/gold = emphasis/warnings). Was a teal `tertiaryContainer`
-    // card with a plain text button.
-    if (contextLocked) {
-        Card(
-            Modifier.fillMaxWidth().testTag("context_lock_banner"),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
-        ) {
-            Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                Text(
-                    "Context automation is paused after a manual profile load.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-                FilledTonalButton(onClick = onResumeContext, modifier = Modifier.testTag("resume_context")) {
-                    Icon(
-                        Icons.Filled.PlayArrow,
-                        contentDescription = null,
-                        modifier = Modifier.padding(end = 8.dp),
-                    )
-                    Text("Resume context automation")
-                }
-            }
-        }
-    }
+    if (contextLocked) ContextLockBanner(onResumeContext)
 
     // S13c restyle (m3_audit §3 row 10): empty hints become `EmptyState`; rows become `AabCard`s.
     SectionHeader("Saved profiles", divider = true)
@@ -292,8 +266,35 @@ fun ProfilesBody(
     }
 }
 
+/**
+ * G2R-F30 / D-111: a manual profile load pauses context automation; offer a Resume control. Styled as
+ * the Tasker "golden banner with a play button" — the gold `secondaryContainer` + leading ▶ icon,
+ * coherent with the dashboard's `OverrideCard` resume affordance and the M3 audit's gold-emphasis role
+ * (design/m3_audit.md §2.4: `secondary`/gold = emphasis/warnings). Shared by [ProfilesBody] and the
+ * unified [ProfilesContextsScreen].
+ */
 @Composable
-private fun ProfileCard(
+internal fun ContextLockBanner(onResumeContext: () -> Unit) {
+    Card(
+        Modifier.fillMaxWidth().testTag("context_lock_banner"),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
+    ) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(
+                "Context automation is paused after a manual profile load.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            FilledTonalButton(onClick = onResumeContext, modifier = Modifier.testTag("resume_context")) {
+                Icon(Icons.Filled.PlayArrow, contentDescription = null, modifier = Modifier.padding(end = 8.dp))
+                Text("Resume context automation")
+            }
+        }
+    }
+}
+
+@Composable
+internal fun ProfileCard(
     entry: SavedProfile,
     onApply: () -> Unit,
     onOverwrite: (String) -> Unit,
@@ -386,7 +387,7 @@ private fun ExpandableSection(
 }
 
 @Composable
-private fun SaveProfileDialog(
+internal fun SaveProfileDialog(
     currentSettings: AabSettings,
     onDismiss: () -> Unit,
     onConfirm: (String) -> Unit,

--- a/app/src/main/res/drawable/ic_folder.xml
+++ b/app/src/main/res/drawable/ic_folder.xml
@@ -1,0 +1,10 @@
+<!-- Material "folder" glyph (Load action). Tinted by the button content colour. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M10,4H4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V8c0,-1.1 -0.9,-2 -2,-2h-8l-2,-2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_save.xml
+++ b/app/src/main/res/drawable/ic_save.xml
@@ -1,0 +1,10 @@
+<!-- Material "save" (floppy disk) glyph (Save action). Tinted by the button content colour. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M17,3H5c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2V7l-4,-4zM12,19c-1.66,0 -3,-1.34 -3,-3s1.34,-3 3,-3 3,1.34 3,3 -1.34,3 -3,3zM15,9H5V5h10v4z" />
+</vector>

--- a/app/src/main/res/drawable/ic_tune.xml
+++ b/app/src/main/res/drawable/ic_tune.xml
@@ -1,0 +1,10 @@
+<!-- Material "tune" (sliders) glyph (Contexts action). Tinted by the button content colour. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M3,17v2h6v-2L3,17zM3,5v2h10L13,5L3,5zM13,21v-2h8v-2h-8v-2h-2v6h2zM7,9v2L3,11v2h4v2h2L9,9L7,9zM21,13v-2L11,11v2h10zM15,9h2L17,7h4L21,5h-4L17,3h-2v6z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,7 @@
     <string name="profiles_reset_defaults">Reset settings to defaults</string>
     <string name="profiles_export">Export current settings…</string>
     <string name="profiles_view_current">View current settings…</string>
+    <string name="profiles_active_tag">Active</string>
     <string name="profile_more_actions">More actions</string>
     <string name="legacy_import_header">Import from Tasker AAB</string>
     <string name="manage_profiles_header">Manage profiles &amp; Export</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,23 @@
     <string name="title_profiles_contexts">Profiles &amp; Contexts</string>
     <string name="seg_profiles">Profiles</string>
     <string name="seg_rules">Rules</string>
+    <!-- D-111: Tasker-style sticky Load / Save / Contexts action bar on the Profiles &amp; Contexts screen. -->
+    <string name="profiles_action_load">Load</string>
+    <string name="profiles_action_save">Save</string>
+    <string name="profiles_action_contexts">Contexts</string>
+    <string name="profiles_load_title">Load &amp; manage</string>
+    <string name="profiles_contexts_title">Context rules</string>
+    <string name="profiles_close">Close</string>
+    <string name="profiles_no_saved">No saved profiles yet.</string>
+    <string name="profiles_load_failed_title">Couldn\'t load</string>
+    <string name="profiles_import_file">Import a settings file…</string>
+    <string name="profiles_link_legacy">Link legacy configs folder…</string>
+    <string name="profiles_relink_legacy">Re-link legacy folder…</string>
+    <string name="profiles_load_legacy_entry">Load %1$s</string>
+    <string name="profiles_restore_factory">Restore factory profiles</string>
+    <string name="profiles_reset_defaults">Reset settings to defaults</string>
+    <string name="profiles_export">Export current settings…</string>
+    <string name="profiles_view_current">View current settings…</string>
     <string name="profile_more_actions">More actions</string>
     <string name="legacy_import_header">Import from Tasker AAB</string>
     <string name="manage_profiles_header">Manage profiles &amp; Export</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,12 @@
 
     <!-- Dashboard -->
     <string name="dashboard_stale_banner">Live data may be stale — the monitor may have stopped responding.</string>
+    <string name="dashboard_circadian_stale">Circadian using a sun position cached %1$d day(s) ago — turn on Location briefly to refresh.</string>
+    <string name="dashboard_circadian_no_location">Circadian using default sun times (no location) — turn on Location briefly for accurate sunrise/sunset.</string>
+
+    <!-- Circadian -->
+    <string name="circadian_stale_banner">Showing cached sun events from %1$d day(s) ago. Turn on Location briefly — or enable the IP fallback below — to refresh sunrise/sunset.</string>
+    <string name="circadian_no_location_banner">No location yet, so circadian is using default sun times. Turn on Location briefly — or enable the IP fallback below — for accurate sunrise/sunset.</string>
     <string name="dashboard_tier_none">No write access — tap to set up</string>
     <string name="dashboard_tier_basic">Basic access (Modify system settings)</string>
     <string name="dashboard_tier_elevated">Elevated access (super dimming ready)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,16 @@
     <string name="profiles_export">Export current settings…</string>
     <string name="profiles_view_current">View current settings…</string>
     <string name="profiles_active_tag">Active</string>
+    <!-- D-114: Tasker-style confirmations for destructive profile/rule actions. -->
+    <string name="confirm_delete">Delete</string>
+    <string name="confirm_overwrite">Overwrite</string>
+    <string name="confirm_cancel">Cancel</string>
+    <string name="confirm_delete_rule_title">Delete rule?</string>
+    <string name="confirm_delete_rule_msg">Delete “%1$s”? This can\'t be undone.</string>
+    <string name="confirm_delete_profile_title">Delete profile?</string>
+    <string name="confirm_delete_profile_msg">Delete the profile “%1$s”? This can\'t be undone.</string>
+    <string name="confirm_overwrite_profile_title">Overwrite profile?</string>
+    <string name="confirm_overwrite_profile_msg">Replace “%1$s” with your current settings? The saved profile will be overwritten.</string>
     <string name="profile_more_actions">More actions</string>
     <string name="legacy_import_header">Import from Tasker AAB</string>
     <string name="manage_profiles_header">Manage profiles &amp; Export</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,7 @@
     <string name="profiles_export">Export current settings…</string>
     <string name="profiles_view_current">View current settings…</string>
     <string name="profiles_active_tag">Active</string>
+    <string name="rule_priority_over_max">Above the 1–100 range — this will be saved as 100.</string>
     <!-- D-114: Tasker-style confirmations for destructive profile/rule actions. -->
     <string name="confirm_delete">Delete</string>
     <string name="confirm_overwrite">Overwrite</string>

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineControllerTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineControllerTest.kt
@@ -266,9 +266,10 @@ class BrightnessPipelineControllerTest {
     }
 
     // G2R-F27/D-050: in PWM-sensitive mode the HARDWARE brightness is floored at the dimming
-    // threshold when the target would fall below it (task698 step 3).
+    // threshold when the target would fall below it (task698 step 3). D-109: the read-out
+    // (targetBrightness) must still track the PERCEIVED (un-floored) brightness, NOT stick at the floor.
     @Test
-    fun pwmSensitive_floorsHardwareAtDimmingThreshold() = runTest {
+    fun pwmSensitive_floorsHardwareButReadoutTracksPerceived() = runTest {
         val sensor = FakeSensor()
         val brightness = FakeBrightness()
         val pwm = settings.copy(minBrightness = 1, pwmSensitive = true, dimmingThreshold = 40)
@@ -280,8 +281,12 @@ class BrightnessPipelineControllerTest {
         controller.start()
         sensor.flow.emit(sample(lux = 1.0)) // maps to ~5, below threshold 40
         advanceUntilIdle()
-        assertEquals(40, controller.state.value.targetBrightness, "PWM floor holds hardware at threshold")
-        assertEquals(40, brightness.writes.last())
+        // Hardware write + lastAppliedBrightness are floored to the threshold (D-050).
+        assertEquals(40, brightness.writes.last(), "PWM floor holds the hardware write at threshold")
+        assertEquals(40, controller.state.value.lastAppliedBrightness, "hardware-applied value is floored")
+        // The read-out tracks the perceived, un-floored calculated brightness (D-109).
+        val perceived = controller.state.value.targetBrightness!!
+        assertTrue(perceived < 40, "read-out follows the perceived (un-floored) brightness, not the floor; was $perceived")
         scope.cancel()
     }
 

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/CircadianWindowProviderTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/CircadianWindowProviderTest.kt
@@ -267,6 +267,70 @@ class CircadianWindowProviderTest {
         scope.cancel()
     }
 
+    // ----- D-110: stale cached location is a fallback across the day rollover -----
+
+    @Test
+    fun staleCachedLocation_acrossDayRollover_stillComputesTodaysWindows_D110() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val today = midJuneEpochSec() / 86_400L
+        val yesterday = today - 1
+        var refreshed = 0
+        val provider = CircadianWindowProvider(
+            scope = scope,
+            overrideFlow = MutableStateFlow(ExperimentDateLocation()),
+            location = FakeLocationReader(), // no live fix
+            geoIpFallback = { null },        // geo-IP off
+            loadCachedLocation = { CachedSunLocation(lat, lon, yesterday) }, // cache from YESTERDAY
+            clock = { midJuneEpochSec() * 1000L },
+            tzOffsetForDate = { 2.0 },
+        )
+        provider.onWindowsRefreshed = { refreshed++ }
+        val w = provider.current(transitionFactor)
+        // The day rolled over and no fresh fix exists, but the stale cache must still drive TODAY's
+        // windows instead of returning null → the default-window 0.85 (the owner's report).
+        assertNotNull(w, "a day-old cached location must still produce windows (D-110), not null")
+        assertEquals(CircadianWindowProvider.compute(lat, lon, midJuneEpochSec(), 2.0, transitionFactor), w)
+        // Staleness is surfaced for the UI hint.
+        assertTrue(provider.status.isStale, "a day-old cache is stale")
+        assertEquals(1L, provider.status.ageDays, "cache age is 1 day")
+        assertTrue(refreshed >= 1, "seeding a cached location recomputes (onWindowsRefreshed)")
+        scope.cancel()
+    }
+
+    @Test
+    fun freshFixToday_isNotStale_D110() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val provider = CircadianWindowProvider(
+            scope = scope,
+            overrideFlow = MutableStateFlow(ExperimentDateLocation()),
+            location = FakeLocationReader(lastKnown = LocationSnapshot(lat, lon)),
+            geoIpFallback = { null },
+            clock = { midJuneEpochSec() * 1000L },
+            tzOffsetForDate = { 2.0 },
+        )
+        provider.current(transitionFactor)
+        assertFalse(provider.status.isStale, "a fix acquired today is fresh")
+        assertEquals(0L, provider.status.ageDays)
+        scope.cancel()
+    }
+
+    @Test
+    fun noLocationEver_statusHasNoLocation_D110() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val provider = CircadianWindowProvider(
+            scope = scope,
+            overrideFlow = MutableStateFlow(ExperimentDateLocation()),
+            location = FakeLocationReader(),
+            geoIpFallback = { null },
+            clock = { midJuneEpochSec() * 1000L },
+            tzOffsetForDate = { 2.0 },
+        )
+        assertNull(provider.current(transitionFactor))
+        assertFalse(provider.status.hasLocation, "no fix anywhere → status has no location")
+        assertFalse(provider.status.isStale)
+        scope.cancel()
+    }
+
     // ----- F73: tz offset is taken at the TARGET date instant (DST-aware) -----
 
     @Test

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/ContextEngineTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/ContextEngineTest.kt
@@ -83,7 +83,7 @@ class ContextEngineTest {
 
     private fun TestScope.engine(
         rules: List<ContextRule>,
-        signalSource: FakeSignalSource,
+        signalSource: ContextSignalSource,
         baseline: AabSettings = this@ContextEngineTest.baseline,
         clock: () -> Long = { 0L },
         onChanged: () -> Unit = {},
@@ -178,6 +178,71 @@ class ContextEngineTest {
         now = 80_000L
         src.batteryPercent = 15
         src.battery.emit(BatterySignal(15, plugged = false))
+        advanceUntilIdle()
+        assertEquals("Low Battery", engine.activeContext.value)
+        scope.cancel()
+    }
+
+    /** Source that honours the battery percent the engine passes into [assemble] (the live snapshot),
+     *  so the seed-evaluation "no reading yet" path can be exercised. */
+    private class PassThroughBatterySource(
+        var dayOfWeek: Int = 4,
+        var nowSecondsOfDay: Int = 12 * 3600,
+    ) : ContextSignalSource {
+        val battery = MutableSharedFlow<BatterySignal>(extraBufferCapacity = 16)
+        override fun batteryFlow(): Flow<BatterySignal> = battery
+        override fun wifiFlow(): Flow<String?> = MutableSharedFlow()
+        override fun foregroundAppFlow(intervalMs: Long): Flow<String?> = MutableSharedFlow()
+        override fun locationFlow(): Flow<LocationSignal> = MutableSharedFlow()
+        override suspend fun assemble(
+            app: String, batteryPercent: Int, plugged: Boolean, wifi: String, lat: Double, lon: Double,
+        ): ContextSignals = ContextSignals(
+            app = app, lat = lat, lon = lon, batteryPercent = batteryPercent, plugged = plugged,
+            wifi = wifi, dayOfWeek = dayOfWeek, nowSecondsOfDay = nowSecondsOfDay,
+        )
+    }
+
+    @Test
+    fun serviceStart_noBatteryReadingYet_doesNotFlashSaver_D108() = runTest {
+        // D-108: at start() the seed GENERAL eval runs before the battery callbackFlow delivers its
+        // first value. The snapshot reports -1 ("unknown"), so the max=20 saver rule must NOT match —
+        // no Battery Saver flash. Once a real (high) reading arrives the engine stays on the baseline;
+        // a real LOW reading then correctly applies the saver.
+        var now = 0L
+        val src = PassThroughBatterySource()
+        val (engine, scope) = engine(listOf(batterySaverRule), src, clock = { now })
+        engine.start(scope)
+        advanceUntilIdle()
+        assertNull(engine.activeContext.value, "seed eval with unknown battery must not match the saver")
+
+        // First real reading: 80% (unplugged) → still no saver. (Past the 30s battery cooldown so the
+        // BATTERY caller isn't debounced against the seed eval's lastEvalTime.)
+        now = 35_000L
+        src.battery.emit(BatterySignal(80, plugged = false))
+        advanceUntilIdle()
+        assertNull(engine.activeContext.value, "80% must not match a max=20 saver rule")
+
+        // Battery later drains to 10% → the saver correctly engages.
+        now = 70_000L
+        src.battery.emit(BatterySignal(10, plugged = false))
+        advanceUntilIdle()
+        assertEquals("Low Battery", engine.activeContext.value, "a real low reading applies the saver")
+        scope.cancel()
+    }
+
+    @Test
+    fun serviceStart_realLowBatteryFirstReading_appliesSaverWithoutVeto_D108() = runTest {
+        // The first real reading transitions lastBatt from the -1 sentinel; even a low value within
+        // BATTERY_DELTA_THRESHOLD of -1 must not be vetoed (D-108).
+        var now = 0L
+        val src = PassThroughBatterySource()
+        val (engine, scope) = engine(listOf(batterySaverRule), src, clock = { now })
+        engine.start(scope)
+        advanceUntilIdle()
+        assertNull(engine.activeContext.value)
+
+        now = 35_000L // past the 30s battery cooldown vs the seed eval
+        src.battery.emit(BatterySignal(3, plugged = false)) // |3 - (-1)| = 4 < 5, must still evaluate
         advanceUntilIdle()
         assertEquals("Low Battery", engine.activeContext.value)
         scope.cancel()

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/ui/SettingsScreensTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/ui/SettingsScreensTest.kt
@@ -441,6 +441,57 @@ class SettingsScreensTest {
     }
 
     @Test
+    fun profiles_deleteAndOverwrite_requireConfirmation_D114() {
+        // D-114: Tasker prompted before deleting or overwriting a profile — both must confirm first.
+        var deleted: String? = null
+        var overwritten: String? = null
+        val profiles = listOf(com.tideo.autobrightness.app.settings.SavedProfile("Mine", AabSettings()))
+        compose.setContent {
+            MaterialTheme {
+                com.tideo.autobrightness.app.ui.screens.ProfilesContent(
+                    profiles = profiles, legacyEntries = emptyList(), contextLocked = false, status = null,
+                    onBack = {}, onApplyProfile = {}, onOverwriteProfile = { overwritten = it }, onDeleteProfile = { deleted = it },
+                    onSaveCurrentAs = {}, onRestoreFactory = {}, onResumeContext = {}, onReset = {},
+                    onExport = {}, onImport = {}, onChooseLegacyFolder = {}, onLoadLegacy = {},
+                )
+            }
+        }
+        compose.onNodeWithTag("profile_menu_Mine").performScrollTo().performClick()
+        compose.onNodeWithTag("delete_profile_Mine").performClick()
+        assertEquals(null, deleted, "delete must not fire before confirmation")
+        compose.onNodeWithTag("confirm_delete_Mine").performClick()
+        assertEquals("Mine", deleted, "confirming the dialog deletes")
+
+        compose.onNodeWithTag("profile_menu_Mine").performScrollTo().performClick()
+        compose.onNodeWithTag("overwrite_profile_Mine").performClick()
+        assertEquals(null, overwritten, "overwrite must not fire before confirmation")
+        compose.onNodeWithTag("confirm_overwrite_Mine").performClick()
+        assertEquals("Mine", overwritten, "confirming the dialog overwrites")
+    }
+
+    @Test
+    fun contexts_deleteRule_requiresConfirmation_D114() {
+        // D-114: deleting a context rule must confirm first (Tasker prompted).
+        var deleted: String? = null
+        val rule = com.tideo.autobrightness.app.settings.ContextRule(
+            id = "r1", name = "Cinema", profile = "Default",
+            triggers = com.tideo.autobrightness.app.settings.ContextTriggers(),
+        )
+        compose.setContent {
+            MaterialTheme {
+                ContextsContent(
+                    rules = listOf(rule), profileNames = listOf("Default"), apps = emptyList(),
+                    onBack = {}, onSave = {}, onDelete = { deleted = it },
+                )
+            }
+        }
+        compose.onNodeWithTag("delete_r1").performScrollTo().performClick()
+        assertEquals(null, deleted, "delete must not fire before confirmation")
+        compose.onNodeWithTag("confirm_delete_r1").performClick()
+        assertEquals("r1", deleted, "confirming the dialog deletes the rule")
+    }
+
+    @Test
     fun profiles_contextLockBanner_offersResume() {
         // G2R-F30: a manual profile load latches the context lock; the Profiles screen offers Resume.
         var resumed = false

--- a/docs/rebuild/DEVIATIONS_LEDGER.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER.md
@@ -1956,6 +1956,13 @@ the permanent registry — never compress or remove them.
   (`rule_priority_over_max`) when the value exceeds 100, and clamps to 1..100 ONLY on save — so an old
   150 is shown truthfully and capped to 100 only if/when the user re-saves that rule (relative ordering
   is preserved until then).
+  (e) **Disconnected dropdown menu fix (owner screenshot).** The rule editor's "Switch to profile"
+  `DropdownMenu` was a bare sibling of its anchor button in the scrolling editor `Column`, so it had no
+  layout anchor and the open menu floated DOWN over the Triggers section ("disconnected" list). Wrapped
+  the button + menu in a `Box` (the canonical Compose pattern, already used by `ProfileCard`'s overflow).
+  Swept the codebase for the same anti-pattern and fixed `LiveDebugScreen.DebugLevelSelector` too;
+  `ProfilesScreen`'s overflow was already boxed. **Lesson:** a `DropdownMenu` must share a `Box` with its
+  anchor — a bare sibling in a Column anchors to the wrong place.
 
 - **D-114: confirmation prompts for destructive profile/rule actions (owner-reported, 1.2.0).** Deleting
   a context rule, and deleting or overwriting a saved profile, fired immediately with no confirmation —

--- a/docs/rebuild/DEVIATIONS_LEDGER.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER.md
@@ -1947,6 +1947,15 @@ the permanent registry — never compress or remove them.
   current SSID by overwriting the field; it now appends the SSID to the comma-separated list (de-duped),
   so a rule can match several networks — matching Tasker's behaviour. No new strings beyond the gold
   "Active" tag (reused `profiles_active_tag`); `HardcodedStringCheckTest` ratchet still ≤ 92.
+  (d) **Follow-ups (owner): editor profile emphasis + legacy-priority safety.** The rule editor's
+  "Switch to profile" selector now renders the chosen profile in gold `titleSmall` + a dropdown caret
+  (matching the rule card's "Loads <profile>"). On the priority migration: a pre-existing rule with a
+  stored priority > 100 is NOT broken — `ContextOverrideResolver` still ranks by the raw stored value
+  (higher wins), so it keeps resolving as before. The editor now seeds the field with the rule's REAL
+  stored value (≥1; legacy/unset 0 → 1) instead of pre-capping it, shows an error hint
+  (`rule_priority_over_max`) when the value exceeds 100, and clamps to 1..100 ONLY on save — so an old
+  150 is shown truthfully and capped to 100 only if/when the user re-saves that rule (relative ordering
+  is preserved until then).
 
 - **D-114: confirmation prompts for destructive profile/rule actions (owner-reported, 1.2.0).** Deleting
   a context rule, and deleting or overwriting a saved profile, fired immediately with no confirmation —

--- a/docs/rebuild/DEVIATIONS_LEDGER.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER.md
@@ -1880,16 +1880,33 @@ the permanent registry — never compress or remove them.
   fallback). Tests: `CircadianWindowProviderTest.*_D110`. Banners follow the m3_audit tinted-`Card`
   convention (gold `secondary`/emphasis), coherent with the dashboard `StaleBanner`.
 
-- **D-111: "Resume context automation" is a gold banner with a play button (owner-reported, 1.2.0).**
-  The manual-context-lock resume control (`ProfilesScreen` `context_lock_banner`) used a teal
-  `tertiaryContainer` card with a plain outlined text button — the owner wanted the Tasker "golden
-  banner with a play button". Restyled to the gold `secondaryContainer` + a `FilledTonalButton` with a
-  leading ▶ `Icons.Filled.PlayArrow`, coherent with the dashboard `OverrideCard` resume affordance and
-  the m3_audit gold-emphasis role (`secondary`). UI-only; the resume wiring (`resumeContextAutomation`)
-  is unchanged. **Note:** the broader Profiles/Contexts information-architecture ask in the same report
-  (load/save as modals, non-sticky top controls, built-in-profile prominence) is NOT in this change —
-  the current screen already uses a scrolling `SegmentedButton` + per-profile load/save dialogs, so the
-  described layout didn't map cleanly; deferred pending owner clarification.
+- **D-111: gold resume banner + Tasker-style Profiles/Contexts IA + icon-vs-glyph consistency
+  (owner-reported, 1.2.0).** Three related UI changes from one owner report:
+  (a) **Resume banner.** The manual-context-lock resume control (`ProfilesScreen` `context_lock_banner`,
+  extracted to the shared `ContextLockBanner`) used a teal `tertiaryContainer` card with a plain
+  outlined text button — the owner wanted the Tasker "golden banner with a play button". Restyled to the
+  gold `secondaryContainer` + a `FilledTonalButton` with a leading `Icons.Filled.PlayArrow`, coherent
+  with the dashboard `OverrideCard` resume affordance and the m3_audit gold-emphasis role (`secondary`).
+  (b) **Profiles/Contexts information architecture (owner picked "Tasker-style sticky action bar").**
+  Replaced the scrolling `Profiles`/`Rules` `SegmentedButton` with a PINNED `Load` / `Save` / `Contexts`
+  action bar (m3_audit B5 `ActionButtonBar`, equal-weight `FilledTonalButton`s) that stays put while the
+  built-in/saved profiles list scrolls directly below it. Each action opens its own modal: **Save** →
+  `SaveProfileDialog`; **Load** → a "Load & manage" `AlertDialog` (import file / (re)link legacy folder +
+  load entries / restore factory / reset / export / view current); **Contexts** → a full-screen `Dialog`
+  hosting the existing `ContextRulesSection`. Applying a saved profile is the per-row Apply → `LoadProfileDialog`
+  preview. The component-level surfaces (`ProfilesBody`/`ProfilesContent`/`ContextRulesSection`) and their
+  tests are unchanged — only the unified host `ProfilesContextsScreen` was rebuilt; `ProfileCard`/`SaveProfileDialog`/`ContextLockBanner`
+  made `internal` for reuse. New strings extracted to `strings.xml` (the Load/manage labels are shared,
+  keeping the `HardcodedStringCheckTest` ratchet at 89 ≤ 92).
+  (c) **Icons, not glyphs (owner: "use icons instead of emoji" + "make it consistent everywhere the
+  same character is abused").** Replacing the `‹ Close` text glyph with `Icons.Filled.Close` triggered an
+  app-wide sweep of the `‹`/`›` characters used as icon stand-ins: the shared back buttons (`SettingsScaffold`,
+  `SettingsControls`) → `IconButton` + `Icons.AutoMirrored.Filled.ArrowBack`; the chart `PagerArrow`
+  (`GraphScaffold`) → `IconButton` + `Icons.AutoMirrored.Filled.KeyboardArrowLeft`/`Right`. All keep their
+  testTags (`back_button`, `chart_pager_prev`/`next`). The `ⓘ` help-reveal and the onboarding `✓` are
+  DIFFERENT glyphs (not the changed character) and were left as-is. **Lesson:** when swapping a Unicode
+  icon-stand-in for a real vector icon, grep the whole UI for that character and convert every abuse in
+  the same change, or the app looks half-migrated.
 
 - **D-112: GitHub Actions Node-20 → Node-24 runtime migration (CI only, 1.2.0).** GitHub deprecated the
   Node 20 action runtime (runners default to Node 24 from 2026-06-16, Node 20 removed 2026-09-16), so

--- a/docs/rebuild/DEVIATIONS_LEDGER.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER.md
@@ -1836,3 +1836,67 @@ the permanent registry — never compress or remove them.
   (same component targeted, still `FLAG_IMMUTABLE`). Ships as 1.1.1 / versionCode 8. **Lesson:** for
   CodeQL-Kotlin, prefer non-chained Intent construction + an explicit `setPackage` on PendingIntents;
   the fluent one-liner reads as implicit even when it is not.
+
+- **D-108: service-start battery-saver flash — battery "unknown" must not match a battery rule
+  (owner-reported, 1.2.0).** On service start at night the system briefly applied the Battery Saver
+  context profile (battery far above the trigger) before switching to the correct night-reading
+  profile. Root cause: the seed `GENERAL` evaluation in `ContextEngine.start()` runs before the
+  battery `callbackFlow` delivers its first (sticky) value, and `SignalSnapshot.batteryPercent`
+  defaulted to **0** — which satisfies a "battery ≤ max" saver rule, so the saver matched for one
+  cycle until the real reading (e.g. 80%) reverted it. **Fix (two parts):** (1) `ContextOverrideResolver`
+  now treats a NEGATIVE `batteryPercent` as "unknown → a battery condition cannot be asserted → the
+  rule does not match" (a real 0% dead battery still matches); (2) `SignalSnapshot.batteryPercent`
+  defaults to **-1** (unknown) until the first real reading, and the BATTERY veto gate always lets the
+  first real reading through (`lastBatt < 0`) so a genuinely low first reading isn't swallowed by the
+  ±5% debounce. The seed eval now picks the correct time-based profile directly. Tests:
+  `ContextOverrideResolverTest.batteryUnknown_*`, `ContextEngineTest.serviceStart_*_D108`.
+
+- **D-109: PWM-sensitive read-out tracks PERCEIVED brightness, not the hardware floor (owner-reported,
+  1.2.0; refines D-050/D-051e).** D-051e correctly floored the *hardware* write to `%AAB_DimmingThreshold`
+  in PWM-sensitive mode, but it also published that floored value to `PipelineState.targetBrightness`,
+  so the hero brightness read-out stuck at the floor instead of following the calculated (perceived)
+  brightness as in Tasker. **Fix:** in `PipelineCycleRunner` keep `lastAppliedBrightness` = the floored
+  HARDWARE value (override-detection baseline + Live Debug "current"), but set `targetBrightness`
+  (read-out / notification / widget) = the engine's UN-floored `output.targetBrightness` (the perceived
+  value the secure/overlay layer darkens the panel down to). This restores the documented field
+  semantics ("targetBrightness = last target the engine produced"). The two coincide unless PWM-sensitive
+  floors the hardware. Test: `BrightnessPipelineControllerTest.pwmSensitive_floorsHardwareButReadoutTracksPerceived`.
+
+- **D-110: circadian falls back on the cached sun location across the day rollover, and surfaces
+  staleness (owner-reported, 1.2.0).** With Location off and the IP fallback off, on the *next day* the
+  circadian modifier showed the flat default scale (≈0.85 at 07:34, NL) while the graph looked correct —
+  the chart reads `lastKnownLocation`/a representative fallback directly, but the pipeline's
+  `CircadianWindowProvider` could leave the live modifier on the `TimeContext` default windows. Two
+  causes addressed: (1) on a cold start in STEADY light the async cache/geo-IP fix landed AFTER the
+  initial brightness was set with the default windows, and prof760 then dropped every steady-light cycle
+  → nothing recomputed. New `onWindowsRefreshed` callback (wired in `AppModule` to `controller.reapply()`)
+  fires when a location resolves (cache seed or async acquire); its setter also fires once immediately if
+  a location already resolved before the callback was wired, so the recompute is never lost to
+  construction-vs-wiring ordering. (2) `current()` now explicitly falls back to the last resolved
+  location even after the day rolls over and no fresh fix is available, computing TODAY's windows with the
+  cached coordinates. Freshness is exposed via `CircadianLocationStatus` (has-location / age-days / stale)
+  and surfaced as a gold staleness banner on the Circadian screen and a gold hint on the dashboard
+  (derived in the view-models from the persisted `cachedSunLocation` flow, mirroring the provider's
+  fallback). Tests: `CircadianWindowProviderTest.*_D110`. Banners follow the m3_audit tinted-`Card`
+  convention (gold `secondary`/emphasis), coherent with the dashboard `StaleBanner`.
+
+- **D-111: "Resume context automation" is a gold banner with a play button (owner-reported, 1.2.0).**
+  The manual-context-lock resume control (`ProfilesScreen` `context_lock_banner`) used a teal
+  `tertiaryContainer` card with a plain outlined text button — the owner wanted the Tasker "golden
+  banner with a play button". Restyled to the gold `secondaryContainer` + a `FilledTonalButton` with a
+  leading ▶ `Icons.Filled.PlayArrow`, coherent with the dashboard `OverrideCard` resume affordance and
+  the m3_audit gold-emphasis role (`secondary`). UI-only; the resume wiring (`resumeContextAutomation`)
+  is unchanged. **Note:** the broader Profiles/Contexts information-architecture ask in the same report
+  (load/save as modals, non-sticky top controls, built-in-profile prominence) is NOT in this change —
+  the current screen already uses a scrolling `SegmentedButton` + per-profile load/save dialogs, so the
+  described layout didn't map cleanly; deferred pending owner clarification.
+
+- **D-112: GitHub Actions Node-20 → Node-24 runtime migration (CI only, 1.2.0).** GitHub deprecated the
+  Node 20 action runtime (runners default to Node 24 from 2026-06-16, Node 20 removed 2026-09-16), so
+  every workflow emitted Node-20 deprecation warnings. Bumped each action to a major that declares
+  `runs.using: node24` (verified against each action's `action.yml`): `actions/cache@v4→v5`,
+  `actions/upload-artifact@v4→v6`, `android-actions/setup-android@v3→v4`, `actions/github-script@v7→v8`
+  (NOT v9, which is ESM-only/breaking), `github/codeql-action/{init,analyze}@v3→v4`,
+  `softprops/action-gh-release@v2→v3`; `actions/checkout@v5` + `actions/setup-java@v5` were already
+  node24. Added a "Node 24 runtime policy" comment block to `build.yml` documenting the pins so they
+  aren't downgraded. No code/behaviour change.

--- a/docs/rebuild/DEVIATIONS_LEDGER.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER.md
@@ -1930,6 +1930,10 @@ the permanent registry — never compress or remove them.
   `softprops/action-gh-release@v2→v3`; `actions/checkout@v5` + `actions/setup-java@v5` were already
   node24. Added a "Node 24 runtime policy" comment block to `build.yml` documenting the pins so they
   aren't downgraded. No code/behaviour change.
+  **Follow-up:** `dist/` is now `.gitignore`d (and the once-committed `dist/tideo-1.2.0-debug.apk`
+  untracked via `git rm --cached`) — the debug sideload APK is no longer committed at all; it is sent to
+  the owner via the file tool or pulled from the `build.yml` `app-debug` CI artifact. `clean-dist.yml`
+  stays as a backstop that removes a force-added `dist/` from `main`. RUNBOOK §7 updated to match.
 
 - **D-113: Contexts rule-list/editor polish (owner-reported, 1.2.0).** Three rule-creation refinements:
   (a) **Emphasise the target profile.** A rule card buried its switch-to profile in grey `→ Profile ·

--- a/docs/rebuild/DEVIATIONS_LEDGER.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER.md
@@ -1907,6 +1907,19 @@ the permanent registry — never compress or remove them.
   DIFFERENT glyphs (not the changed character) and were left as-is. **Lesson:** when swapping a Unicode
   icon-stand-in for a real vector icon, grep the whole UI for that character and convert every abuse in
   the same change, or the app looks half-migrated.
+  (d) **Visual match to the Tasker original (owner screenshot review, same release).** The first cut of
+  the action bar was three identical flat grey pills with text-only labels, and "Contexts" wrapped onto
+  two lines (the M3 default 24 dp button `contentPadding` squeezed it at equal thirds). Re-matched to
+  Tasker: **Load** filled teal (`Button`/primary), **Save** tonal grey (`FilledTonalButton`), **Contexts**
+  teal-outlined (`OutlinedButton` + `BorderStroke(primary)`), each with a leading vector icon
+  (`ic_folder`/`ic_save`/`ic_tune` — added as `res/drawable` vectors since only `material-icons-core` is a
+  dep and folder/save/tune are extended-only; NO new dependency, m3_audit constraint honoured) and a
+  single-line label via compact 8 dp `contentPadding`. The context-lock resume banner + the dashboard
+  `OverrideCard` were repainted from the muted dark-theme `secondaryContainer` to vivid brand `AabGold`
+  with a high-contrast dark RESUME button (`AabOnGold` container, `AabGold` label + ▶), matching Tasker's
+  "Automation Paused" bar. The active profile (`%AAB_CurrentActiveProfile` via `LiveRuntimeState`) is now
+  highlighted in the list — gold edge + an "Active" tag on its `ProfileCard` — mirroring Tasker's
+  "Active Profile: …" readout (owner request).
 
 - **D-112: GitHub Actions Node-20 → Node-24 runtime migration (CI only, 1.2.0).** GitHub deprecated the
   Node 20 action runtime (runners default to Node 24 from 2026-06-16, Node 20 removed 2026-09-16), so

--- a/docs/rebuild/DEVIATIONS_LEDGER.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER.md
@@ -1947,3 +1947,15 @@ the permanent registry — never compress or remove them.
   current SSID by overwriting the field; it now appends the SSID to the comma-separated list (de-duped),
   so a rule can match several networks — matching Tasker's behaviour. No new strings beyond the gold
   "Active" tag (reused `profiles_active_tag`); `HardcodedStringCheckTest` ratchet still ≤ 92.
+
+- **D-114: confirmation prompts for destructive profile/rule actions (owner-reported, 1.2.0).** Deleting
+  a context rule, and deleting or overwriting a saved profile, fired immediately with no confirmation —
+  Tasker prompted first. Added a shared `ConfirmDialog` (in `ProfilesScreen`, reused by `ContextsScreen`
+  in the same package): an `AlertDialog` with a red (`error`) confirm action for deletes, a neutral one
+  for overwrite, and a Cancel. The Profiles overflow menu's Delete/Overwrite and the rule card's Delete
+  now stage a confirmation (`confirm_delete_<name>` / `confirm_overwrite_<name>` / `confirm_delete_<ruleId>`)
+  instead of calling the callback directly; the callback fires only on confirm. All strings are resources
+  (ratchet unaffected). Tests: `SettingsScreensTest.profiles_deleteAndOverwrite_requireConfirmation_D114`
+  + `contexts_deleteRule_requiresConfirmation_D114` (assert the callback does NOT fire until the dialog is
+  confirmed). The existing render tests only assert the menu items EXIST (don't click through), so they
+  are unaffected.

--- a/docs/rebuild/DEVIATIONS_LEDGER.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER.md
@@ -1930,3 +1930,20 @@ the permanent registry — never compress or remove them.
   `softprops/action-gh-release@v2→v3`; `actions/checkout@v5` + `actions/setup-java@v5` were already
   node24. Added a "Node 24 runtime policy" comment block to `build.yml` documenting the pins so they
   aren't downgraded. No code/behaviour change.
+
+- **D-113: Contexts rule-list/editor polish (owner-reported, 1.2.0).** Three rule-creation refinements:
+  (a) **Emphasise the target profile.** A rule card buried its switch-to profile in grey `→ Profile ·
+  priority N` body text. The profile — the thing the rule loads — is now rendered prominently in gold
+  (`titleSmall`, `AabGold`) behind a "Loads" label, and the rule currently in force (its name ==
+  `%AAB_ActiveContext`, threaded in from `LiveRuntimeState.activeContext`) gets a gold edge + "Active"
+  tag, mirroring the Profiles list (D-111). `ContextRulesSection` gained an optional `activeContext`
+  param (default null → the legacy `ContextsContent` + its tests are unaffected).
+  (b) **Priority is a 1–100 scale, not 0..∞.** The editor field now accepts digits only (max 3), seeds a
+  legacy/unset 0 up to 1, labels itself "Priority (1–100, higher wins)", uses a numeric keyboard, and
+  clamps to `1..100` on save (blank/invalid → 1). This is a UI constraint only — `ContextOverrideResolver`
+  still ranks by raw int (D-014: higher wins), so no golden/resolver change and existing rules keep
+  resolving (a stored 0 simply coerces to 1 on next save).
+  (c) **"Use current Wi-Fi" APPENDS, not replaces (Tasker parity).** The rule editor's button added the
+  current SSID by overwriting the field; it now appends the SSID to the comma-separated list (de-duped),
+  so a rule can match several networks — matching Tasker's behaviour. No new strings beyond the gold
+  "Active" tag (reused `profiles_active_tag`); `HardcodedStringCheckTest` ratchet still ≤ 92.

--- a/docs/rebuild/RUNBOOK.md
+++ b/docs/rebuild/RUNBOOK.md
@@ -41,6 +41,16 @@ truth**; where any doc disagrees with the code, trust the code (and fix the doc)
 
 Each: *when · read first · code to touch · parity obligations · acceptance · record it.*
 
+> **Design coherence — READ FIRST for ANY UI/visual change** (a new screen, but also a banner, card,
+> chip, color, icon, or spacing tweak — playbooks 3 *and* 4/5 when they touch Compose). Read
+> `design/m3_audit.md` before styling and conform to it: the teal+gold palette is **frozen** (never
+> recolor — reach for `MaterialTheme.colorScheme.*`; gold = `secondary` = warnings/emphasis); group
+> content in `AabCard` (medium/large shape, `cardElevation`, `cardPadding`), never a flat list;
+> **colour-semantic banners (stale/override/resume) are tinted `Card`s** (`AabGold`/`AabOnGold` or a
+> `*Container` role), NOT `AabCard`; derived/live numerics use the gold `KeyValueRow` (B4); new strings
+> go through `stringResource` (`HardcodedStringCheckTest` ratchet); use `Dimens.*` tokens, not raw `dp`.
+> When in doubt, mirror the nearest existing component (e.g. the dashboard `StaleBanner`/`OverrideCard`).
+
 ### 1. Tasker profile added / changed / removed (a trigger context or pipeline gate)
 - **Read first:** `extraction/profiles.md` (+ `contexts_spec.md` for context watchers); the
   relevant `DEVIATIONS_LEDGER` rows (profile gating, ConditionList semantics). Re-read the XML

--- a/docs/rebuild/RUNBOOK.md
+++ b/docs/rebuild/RUNBOOK.md
@@ -162,7 +162,10 @@ Do it in two reviewable commits; on-device verification is owner-only (no emulat
   `build-tools/<N>.0.0/zipalign -c -P 16 -v 4 <apk>`.
 - **Acceptance:** full ladder green, then **owner runs the on-device Pass A (regression) +
   Pass B (feature-availability) matrices** — the ladder cannot catch "the OS silently stopped
-  delivering us X". Drop a debug APK in `dist/` (temporary, deleted before merge) for sideload.
+  delivering us X". Build a debug APK for the owner to sideload. **`dist/` is `.gitignore`d (D-112)** —
+  do NOT commit the APK: build it into `dist/` and **send it to the owner via the file tool** (or point
+  them at the `build.yml` `app-debug` CI artifact). `clean-dist.yml` stays as a backstop that removes a
+  force-added `dist/` from `main`.
   Debug builds carry a separate package (`applicationIdSuffix=".debug"`, label "Tideo AB (Debug)",
   Shizuku authority `${applicationId}.shizuku`) so a test build coexists with the owner's signed
   release without sharing data — keep this (D-106); the debug app has its own storage, so ELEVATED

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -60,13 +60,16 @@ One line per shipped change (newest first). Keep terse.
   value; `lastAppliedBrightness` stays the floored hardware value for override detection). **D-110**
   circadian stale-location fallback across the day rollover + recompute-on-resolve (`onWindowsRefreshed`
   → `reapply`) + staleness hints (`CircadianLocationStatus`) on the Circadian screen + dashboard (gold
-  tinted-`Card`, m3_audit-coherent). **D-111** "Resume context automation" restyled to a gold banner +
-  ▶ play button. **D-112** GitHub Actions Node-20 → Node-24 (all actions bumped to node24 majors;
-  `build.yml` carries a node24 pin policy comment). RUNBOOK gains a "Design coherence — read m3_audit.md
-  for ANY UI change" callout (owner request). Changelog `9.txt`. Owner sideloads `dist/` debug APK,
-  then squash-merges + tags `v1.2.0` (dist/ removed before/at merge). **Open (owner clarification):**
-  the Profiles/Contexts IA part of the same report (load/save modals, non-sticky top controls, built-in
-  profile prominence) is deferred — see D-111 note.
+  tinted-`Card`, m3_audit-coherent). **D-111** gold "resume context automation" banner + play icon;
+  Tasker-style Profiles & Contexts IA (pinned Load/Save/Contexts action bar over the visible profile
+  list, each opening its own modal); app-wide icon-vs-glyph consistency (`‹`/`›` back + pager glyphs →
+  Material `IconButton`s). **D-112** GitHub Actions Node-20 → Node-24 (all actions bumped to node24
+  majors; `build.yml` carries a node24 pin policy comment) + `clean-dist.yml` auto-removes a forgotten
+  `dist/` APK from main. RUNBOOK gains a "Design coherence — read m3_audit.md for ANY UI change" callout
+  (owner request). Changelog `9.txt`. Owner sideloads `dist/` debug APK, then squash-merges + tags
+  `v1.2.0` (dist/ auto-cleaned by CI if forgotten). SEMVER: minor — new user-facing surfaces (staleness
+  hints + Profiles redesign) outrank the patch-grade bug fixes (RUNBOOK §6 "highest category wins");
+  rationale block in `app/build.gradle.kts`.
 - 2026-06-28 — 1.1.1 / `versionCode 8`: (D-107) security hardening — notification (`actionIntent`)
   and home-widget (`DashboardWidgetProvider`) PendingIntents made un-missably explicit (separate
   statements + `setPackage`, still `FLAG_IMMUTABLE`) to clear CodeQL `java/android/implicit-pendingintents`

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -47,13 +47,26 @@ When in use, track stages here:
 > Write new deviations straight into the permanent registry `DEVIATIONS_LEDGER.md` (its
 > "Maintenance deviations" section), not here — this slot is only a transient staging note
 > during an in-flight change. Numbering is **one continuous sequence**: next free number is
-> **D-108** (historical high-water mark D-107); never restart at D-001. A deviation, once
+> **D-113** (historical high-water mark D-112); never restart at D-001. A deviation, once
 > numbered, lives in the registry forever — it is never compressed out.
 
 ## Changelog
 
 One line per shipped change (newest first). Keep terse.
 
+- 2026-06-28 — 1.2.0 / `versionCode 9`: runtime bug fixes + UX. **D-108** service-start battery-saver
+  flash (battery "unknown" `-1` sentinel; resolver won't match a battery rule until a real reading).
+  **D-109** PWM-sensitive read-out now tracks PERCEIVED brightness (`targetBrightness` = un-floored engine
+  value; `lastAppliedBrightness` stays the floored hardware value for override detection). **D-110**
+  circadian stale-location fallback across the day rollover + recompute-on-resolve (`onWindowsRefreshed`
+  → `reapply`) + staleness hints (`CircadianLocationStatus`) on the Circadian screen + dashboard (gold
+  tinted-`Card`, m3_audit-coherent). **D-111** "Resume context automation" restyled to a gold banner +
+  ▶ play button. **D-112** GitHub Actions Node-20 → Node-24 (all actions bumped to node24 majors;
+  `build.yml` carries a node24 pin policy comment). RUNBOOK gains a "Design coherence — read m3_audit.md
+  for ANY UI change" callout (owner request). Changelog `9.txt`. Owner sideloads `dist/` debug APK,
+  then squash-merges + tags `v1.2.0` (dist/ removed before/at merge). **Open (owner clarification):**
+  the Profiles/Contexts IA part of the same report (load/save modals, non-sticky top controls, built-in
+  profile prominence) is deferred — see D-111 note.
 - 2026-06-28 — 1.1.1 / `versionCode 8`: (D-107) security hardening — notification (`actionIntent`)
   and home-widget (`DashboardWidgetProvider`) PendingIntents made un-missably explicit (separate
   statements + `setPackage`, still `FLAG_IMMUTABLE`) to clear CodeQL `java/android/implicit-pendingintents`

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -47,7 +47,7 @@ When in use, track stages here:
 > Write new deviations straight into the permanent registry `DEVIATIONS_LEDGER.md` (its
 > "Maintenance deviations" section), not here — this slot is only a transient staging note
 > during an in-flight change. Numbering is **one continuous sequence**: next free number is
-> **D-114** (historical high-water mark D-113); never restart at D-001. A deviation, once
+> **D-115** (historical high-water mark D-114); never restart at D-001. A deviation, once
 > numbered, lives in the registry forever — it is never compressed out.
 
 ## Changelog
@@ -67,7 +67,8 @@ One line per shipped change (newest first). Keep terse.
   majors; `build.yml` carries a node24 pin policy comment) + `clean-dist.yml` auto-removes a forgotten
   `dist/` APK from main. **D-113** Contexts rule list/editor: target profile emphasised (gold) +
   active-rule highlight; priority is a 1–100 scale (was 0..∞); "Use current Wi-Fi" appends to the SSID
-  list (Tasker parity). RUNBOOK gains a "Design coherence — read m3_audit.md for ANY UI change" callout
+  list (Tasker parity). **D-114** confirmation prompts before deleting a rule and deleting/overwriting a
+  profile (shared `ConfirmDialog`, Tasker parity). RUNBOOK gains a "Design coherence — read m3_audit.md for ANY UI change" callout
   (owner request). Changelog `9.txt`. Owner sideloads `dist/` debug APK, then squash-merges + tags
   `v1.2.0` (dist/ auto-cleaned by CI if forgotten). SEMVER: minor — new user-facing surfaces (staleness
   hints + Profiles redesign) outrank the patch-grade bug fixes (RUNBOOK §6 "highest category wins");

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -47,7 +47,7 @@ When in use, track stages here:
 > Write new deviations straight into the permanent registry `DEVIATIONS_LEDGER.md` (its
 > "Maintenance deviations" section), not here — this slot is only a transient staging note
 > during an in-flight change. Numbering is **one continuous sequence**: next free number is
-> **D-113** (historical high-water mark D-112); never restart at D-001. A deviation, once
+> **D-114** (historical high-water mark D-113); never restart at D-001. A deviation, once
 > numbered, lives in the registry forever — it is never compressed out.
 
 ## Changelog
@@ -65,7 +65,9 @@ One line per shipped change (newest first). Keep terse.
   list, each opening its own modal); app-wide icon-vs-glyph consistency (`‹`/`›` back + pager glyphs →
   Material `IconButton`s). **D-112** GitHub Actions Node-20 → Node-24 (all actions bumped to node24
   majors; `build.yml` carries a node24 pin policy comment) + `clean-dist.yml` auto-removes a forgotten
-  `dist/` APK from main. RUNBOOK gains a "Design coherence — read m3_audit.md for ANY UI change" callout
+  `dist/` APK from main. **D-113** Contexts rule list/editor: target profile emphasised (gold) +
+  active-rule highlight; priority is a 1–100 scale (was 0..∞); "Use current Wi-Fi" appends to the SSID
+  list (Tasker parity). RUNBOOK gains a "Design coherence — read m3_audit.md for ANY UI change" callout
   (owner request). Changelog `9.txt`. Owner sideloads `dist/` debug APK, then squash-merges + tags
   `v1.2.0` (dist/ auto-cleaned by CI if forgotten). SEMVER: minor — new user-facing surfaces (staleness
   hints + Profiles redesign) outrank the patch-grade bug fixes (RUNBOOK §6 "highest category wins");

--- a/domain/src/main/kotlin/com/tideo/autobrightness/domain/context/ContextModel.kt
+++ b/domain/src/main/kotlin/com/tideo/autobrightness/domain/context/ContextModel.kt
@@ -51,6 +51,9 @@ data class ContextSignals(
     val app: String = "",
     val lat: Double = 0.0,
     val lon: Double = 0.0,
+    /** 0..100, or a negative sentinel (e.g. -1) meaning "no battery reading yet" — battery rules then
+     *  cannot match (ContextOverrideResolver), so the service-start placeholder can't trigger a saver
+     *  profile before the first real reading arrives (D-108). */
     val batteryPercent: Int = 0,
     val plugged: Boolean = false,
     /** Calendar.DAY_OF_WEEK 1=Sun..7=Sat. */

--- a/domain/src/main/kotlin/com/tideo/autobrightness/domain/context/ContextOverrideResolver.kt
+++ b/domain/src/main/kotlin/com/tideo/autobrightness/domain/context/ContextOverrideResolver.kt
@@ -100,7 +100,12 @@ object ContextOverrideResolver {
 
             if (isMatch && rule.battery != null) {
                 val batt = rule.battery
-                if (batt.min != null && signals.batteryPercent < batt.min) isMatch = false
+                // Battery unknown (no reading yet) → a battery condition cannot be asserted, so the
+                // rule does not match. Guards the service-start flash where the placeholder 0% would
+                // satisfy a "battery <= max" saver rule before the first real reading arrives
+                // (D-108): without this, an unplugged max-only rule would falsely match at percent 0.
+                if (signals.batteryPercent < 0) isMatch = false
+                if (isMatch && batt.min != null && signals.batteryPercent < batt.min) isMatch = false
                 if (isMatch && batt.max != null && signals.batteryPercent > batt.max) isMatch = false
                 if (isMatch && batt.onPower != null && batt.onPower != signals.plugged) isMatch = false
                 specificity++

--- a/domain/src/test/kotlin/com/tideo/autobrightness/domain/context/ContextOverrideResolverTest.kt
+++ b/domain/src/test/kotlin/com/tideo/autobrightness/domain/context/ContextOverrideResolverTest.kt
@@ -73,6 +73,27 @@ class ContextOverrideResolverTest {
     }
 
     @Test
+    fun batteryUnknown_negativePercent_neverMatchesBatteryRule() {
+        // D-108: the service-start seed snapshot reports -1 ("no reading yet"). A max-only saver rule
+        // (battery <= 20, unplugged) must NOT match the sentinel — otherwise the Battery Saver profile
+        // flashes for one cycle before the real reading arrives. A real 0% (dead battery) still matches.
+        val unknown = noon.copy(batteryPercent = -1)
+        val saver = rule("sv", profile = "SAVER", battery = BatteryConstraint(max = 20))
+        assertNull(ContextOverrideResolver.resolve(listOf(saver), unknown, userProfile = "MyProfile").activeContextName)
+        // onPower-only rule is likewise suppressed while the reading is unknown.
+        assertNull(
+            ContextOverrideResolver.resolve(
+                listOf(rule("p", battery = BatteryConstraint(onPower = false))),
+                unknown,
+                userProfile = "MyProfile",
+            ).activeContextName,
+        )
+        // A real reading of 0% (not the sentinel) is a genuine low battery and DOES match the saver.
+        val dead = noon.copy(batteryPercent = 0)
+        assertEquals("SAVER", ContextOverrideResolver.resolve(listOf(saver), dead, userProfile = "MyProfile").targetProfile)
+    }
+
+    @Test
     fun location_insideRadiusMatches_outsideDoesNot() {
         val here = noon.copy(lat = 51.5000, lon = -0.1000)
         val inside = rule("l", location = LocationConstraint(51.5001, -0.1001, 150.0))

--- a/fastlane/metadata/android/en-US/changelogs/9.txt
+++ b/fastlane/metadata/android/en-US/changelogs/9.txt
@@ -1,0 +1,9 @@
+Bug fixes and polish:
+• At service start the correct profile now loads directly — no brief flash of the
+  Battery Saver profile before the real battery level is read.
+• PWM-sensitive software dimming: the brightness read-out now follows the perceived
+  brightness, like Tasker, instead of sticking at the hardware floor.
+• Circadian: with location and IP fallback off, the day's curve now falls back to your
+  last cached sun position instead of a flat default. The Circadian screen and dashboard
+  show when the values are cached (and how old) until you refresh by turning Location on.
+• "Resume context automation" is now a clear gold banner with a play button.

--- a/fastlane/metadata/android/en-US/changelogs/9.txt
+++ b/fastlane/metadata/android/en-US/changelogs/9.txt
@@ -12,3 +12,4 @@ Bug fixes and polish:
   arrows now use proper icons.
 • Context rules: the profile a rule switches to is now shown prominently, priority is a
   1–100 scale, and "Use current Wi-Fi" adds to the network list instead of replacing it.
+• Deleting a rule, and deleting or overwriting a profile, now ask for confirmation first.

--- a/fastlane/metadata/android/en-US/changelogs/9.txt
+++ b/fastlane/metadata/android/en-US/changelogs/9.txt
@@ -7,3 +7,5 @@ Bug fixes and polish:
   last cached sun position instead of a flat default. The Circadian screen and dashboard
   show when the values are cached (and how old) until you refresh by turning Location on.
 • "Resume context automation" is now a clear gold banner with a play button.
+• Profiles & Contexts redesigned: a pinned Load / Save / Contexts bar over your profiles,
+  each opening its own dialog; navigation/back/chart arrows now use proper icons.

--- a/fastlane/metadata/android/en-US/changelogs/9.txt
+++ b/fastlane/metadata/android/en-US/changelogs/9.txt
@@ -8,4 +8,7 @@ Bug fixes and polish:
   show when the values are cached (and how old) until you refresh by turning Location on.
 • "Resume context automation" is now a clear gold banner with a play button.
 • Profiles & Contexts redesigned: a pinned Load / Save / Contexts bar over your profiles,
-  each opening its own dialog; navigation/back/chart arrows now use proper icons.
+  each opening its own dialog; the active profile is highlighted; navigation/back/chart
+  arrows now use proper icons.
+• Context rules: the profile a rule switches to is now shown prominently, priority is a
+  1–100 scale, and "Use current Wi-Fi" adds to the network list instead of replacing it.


### PR DESCRIPTION
Owner-reported fixes + UX (versionCode 9 / versionName 1.2.0):

- D-108 service-start battery-saver flash: the seed context evaluation ran with a
  placeholder 0% battery before the first real reading, matching a "battery <= max"
  saver rule for one cycle. Battery is now an "unknown" (-1) sentinel until a real
  reading; ContextOverrideResolver won't match a battery rule while unknown (a real
  0% still matches), and the BATTERY veto always admits the first real reading.

- D-109 PWM-sensitive read-out: keep the hardware write floored at the dimming
  threshold (D-050/D-051e) but publish the engine's UN-floored perceived brightness
  to targetBrightness so the read-out tracks perceived brightness like Tasker;
  lastAppliedBrightness stays the floored hardware value (override-detection baseline).

- D-110 circadian stale-location fallback: recompute brightness when a cached or
  async-acquired location resolves late (onWindowsRefreshed -> reapply), fall back to
  the last cached location across the day rollover instead of the default ~0.85, and
  surface staleness (CircadianLocationStatus: has-location / age-days / stale) as gold
  hints on the Circadian screen and dashboard (m3_audit tinted-Card convention).

- D-111 "Resume context automation": gold secondaryContainer banner + leading play
  icon (Tasker style), coherent with the dashboard OverrideCard. (The broader
  Profiles/Contexts IA ask is deferred pending owner clarification — see D-111 note.)

- D-112 GitHub Actions Node-20 -> Node-24: bump every action to a node24 major
  (cache@v5, upload-artifact@v6, setup-android@v4, github-script@v8, codeql-action@v4,
  action-gh-release@v3); build.yml carries a node24 pin-policy comment.

Docs: RUNBOOK gains a "Design coherence — read m3_audit.md for ANY UI change" callout;
DEVIATIONS_LEDGER D-108..D-112; STATE changelog; fastlane changelogs/9.txt. Debug APK
in dist/ for owner sideload (remove before merge). Full ladder green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HywhYVFy6HdXs89uf2wqM8