### PR TITLE
docs: F-Droid changelog 500-char limit + runbook update

### DIFF
--- a/docs/rebuild/RUNBOOK.md
+++ b/docs/rebuild/RUNBOOK.md
@@ -152,7 +152,9 @@ so check it explicitly.
     re-used code). Bump by 1 from the highest code ever shipped, not from the last tag's code if
     that tag forgot to bump. (versionCode is always +1 regardless of which semver field moved.)
 - **F-Droid changelog:** add `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt` (the
-  filename is the **versionCode**, not the name) with a short user-facing note. **`release.yml`
+  filename is the **versionCode**, not the name) with a short user-facing note. **Keep it under 500
+  characters** (whole file incl. the trailing newline — aim ≤ 480 for margin): F-Droid's code-quality
+  scan flags a longer `whatsNew` as a Minor finding (`wc -c` the file before committing). **`release.yml`
   auto-reuses this file as the GitHub Release's "What's new" section (D-123)** — it reads the tagged
   build's `versionCode`, looks up the matching changelog, and slots it between the owner's UI summary
   and GitHub's auto "What's Changed". So the owner no longer hand-copies the changelog into the release

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -67,10 +67,11 @@ registry stays live.
 
 One line per shipped change (newest first). Keep terse; details live in the ledger.
 
-- 2026-07-05 — docs/metadata only (F-Droid code-quality scan): `changelogs/17.txt` trimmed
-  972→472 chars (F-Droid flags `whatsNew` ≥ 500 as Minor). RUNBOOK F-Droid-changelog bullet gains
-  the <500-char rule. No fdroiddata change needed — the `whatsNew` is read from the app repo's
-  fastlane tree at the pinned build commit.
+- 2026-07-05 — docs-only (F-Droid code-quality scan): RUNBOOK F-Droid-changelog bullet gains the
+  <500-char `whatsNew` rule (F-Droid flags ≥ 500 as Minor). `changelogs/17.txt` left at 972 chars —
+  vc17 is already tagged, so the fix would need a release re-cut for a cosmetic Minor; the rule
+  keeps vc18+ within the limit. No fdroiddata change needed (whatsNew is read from the app repo's
+  fastlane tree at the pinned build commit).
 - 2026-07-05 — folds into 1.7.0/vc17 (owner on-device finding): **D-155** panic (Reset) now
   returns ALL privileged display toggles to DEFAULTS (unconditional writes — not the baseline,
   which may itself impair the screen; temperature untouched) via

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -67,6 +67,10 @@ registry stays live.
 
 One line per shipped change (newest first). Keep terse; details live in the ledger.
 
+- 2026-07-05 — docs/metadata only (F-Droid code-quality scan): `changelogs/17.txt` trimmed
+  972→472 chars (F-Droid flags `whatsNew` ≥ 500 as Minor). RUNBOOK F-Droid-changelog bullet gains
+  the <500-char rule. No fdroiddata change needed — the `whatsNew` is read from the app repo's
+  fastlane tree at the pinned build commit.
 - 2026-07-05 — folds into 1.7.0/vc17 (owner on-device finding): **D-155** panic (Reset) now
   returns ALL privileged display toggles to DEFAULTS (unconditional writes — not the baseline,
   which may itself impair the screen; temperature untouched) via

--- a/fastlane/metadata/android/en-US/changelogs/17.txt
+++ b/fastlane/metadata/android/en-US/changelogs/17.txt
@@ -1,7 +1,5 @@
-New: Privileged Display settings (needs the one-time WRITE_SECURE_SETTINGS grant) — Night Light with temperature, grayscale/color correction, color inversion, always-on display, keep-awake while charging, and experimental force-SDR (Android 14+), all via standard AOSP settings keys.
+New: Privileged Display settings (one-time WRITE_SECURE_SETTINGS grant) — Night Light with temperature, grayscale, color inversion, always-on display, keep-awake charging, and experimental force-SDR. Like super dimming, these live in your brightness profiles: loading a profile applies them, returning to baseline restores them.
 
-These are part of your brightness profile, like super dimming: loading a profile (manually or through a Contexts rule) applies them, and returning to your baseline restores its values — so "grayscale on weekday nights" is just a Contexts rule loading a profile with grayscale on.
+New: "Follow circadian scaling" tracks Night Light temperature to your curve.
 
-New: "Follow circadian scaling" — the Night Light temperature can track your circadian curve while the service runs: warmest at night (your slider value), relaxing to the weakest filter in daylight.
-
-The emergency panic gesture (flip upside-down + shake) now also resets all privileged display toggles to their defaults — a too-dark, grayscale or inverted screen is fully recovered in one gesture.
+The panic gesture now also resets these toggles to defaults.

--- a/fastlane/metadata/android/en-US/changelogs/17.txt
+++ b/fastlane/metadata/android/en-US/changelogs/17.txt
@@ -1,5 +1,7 @@
-New: Privileged Display settings (one-time WRITE_SECURE_SETTINGS grant) — Night Light with temperature, grayscale, color inversion, always-on display, keep-awake charging, and experimental force-SDR. Like super dimming, these live in your brightness profiles: loading a profile applies them, returning to baseline restores them.
+New: Privileged Display settings (needs the one-time WRITE_SECURE_SETTINGS grant) — Night Light with temperature, grayscale/color correction, color inversion, always-on display, keep-awake while charging, and experimental force-SDR (Android 14+), all via standard AOSP settings keys.
 
-New: "Follow circadian scaling" tracks Night Light temperature to your curve.
+These are part of your brightness profile, like super dimming: loading a profile (manually or through a Contexts rule) applies them, and returning to your baseline restores its values — so "grayscale on weekday nights" is just a Contexts rule loading a profile with grayscale on.
 
-The panic gesture now also resets these toggles to defaults.
+New: "Follow circadian scaling" — the Night Light temperature can track your circadian curve while the service runs: warmest at night (your slider value), relaxing to the weakest filter in daylight.
+
+The emergency panic gesture (flip upside-down + shake) now also resets all privileged display toggles to their defaults — a too-dark, grayscale or inverted screen is fully recovered in one gesture.


### PR DESCRIPTION
## Summary
Documented F-Droid code-quality scan requirement: changelog files (`fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`) must stay under 500 characters to avoid Minor findings. Updated RUNBOOK.md with the constraint and measurement guidance; added STATE.md ledger entry explaining the rule's application to vc18+ (vc17 already tagged, so no re-cut needed).

## Release impact
None (CI / docs only)

## Verification
N/A — docs-only change.

## Repo hygiene
- **RUNBOOK.md:** Added 500-char limit rule to F-Droid changelog section with measurement guidance (`wc -c` before commit, aim ≤480 for margin).
- **STATE.md:** Appended ledger entry (2026-07-05) explaining the rule's scope and rationale (vc17 already shipped; rule applies to vc18+).

## Owner action
None — squash-merge when ready.

https://claude.ai/code/session_01CBsSeanPujELfydBueSQm4