### PR TITLE
ci: per-job timeouts + wrapper file in Gradle cache keys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30  # cap a hung Gradle daemon / SDK fetch (GitHub's default is 360)
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -53,7 +54,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts', 'gradle/libs.versions.toml') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts', 'gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
 
       # The CLAUDE.md acceptance ladder: domain + platform + app tests, lint (hard gate), debug APK.

--- a/.github/workflows/clean-dist.yml
+++ b/.github/workflows/clean-dist.yml
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   clean:
     runs-on: ubuntu-latest
+    timeout-minutes: 10  # quick git op; cap a hang
     steps:
       - name: Checkout
         uses: actions/checkout@v5  # node24 runtime (see build.yml node24 policy)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,7 @@ jobs:
   analyze:
     name: Analyze (java-kotlin)
     runs-on: ubuntu-latest
+    timeout-minutes: 30  # cap a hung analysis (GitHub's default is 360)
     permissions:
       security-events: write  # upload results to the Security tab
       contents: read
@@ -58,7 +59,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts', 'gradle/libs.versions.toml') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts', 'gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
 
       - name: Initialize CodeQL

--- a/.github/workflows/redirect-external-prs.yml
+++ b/.github/workflows/redirect-external-prs.yml
@@ -24,6 +24,7 @@ jobs:
       github.event.pull_request.user.login != 'faded-penguin021' &&
       github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
+    timeout-minutes: 10  # single github-script comment + label; cap a hang
     steps:
       - name: Comment and label for triage
         uses: actions/github-script@v8

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -28,6 +28,7 @@ concurrency:
 jobs:
   preflight:
     runs-on: ubuntu-latest
+    timeout-minutes: 10  # pure shell + gh, runs in seconds; cap a hung gh call
     steps:
       - name: Checkout (full history + tags)
         uses: actions/checkout@v5

--- a/.github/workflows/release-signing.yml
+++ b/.github/workflows/release-signing.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   build-signed-apk:
     runs-on: ubuntu-latest
+    timeout-minutes: 30  # cap a hung build/sign step (GitHub's default is 360)
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -34,7 +35,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts', 'gradle/libs.versions.toml') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts', 'gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
 
       # Acceptance ladder (CLAUDE.md) — fail before we sign a broken build.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30  # cap a hung build/sign step (GitHub's default is 360)
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -65,7 +66,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts', 'gradle/libs.versions.toml') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts', 'gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
 
       # Acceptance ladder (CLAUDE.md) — never cut a release from a broken tree.

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -34,6 +34,11 @@ How changes are made now: see `RUNBOOK.md` (change-type playbooks). The migratio
 
 One line per shipped change (newest first). Keep terse.
 
+- 2026-06-29 — CI-only (no app/version change): workflow hygiene — `timeout-minutes` on every job (caps a
+  hung Gradle daemon / SDK fetch / `gh` call vs GitHub's 360-min default) and `gradle/wrapper/gradle-wrapper.properties`
+  added to the 4 Gradle cache keys (a wrapper bump no longer reuses a stale cache). Prompted by a workflow
+  review; the higher-ceremony suggestions (strict dependency verification, action SHA-pinning, a Gradle
+  task for versionCode) were deliberately declined as wrong cost/benefit for a solo F-Droid app.
 - 2026-06-29 — 1.5.0 / `versionCode 13` (MINOR — observable user-facing behaviour): **D-125** the Curve &
   Brightness screen no longer auto-draws a suggested curve whenever ≥ 9 override points exist. The suggestion
   is now **user-driven** (Tasker task38→preview→task655 parity): the Tools wizard's "Preview graph" stashes


### PR DESCRIPTION
## Summary
Two cheap CI-hygiene wins from a workflow review — both pure upside, no behaviour change.

## Release impact
None (CI only — no app code, no version bump).

## Verification
No app code changed, so the Gradle acceptance ladder has nothing to exercise. Validated all 7 workflows parse as YAML and confirmed every job now carries a `timeout-minutes` and the 4 Gradle caches key on the wrapper file. The `preflight` gate should pass: this PR touches only `.github/` + `docs/`, so it's classified non-shipping (version/changelog checks skipped), and no commit message / PR title carries a CI-skip token.

## Repo hygiene
- **`timeout-minutes` on every job** — build / release / release-signing / codeql = 30; preflight / clean-dist / triage = 10. Caps a hung Gradle daemon, SDK fetch, or `gh` call instead of letting it run to GitHub's 360-minute default.
- **`gradle/wrapper/gradle-wrapper.properties` added to the 4 Gradle cache keys** (build, codeql, release, release-signing) — a Gradle wrapper bump no longer risks reusing a stale cache.

**Deliberately declined** (wrong cost/benefit for a solo F-Droid app, rationale in the STATE changelog):
- _Strict Gradle dependency verification_ — high-churn `verification-metadata.xml` with AGP, and the released-APK integrity comes from keystore signing + F-Droid's own source rebuild, not build-time dep verification.
- _Action SHA-pinning_ — only worthwhile on the signing workflow and only paired with Dependabot, else it silently strands you on a vulnerable action; collides with the deliberate Node-24 major-pin policy.
- _A `printVersionCode` Gradle task instead of grep_ — would force JDK+SDK+Gradle setup into the deliberately fast, SDK-free preflight gate to read one stable `versionCode = N` line.

## Owner action
Squash-merge to `main`. No release implications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yRfDnE23rbzGzhCewiDhX

---
_Generated by [Claude Code](https://claude.ai/code/session_018yRfDnE23rbzGzhCewiDhX)_