### PR TITLE
1.8.1 (vc19): fix Resume context automation (DA-018) + changelog char-count guard (DA-019)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         // the change — RUNBOOK §6 "Cutting a release". `release-preflight.yml` (D-124) enforces this on PRs.
         // Per-version history is NOT kept here — see the STATE.md Changelog, DEVIATIONS_LEDGER, and
         // fastlane/.../changelogs/<versionCode>.txt.
-        versionCode = 18
-        versionName = "1.8.0"
+        versionCode = 19
+        versionName = "1.8.1"
         manifestPlaceholders["appLabel"] = "Tideo Auto Brightness"
     }
 

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
@@ -178,6 +178,22 @@ class AmbientMonitoringService : Service() {
                     controller.reapply()
                 }
             }
+            ACTION_RESUME_CONTEXT -> {
+                // DA-018: "Resume context automation" (Profiles banner / CONTEXTS_RESUME). Same D-140
+                // not-running gate as REAPPLY — a Resume aimed at a dead pipeline must not birth a zombie
+                // (the manual lock is already cleared in the store; the next start evaluates fresh).
+                if (!controller.state.value.serviceOn) return stopNotRunning(startId)
+                ensureRunning()
+                // Tasker _ContextResume → evaluate contexts → Set Initial Brightness: a GENUINE
+                // evaluate(RESUME) so a currently-matching rule applies NOW / a no-match reverts to
+                // %AAB_ProfileUser, THEN reapply (Set Initial Brightness). Unlike REAPPLY (reevaluate
+                // only republishes), this actually re-runs the resolver so the store + active-profile
+                // label stop diverging (the owner-reported staleness after Resume).
+                scope.launch {
+                    contextEngine.resumeContextAutomation()
+                    controller.reapply()
+                }
+            }
             ACTION_PANIC -> {
                 // task528 panic = full stop (not a pausable state, G1-F4): restore brightness +
                 // drop dimming, then tear the service down like Disable.
@@ -610,6 +626,9 @@ class AmbientMonitoringService : Service() {
         const val ACTION_DISABLE = "com.tideo.autobrightness.runtime.action.DISABLE"
         const val ACTION_PANIC = "com.tideo.autobrightness.runtime.action.PANIC"
         const val ACTION_REAPPLY = "com.tideo.autobrightness.runtime.action.REAPPLY"
+        // DA-018: resume context automation — a genuine context re-evaluation (evaluate(RESUME)) then
+        // Set Initial Brightness, distinct from REAPPLY's republish-only path.
+        const val ACTION_RESUME_CONTEXT = "com.tideo.autobrightness.runtime.action.RESUME_CONTEXT"
         const val EXTRA_REASON = "reason"
 
         // D-157 (U5): the PUBLIC outbound event contract for automation frameworks (Tasker / MacroDroid).

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AutoBrightnessRuntime.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AutoBrightnessRuntime.kt
@@ -41,6 +41,16 @@ object AutoBrightnessRuntime {
     fun reapply(context: Context) = sendServiceAction(context, AmbientMonitoringService.ACTION_REAPPLY)
 
     /**
+     * DA-018: resume context automation (the Profiles "Resume" banner / external `CONTEXTS_RESUME`).
+     * Distinct from [reapply]: the service runs a GENUINE context evaluation (`evaluate(RESUME)`) so a
+     * currently-matching rule applies now and a no-match reverts to `%AAB_ProfileUser`, THEN Set Initial
+     * Brightness — the Tasker `_ContextResume` → evaluate contexts → Set Initial Brightness flow. Plain
+     * reapply only republishes the settings, leaving the store pinned to the manually-loaded profile.
+     * Same not-running contract as reapply (validated service-side, D-140).
+     */
+    fun resumeContext(context: Context) = sendServiceAction(context, AmbientMonitoringService.ACTION_RESUME_CONTEXT)
+
+    /**
      * D-157: full-stop panic from an external command (mirrors the notification's Reset button, which
      * sends the same [AmbientMonitoringService.ACTION_PANIC]): restore brightness, drop dimming, tear
      * the service down. Safe when not running — startForegroundService creates the instance, it panics

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/ContextEngine.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/ContextEngine.kt
@@ -65,7 +65,6 @@ class ContextEngine(
     private val signalSource: ContextSignalSource,
     private val onProfileChanged: () -> Unit,
     private val clock: () -> Long = System::currentTimeMillis,
-    private val userProfileName: String = "Default",
     private val debugSink: DebugSink = NoOpDebugSink,
     private val contextLoadSink: ContextLoadSink = NoOpContextLoadSink,
 ) {
@@ -147,9 +146,25 @@ class ContextEngine(
         val current = settingsProvider()
         if (current.contextOverride) {
             _activeContext.value = null
-            currentProfileName = userProfileName
+            currentProfileName = baselineStore.userProfileName()
         }
         _effective.value = current
+    }
+
+    /**
+     * Resume context automation after the manual lock was cleared (the Profiles "Resume" banner / the
+     * external `CONTEXTS_RESUME` verb, G2R-F30). The Tasker flow is `_ContextResume` → evaluate contexts
+     * → Set Initial Brightness: this is the middle step — a GENUINE evaluation (caller [ContextCaller.RESUME],
+     * cooldown 0, no PASS-2 veto) so a currently-matching rule applies NOW and a no-match reverts to
+     * `%AAB_ProfileUser` (the last manually-loaded profile) immediately, instead of the live store staying
+     * pinned to the loaded profile until the next signal change (DA-018 — the owner-reported staleness).
+     * `reevaluate()` alone (the old [AmbientMonitoringService] REAPPLY path) only republishes the freshly
+     * unlocked settings; it never runs the resolver, so the active-profile label and the settings screens
+     * diverged. The caller runs Set Initial Brightness ([BrightnessPipelineController.reapply]) after.
+     */
+    suspend fun resumeContextAutomation() {
+        reevaluate()
+        evaluate(ContextCaller.RESUME)
     }
 
     fun start(scope: CoroutineScope) {
@@ -369,9 +384,12 @@ class ContextEngine(
         if (!plugChanged && cooldown > 0 && last != null && now - last < cooldown) return@withLock
 
         val signals = signalSource.assemble(snap.app, snap.batteryPercent, snap.plugged, snap.wifi, snap.lat, snap.lon)
+        // %AAB_ProfileUser (DA-018): the last manually-loaded profile = the no-match revert target and
+        // the "am I on a non-baseline profile?" reference for the APP_CHANGED veto. Read once per eval.
+        val userProfile = baselineStore.userProfileName()
 
         // PASS 2 — veto gates.
-        if (!shouldProceed(caller, signals, tokens)) return@withLock
+        if (!shouldProceed(caller, signals, tokens, userProfile)) return@withLock
         lastEvalTime = now
         recordState(signals)
 
@@ -382,23 +400,31 @@ class ContextEngine(
             "app ${signals.app.ifEmpty { "—" }} · loc ${signals.lat},${signals.lon} · wifi ${signals.wifi.ifEmpty { "—" }}"
         }
         val knownProfiles = profileCatalog.names()
+        // The no-match revert target is %AAB_ProfileUser (the last manually-loaded profile), not the
+        // hardcoded "Default" — so after Resume the active-profile label matches the settings the
+        // pipeline actually runs (the write-through live store, D-170), instead of claiming "Default".
         val resolution = ContextOverrideResolver.resolve(
             rules = rules.map { it.toSpec() },
             signals = signals,
             overrideActive = current.contextOverride,
-            userProfile = userProfileName,
+            userProfile = userProfile,
             profileExists = { knownProfiles.contains(it) },
         )
         apply(resolution, current, rules, caller)
     }
 
-    private fun shouldProceed(caller: ContextCaller, signals: ContextSignals, tokens: ContextSignalTokens): Boolean {
+    private fun shouldProceed(
+        caller: ContextCaller,
+        signals: ContextSignals,
+        tokens: ContextSignalTokens,
+        userProfile: String,
+    ): Boolean {
         val midnightRollover = signals.dayOfWeek != lastDay && lastDay != -1
         if (caller == ContextCaller.RESUME || midnightRollover) return true
         return when (caller) {
             ContextCaller.APP_CHANGED -> {
                 val isRuleActive = _activeContext.value != null
-                val isNonDefault = currentProfileName != null && currentProfileName != userProfileName
+                val isNonDefault = currentProfileName != null && currentProfileName != userProfile
                 val appInCache = tokens.appPackages.contains(signals.app)
                 (isRuleActive || isNonDefault || appInCache) && signals.app != lastApp
             }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ContextBaselineStore.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ContextBaselineStore.kt
@@ -19,21 +19,39 @@ import kotlinx.serialization.json.Json
  * taken once, on the baseline→override transition; rule→rule switches keep it. It is cleared when
  * the revert restores it — and by any manual "these settings are now authoritative" moment (manual
  * profile load / Resume via [ProfileApplier]), mirroring task626 re-snapshotting the live var set.
+ *
+ * [userProfileName] is the persisted NAME of `%AAB_ProfileUser` — the user's baseline profile, which
+ * is the last profile the user loaded by hand (DA-018 / contexts_spec §4). It is the no-match revert
+ * TARGET (`ContextOverrideResolver.userProfile`), so it must survive the snapshot's shorter lifecycle
+ * (a snapshot `clear()` must NOT reset the name). Defaults `"Default"` (D-014(c)); a manual load
+ * updates it via [setUserProfileName].
  */
 interface ContextBaselineStore {
     suspend fun snapshot(): AabSettings?
     suspend fun save(baseline: AabSettings)
     suspend fun clear()
+
+    /** `%AAB_ProfileUser` — the user's baseline profile name (the last manually-loaded profile). */
+    suspend fun userProfileName(): String
+
+    /** Record `%AAB_ProfileUser` (a manual profile load, DA-018). Independent of the snapshot. */
+    suspend fun setUserProfileName(name: String)
 }
 
-/** On-disk wrapper for the [ContextBaselineStore] snapshot. */
+/** On-disk wrapper for the [ContextBaselineStore] snapshot + the persisted `%AAB_ProfileUser` name. */
 @Serializable
 data class ContextBaseline(
     val schemaVersion: Int = SCHEMA_VERSION,
     val snapshot: AabSettings? = null,
+    // DA-018: the last manually-loaded profile name (`%AAB_ProfileUser`), the no-match revert target.
+    // Persisted alongside the snapshot (this record IS the "%AAB_ProfileUser revert file", D-170) but
+    // outliving it — snapshot clears leave this untouched. Defaults "Default" (D-014(c)).
+    val userProfileName: String = "Default",
 ) {
     companion object {
-        const val SCHEMA_VERSION = 1
+        // v2 (DA-018): added userProfileName. Additive + ignoreUnknownKeys → v1 files decode with the
+        // "Default" default (no migration hook reads this constant).
+        const val SCHEMA_VERSION = 2
     }
 }
 
@@ -63,10 +81,16 @@ class DataStoreContextBaselineStore(
     private val store: DataStore<ContextBaseline>,
 ) : ContextBaselineStore {
     override suspend fun snapshot(): AabSettings? = store.data.first().snapshot
+    // DA-018: `copy` (not a fresh ContextBaseline) so the snapshot save/clear preserves the persisted
+    // %AAB_ProfileUser name — the name outlives the snapshot's baseline→override→revert lifecycle.
     override suspend fun save(baseline: AabSettings) {
-        store.updateData { ContextBaseline(snapshot = baseline) }
+        store.updateData { it.copy(snapshot = baseline) }
     }
     override suspend fun clear() {
-        store.updateData { ContextBaseline(snapshot = null) }
+        store.updateData { it.copy(snapshot = null) }
+    }
+    override suspend fun userProfileName(): String = store.data.first().userProfileName
+    override suspend fun setUserProfileName(name: String) {
+        store.updateData { it.copy(userProfileName = name) }
     }
 }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ProfileApplier.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ProfileApplier.kt
@@ -44,6 +44,11 @@ class ProfileApplier(
         // (benign), whereas write-then-clear could leave a stale snapshot that a later revert
         // would restore over the user's deliberate choice.
         baselineStore.clear()
+        // DA-018: this profile is now `%AAB_ProfileUser` — the last manually-loaded profile, i.e. the
+        // target a later "Resume context automation" (or any no-match) reverts to. Persist the NAME so
+        // the resolver's fallback + the active-profile label match the settings the pipeline runs,
+        // instead of collapsing to the hardcoded "Default".
+        baselineStore.setUserProfileName(name)
         val updated = appContext.settingsDataStore.updateData { current ->
             profile.copy(
                 serviceEnabled = current.serviceEnabled,
@@ -63,12 +68,21 @@ class ProfileApplier(
     /**
      * Clear the manual context lock latched by [applyProfile] and re-evaluate so the context watchers
      * resume overriding (G2R-F30). Mirrors Tasker clearing %AAB_ContextOverride.
+     *
+     * DA-018: this drives the Tasker `_ContextResume` flow (→ evaluate contexts → Set Initial
+     * Brightness). It routes through [AutoBrightnessRuntime.resumeContext], NOT plain `reapply`: reapply
+     * only republishes the unlocked settings (`ContextEngine.reevaluate`), so a currently-matching rule
+     * never applied and a no-match never re-labelled — the active-profile indicator flipped to "Default"
+     * while the settings screens stayed on the loaded profile (owner report). The dedicated verb runs a
+     * genuine `evaluate(RESUME)` on the engine so the rule applies now, or the store reverts to
+     * `%AAB_ProfileUser`, before Set Initial Brightness runs. `%AAB_ProfileUser` is left as the last
+     * manually-loaded profile — Resume reverts TO it, so it must not be overwritten here.
      */
     suspend fun resumeContextAutomation() {
         // Resume = the current settings become the baseline the next override snapshots (task626
         // re-snapshot semantics, D-170); clear any residual pre-lock snapshot first.
         baselineStore.clear()
         val updated = appContext.settingsDataStore.updateData { it.copy(contextOverride = false) }
-        if (updated.serviceEnabled) AutoBrightnessRuntime.reapply(appContext)
+        if (updated.serviceEnabled) AutoBrightnessRuntime.resumeContext(appContext)
     }
 }

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringServiceTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringServiceTest.kt
@@ -129,6 +129,18 @@ class AmbientMonitoringServiceTest {
         assertTrue(shadowOf(service).isStoppedBySelf, "REAPPLY on a not-running service must not start the pipeline (D-140)")
     }
 
+    @Test
+    fun resumeContext_whenPipelineNotRunning_stopsSelfInsteadOfStartingThePipeline() {
+        // DA-018: the new RESUME_CONTEXT verb shares REAPPLY's D-140 not-running gate — a Resume aimed
+        // at a dead pipeline must not birth a zombie FGS (the manual lock is already cleared in the store).
+        val service = Robolectric.buildService(AmbientMonitoringService::class.java).create().get()
+
+        val result = service.onStartCommand(Intent().setAction(AmbientMonitoringService.ACTION_RESUME_CONTEXT), 0, 1)
+
+        assertEquals(android.app.Service.START_NOT_STICKY, result)
+        assertTrue(shadowOf(service).isStoppedBySelf, "RESUME_CONTEXT on a not-running service must not start the pipeline (D-140)")
+    }
+
     // The positive path must survive the D-140 gate: once START has run the pipeline (serviceOn=true,
     // set synchronously by controller.start()), PAUSE and REAPPLY act on it and keep the service up.
     //

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/ContextEngineTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/ContextEngineTest.kt
@@ -92,11 +92,17 @@ class ContextEngineTest {
         }
     }
 
-    /** In-memory pre-override baseline snapshot (task626 `_ContextResume`, D-170). */
-    private class FakeBaselineStore(var stored: AabSettings? = null) : ContextBaselineStore {
+    /** In-memory pre-override baseline snapshot (task626 `_ContextResume`, D-170) + the persisted
+     *  `%AAB_ProfileUser` name (DA-018). `name` defaults "Default" (D-014(c)) and survives `clear()`. */
+    private class FakeBaselineStore(
+        var stored: AabSettings? = null,
+        var name: String = "Default",
+    ) : ContextBaselineStore {
         override suspend fun snapshot(): AabSettings? = stored
         override suspend fun save(baseline: AabSettings) { stored = baseline }
         override suspend fun clear() { stored = null }
+        override suspend fun userProfileName(): String = name
+        override suspend fun setUserProfileName(name: String) { this.name = name }
     }
 
     private data class EngineHarness(
@@ -901,6 +907,58 @@ class ContextEngineTest {
         advanceUntilIdle()
         assertEquals(3, h.settings.value.minBrightness, "the unchanged no-match eval restores the stale snapshot")
         assertNull(stale.stored, "and clears it")
+        h.scope.cancel()
+    }
+
+    // --- DA-018: Resume context automation runs a genuine evaluation + reverts to %AAB_ProfileUser ---
+
+    @Test
+    fun resumeContextAutomation_appliesCurrentlyMatchingRuleImmediately_DA018() = runTest {
+        // DA-018 (owner report "the rule is not immediately applied"): Resume must run a GENUINE
+        // evaluation (Tasker _ContextResume → evaluate contexts → Set Initial Brightness), so a rule
+        // matching the current environment applies AT ONCE. The old REAPPLY path only republished the
+        // unlocked settings, so a matching rule didn't apply until the next signal change.
+        val src = FakeSignalSource(app = "com.netflix.mediaclient") // the Cinema (Video Streaming) rule matches
+        // The Resume banner appears in the manual-lock state: start latched.
+        val h = engine(listOf(videoStreamingRule), src, baseline = baseline.copy(contextOverride = true))
+        h.engine.start(h.scope)
+        advanceUntilIdle()
+        assertNull(h.engine.activeContext.value, "the manual lock suppresses the rule before Resume")
+
+        // ProfileApplier clears the lock in the store first, then the service runs this on the engine.
+        h.settings.value = h.settings.value.copy(contextOverride = false)
+        h.engine.resumeContextAutomation()
+        advanceUntilIdle()
+
+        assertEquals("Cinema", h.engine.activeContext.value, "Resume applies the matching rule immediately")
+        assertEquals(true, h.engine.effectiveSettings().dimmingEnabled, "the rule's profile is written through (D-170)")
+        h.scope.cancel()
+    }
+
+    @Test
+    fun resumeContextAutomation_noMatch_revertsToUserProfileNotDefault_DA018() = runTest {
+        // DA-018 (owner report "settings screens are still stale"): with no rule matching, Resume must
+        // label the active profile as %AAB_ProfileUser (the last manually-loaded profile), NOT the
+        // hardcoded "Default" — so the indicator agrees with the write-through settings the pipeline
+        // runs (D-170). Under the old resolver fallback the label flipped to "Default" while the live
+        // store kept the loaded profile, which read as stale.
+        LiveRuntimeState.reset()
+        val src = FakeSignalSource(app = "com.other.app") // no rule matches
+        val h = engine(
+            listOf(videoStreamingRule), src,
+            baselineStore = FakeBaselineStore(name = "Outdoors"), // %AAB_ProfileUser = last manual load
+        )
+        h.engine.start(h.scope)
+        advanceUntilIdle()
+        // A manual load would have pinned the loaded profile's label; prove Resume re-derives it.
+        LiveRuntimeState.setActiveProfile("Movie Night")
+
+        h.engine.resumeContextAutomation()
+        advanceUntilIdle()
+
+        assertNull(h.engine.activeContext.value, "no rule matches → no active context")
+        assertEquals("Outdoors", LiveRuntimeState.activeProfile.value, "reverts to %AAB_ProfileUser, not Default")
+        assertEquals(baseline, h.engine.effectiveSettings(), "no snapshot → the live store is unchanged")
         h.scope.cancel()
     }
 

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/settings/DataStoreSchemaVersionTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/settings/DataStoreSchemaVersionTest.kt
@@ -31,8 +31,9 @@ class DataStoreSchemaVersionTest {
     }
 
     @Test
-    fun `context-baseline store is at schema v1 with an identity default`() {
-        assertEquals(1, ContextBaseline.SCHEMA_VERSION)
+    fun `context-baseline store is at schema v2 with an identity default`() {
+        // v2 (DA-018): added the persisted %AAB_ProfileUser name (userProfileName, default "Default").
+        assertEquals(2, ContextBaseline.SCHEMA_VERSION)
         assertEquals(ContextBaseline(), ContextBaselineSerializer.defaultValue)
     }
 

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/settings/ProfileApplierTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/settings/ProfileApplierTest.kt
@@ -2,6 +2,7 @@ package com.tideo.autobrightness.app.settings
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
+import com.tideo.autobrightness.app.runtime.AmbientMonitoringService
 import com.tideo.autobrightness.app.storage.contextBaselineDataStore
 import com.tideo.autobrightness.app.storage.settingsDataStore
 import com.tideo.autobrightness.app.storage.userProfilesDataStore
@@ -9,6 +10,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -74,6 +76,48 @@ class ProfileApplierTest {
         applier.applyProfile("Battery Saver")
 
         assertNull(store.snapshot(), "a manual profile load drops the pre-override snapshot (D-170)")
+    }
+
+    @Test
+    fun applyProfile_recordsUserProfileName_DA018() = runBlocking {
+        // DA-018: a manual load is now %AAB_ProfileUser — the last manually-loaded profile, the target a
+        // later Resume / no-match reverts to. The NAME is persisted so the resolver fallback + the
+        // active-profile label match the loaded settings instead of collapsing to "Default".
+        seed(AabSettings(serviceEnabled = false))
+        val store = DataStoreContextBaselineStore(app.contextBaselineDataStore)
+
+        applier.applyProfile("Battery Saver")
+
+        assertEquals("Battery Saver", store.userProfileName(), "a manual load records %AAB_ProfileUser (DA-018)")
+    }
+
+    @Test
+    fun resumeContextAutomation_routesToResumeContextAction_DA018() = runBlocking {
+        // DA-018: Resume drives the genuine re-evaluation verb (evaluate(RESUME) → Set Initial
+        // Brightness), NOT plain REAPPLY (which only republishes and left the store pinned to the loaded
+        // profile). serviceEnabled=true so the action is emitted.
+        seed(AabSettings(serviceEnabled = true, contextOverride = true))
+
+        applier.resumeContextAutomation()
+
+        val intent = shadowOf(app).nextStartedService
+        assertEquals(
+            AmbientMonitoringService.ACTION_RESUME_CONTEXT,
+            intent.action,
+            "Resume must run a real context re-evaluation, not a republish-only REAPPLY",
+        )
+    }
+
+    @Test
+    fun resumeContextAutomation_leavesUserProfileNameIntact_DA018() = runBlocking {
+        // Resume reverts TO %AAB_ProfileUser, so it must not overwrite it (only a manual load sets it).
+        seed(AabSettings(serviceEnabled = false, contextOverride = true))
+        val store = DataStoreContextBaselineStore(app.contextBaselineDataStore)
+        store.setUserProfileName("Outdoors")
+
+        applier.resumeContextAutomation()
+
+        assertEquals("Outdoors", store.userProfileName(), "Resume leaves %AAB_ProfileUser unchanged (DA-018)")
     }
 
     @Test

--- a/docs/AGENTIC_HARNESS_PROMPT.md
+++ b/docs/AGENTIC_HARNESS_PROMPT.md
@@ -718,7 +718,8 @@ One bash script, `set -euo pipefail`, run by both the agent and CI. Structure:
      nearly every unit, and warn fatigue kills tripwires; their legislative sections stay
      prose-only).
    - {{DOMAIN_GUARDS: any repo-specific machine-checkable release rule — e.g. a changelog
-     length cap, a version-monotonicity check.}}
+     length cap (mind the unit: a store's "500 char" limit is CHARACTERS/codepoints, not bytes —
+     `wc -c` overcounts multibyte text), a version-monotonicity check.}}
 2. **`--guards-only` exits here** (docs-only work).
 3. **The full verification set** in one invocation: `{{TEST + LINT + BUILD tasks}}`.
 

--- a/docs/rebuild/DEVIATIONS_LEDGER_A.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER_A.md
@@ -508,3 +508,20 @@
   (`resumeContextAutomation` + resolver fallback), `ProfileApplier.kt`, `AutoBrightnessRuntime.kt`
   (`resumeContext`), `AmbientMonitoringService.kt` (`ACTION_RESUME_CONTEXT`), `ContextBaselineStore.kt`
   (`userProfileName`) cite DA-018.
+
+- DA-019: F-Droid changelog guard counts CHARACTERS, not bytes (owner-instructed correction of
+  D-173, 2026-07-24). D-173's ladder guard 6 measured the changelog with `wc -c` (bytes) while its
+  own message + RUNBOOK §6 said "500 characters" — a prose/guard unit-drift (the DA-004 lockstep bug
+  class). F-Droid's code-quality scan caps the `whatsNew` by string LENGTH (codepoints), so a note
+  with multibyte glyphs (em dashes, accents, emoji) could exceed 500 bytes while under the real
+  500-char limit and false-fail the guard (and the RUNBOOK's `wc -c` advice overcounted the same
+  way). Fix: guard 6 now counts codepoints, locale-independent — `LC_ALL=C tr -d '\200-\277' < file
+  | wc -c` strips UTF-8 continuation bytes (0x80-0xBF), leaving one byte per codepoint (lead byte /
+  ASCII byte); message + OK line report "chars". Prose synced: RUNBOOK §6 (the `wc -c` advice
+  replaced with the codepoint recipe), the guard-6 header comment, and the agent-agnostic
+  `AGENTIC_HARNESS_PROMPT.md` {{DOMAIN_GUARDS}} example (mind-the-unit note). Fixtures
+  (`test-ladder-guards.sh`) gain two multibyte cases: 250 em dashes (750 B / 250 chars) must PASS,
+  501 em dashes (1503 B / 501 chars) must FAIL — the ASCII 500/501 cases stay. Rule-review
+  (DA-005): in-context (this session cannot spawn a fresh reviewer under the no-subagent harness
+  directive); owner directed the change and is the arbiter. `19.txt` (this release) is 302 chars,
+  unaffected. `[cited]`: none (guard/prose only; no production code cites DA-019).

--- a/docs/rebuild/DEVIATIONS_LEDGER_A.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER_A.md
@@ -473,3 +473,38 @@
   root SSID strategy shares the theoretical on-device stall; bound them the same way if a
   field report ever implicates them. `[cited]`: ForceDarkController.kt `rootExec` kdoc + its
   test's hermeticity comment cite DA-017.
+
+- DA-018 [cited]: "Resume context automation" now runs a GENUINE context evaluation and reverts to
+  `%AAB_ProfileUser` = the last manually-loaded profile (owner-reported bug + owner decision, 2026-07-24).
+  **Report:** pressing the Profiles "Resume" banner showed the active profile flip to "Default" (no rule
+  matching), but the matching rule wasn't applied and the parameter screens stayed on the loaded profile
+  — indicator and settings diverged. **Two root causes.** (1) The Resume path
+  (`ProfileApplier.resumeContextAutomation` → `AutoBrightnessRuntime.reapply` → service `ACTION_REAPPLY`)
+  only called `ContextEngine.reevaluate()` (a republish of the freshly-unlocked settings) + `reapply()`;
+  it never ran the resolver. Screen-on ("resume context automation", `onScreenOn`) worked ONLY because it
+  additionally calls `contextEngine.onScreenOn()` → a real `evaluate(TIME)`. Owner-confirmed Tasker flow:
+  `_ContextResume` → **evaluate contexts** → **Set Initial Brightness**. Fix: a dedicated
+  `ACTION_RESUME_CONTEXT` verb (`AutoBrightnessRuntime.resumeContext`) whose service handler runs
+  `contextEngine.resumeContextAutomation()` (= `reevaluate()` then `evaluate(RESUME)`, cooldown 0 / no
+  PASS-2 veto) THEN `controller.reapply()` (Set Initial Brightness). Same D-140 not-running gate as
+  REAPPLY. (2) The resolver's no-match fallback (`ContextOverrideResolver.userProfile`) was the hardcoded
+  `ContextEngine` default `"Default"` (AppModule never wired it, D-014(c)), so on a no-match the
+  active-profile label was set to "Default" even though the live store (D-170 write-through) still held
+  the manually-loaded profile — the divergence. Fix (Tasker parity, contexts_spec §4 "reverts to
+  `%AAB_ProfileUser`"): persist `%AAB_ProfileUser` = the last manually-loaded profile NAME in
+  `ContextBaseline` (store 9, schema v1→v2, `userProfileName`, survives snapshot `clear()`);
+  `ProfileApplier.applyProfile` records it; the engine reads it per-eval as the resolver fallback + the
+  `APP_CHANGED` "non-baseline profile" reference (replaced the removed `userProfileName` ctor param);
+  Resume leaves it intact (it reverts TO it). Net: a currently-matching rule applies on Resume at once,
+  and a no-match labels the active profile as `%AAB_ProfileUser` — matching the write-through settings the
+  pipeline runs (D-170 unchanged: the loaded profile stays the live baseline; only the label/fallback name
+  was wrong). **Deferred:** import (`SettingsViewModel.replaceAll`) still doesn't set `%AAB_ProfileUser`
+  (its name is saved separately by the screen); a later Resume after an import falls back to the prior
+  `%AAB_ProfileUser`. Not the reported path; noted for a follow-up if it surfaces. Tests:
+  `ContextEngineTest` ×2 `_DA018` (matching rule applies on resume; no-match reverts to `%AAB_ProfileUser`
+  not "Default"), `ProfileApplierTest` ×3 `_DA018` (records the name / routes to the resume verb / leaves
+  the name intact), `AmbientMonitoringServiceTest` (RESUME_CONTEXT D-140 not-running gate),
+  `DataStoreSchemaVersionTest` (context-baseline v2). `[cited]`: `ContextEngine.kt`
+  (`resumeContextAutomation` + resolver fallback), `ProfileApplier.kt`, `AutoBrightnessRuntime.kt`
+  (`resumeContext`), `AmbientMonitoringService.kt` (`ACTION_RESUME_CONTEXT`), `ContextBaselineStore.kt`
+  (`userProfileName`) cite DA-018.

--- a/docs/rebuild/RESUME_CONTEXT_TEST.md
+++ b/docs/rebuild/RESUME_CONTEXT_TEST.md
@@ -1,0 +1,46 @@
+# Resume-context fix — on-device test (DA-018, 1.8.1/vc19)
+
+Debug build: package `com.tideo.autobrightness.debug`, label **Tideo AB (Debug)**. Run only ONE
+variant's service at a time (D-128) — disable the release app's service first, or uninstall it.
+
+## Setup (once)
+
+1. Install the debug APK; open **Tideo AB (Debug)**.
+2. Grant **Modify system settings** (WRITE_SETTINGS) when prompted; toggle the service **On**
+   (Dashboard). Confirm the notification shows it monitoring.
+3. Profiles screen → make sure at least two built-in profiles exist (e.g. **Default** and
+   **Outdoors**). Restore factory profiles if the list is empty.
+4. Contexts screen → add ONE easy-to-trigger rule, e.g.
+   - **App rule** "Cinema" → target profile **Video Streaming**, trigger app = a video app you
+     have installed (grant Usage Access if asked), OR
+   - **Battery rule** "Saver" → target **Battery Saver**, trigger battery ≤ some % above your
+     current level so it matches right now.
+
+## Test A — a matching rule applies immediately on Resume
+
+1. Make the rule's condition currently TRUE (open the app / be under the battery %).
+2. Profiles screen → tap a *different* profile (e.g. **Outdoors**) → **Load**. The "Resume context
+   automation" banner appears; Outdoors is now active.
+3. Tap **Resume** on the banner.
+   - ✅ **Expected:** within a moment the active profile switches to the **rule's** profile
+     (Video Streaming / Battery Saver), the rule name shows as the active context, and the
+     Curve & Brightness screen shows that profile's values.
+   - ❌ **Old bug:** it stayed on Outdoors / flipped to "Default" and did not apply the rule.
+
+## Test B — no match reverts to your last manually-loaded profile (in sync)
+
+1. Make sure NO context rule currently matches (close the app / unplug or adjust battery).
+2. Profiles screen → **Load** the **Outdoors** profile. Banner appears.
+3. Tap **Resume**.
+   - ✅ **Expected:** the active profile shows **Outdoors** (your last manual load) — NOT "Default"
+     — and the Curve & Brightness / Reactivity screens show **Outdoors'** values. Indicator and
+     settings agree.
+   - ❌ **Old bug:** the label flipped to "Default" while the settings screens still showed
+     Outdoors (stale / mismatched).
+
+## Optional — external verb (if you use Tasker/MacroDroid)
+
+With **External control** enabled (Tools), sending
+`com.tideo.autobrightness.control.CONTEXTS_RESUME` behaves exactly like the banner's Resume.
+
+Report back: for A and B, what the active-profile label said vs. what the settings screens showed.

--- a/docs/rebuild/RUNBOOK.md
+++ b/docs/rebuild/RUNBOOK.md
@@ -155,8 +155,11 @@ so check it explicitly.
 - **F-Droid changelog:** add `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt` (the
   filename is the **versionCode**, not the name) with a short user-facing note. **Keep it under 500
   characters** (whole file incl. the trailing newline — aim ≤ 480 for margin): F-Droid's code-quality
-  scan flags a longer `whatsNew` as a Minor finding (`wc -c` the file before committing — and ladder
-  guard 6 machine-fails the current versionCode's file over 500 B, D-173). **`release.yml`
+  scan flags a longer `whatsNew` as a Minor finding. The cap is on **characters (codepoints), not
+  bytes** (DA-019) — a note with em dashes / accents / emoji can exceed 500 bytes while under 500
+  chars, so `wc -c` **overcounts**; measure with `LC_ALL=C tr -d '\200-\277' < file | wc -c`
+  (strips UTF-8 continuation bytes → one byte per codepoint), which is exactly what ladder guard 6
+  machine-fails the current versionCode's file over (D-173). **`release.yml`
   auto-reuses this file as the GitHub Release's "What's new" section (D-123)** — it reads the tagged
   build's `versionCode`, looks up the matching changelog, and slots it between the owner's UI summary
   and GitHub's auto "What's Changed". So the owner no longer hand-copies the changelog into the release

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -92,6 +92,13 @@ zero-`pending`; parity tests green; TODO/FIXME 0; `parity_gaps.md` 0 open. Chang
 
 One line per shipped change (newest first); detail in the D-rows and git history.
 
+- 2026-07-24 — **DA-018** (owner-reported field bug): "Resume context automation" only republished
+  (`ContextEngine.reevaluate` + reapply) — never ran the resolver — so a matching rule didn't apply and
+  the active-profile label flipped to the hardcoded "Default" while the write-through settings kept the
+  loaded profile (indicator/settings diverged). Fix: a dedicated `ACTION_RESUME_CONTEXT` verb runs a
+  genuine `evaluate(RESUME)` then Set Initial Brightness (Tasker `_ContextResume` flow), and the resolver
+  fallback is now the persisted `%AAB_ProfileUser` = last manually-loaded profile (`ContextBaseline` v2,
+  `userProfileName`). Rides on the train tip; folds into the pending 1.8.0/vc18.
 - 2026-07-24 — **CI hang root-caused + fixed (DA-017)** (PR #91, two red runs):
   `ForceDarkControllerTest` spawned the runner's real `su`, whose password prompt blocked
   `rootExec`'s unbounded stdout read forever (named by run 2's jstack step; run 1's

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -26,9 +26,10 @@ tile, boot receiver). Privileges: **BASIC** `WRITE_SETTINGS` = full core pipelin
 
 **Shipped: v1.8.0** (vc18, on `main` via PR #91 — intent control, a11y + crash-log, IME, audit,
 force dark, curve-wizard sort fix, D-156…D-176 + DA-001…DA-017). **Code-complete, awaiting owner
-release: 1.8.1 / vc19** — the **DA-018** Resume-context fix (this session), on branch
-`claude/resume-context-automation-stale-e0mw73` off `main`. Patch bump; F-Droid changelog
-`19.txt` added. No other active work; no plan files. `PARITY_CHECKLIST.md` zero-`pending`; parity
+release: 1.8.1 / vc19** — the **DA-018** Resume-context fix + **DA-019** changelog char-count guard
+(this session), **PR #92 open** (base `main`, head `claude/resume-context-automation-stale-e0mw73`).
+Owner on-device-verified the Resume fix. Patch bump; F-Droid changelog `19.txt` added. No other
+active work; no plan files. `PARITY_CHECKLIST.md` zero-`pending`; parity
 tests green; TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per `RUNBOOK.md`; deviations in
 `DEVIATIONS_LEDGER.md` (live `_A.md`).
 
@@ -42,20 +43,19 @@ tests green; TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per `RUNBOOK.md`; de
 
 **Pending owner actions (the 1.8.1 release path):**
 
-1. **On-device verify the DA-018 Resume fix** with the debug APK sent this session (the
-   `RESUME_CONTEXT_TEST.md` script) — confirm Resume immediately applies a matching rule / reverts
-   to the last manually-loaded profile with the settings screens in sync; findings → **Incoming
-   findings**.
-2. **Merge `claude/resume-context-automation-stale-e0mw73` → `main`** (1.8.1 / vc19, DA-018) once CI
-   is green — no `[skip ci]`-class tokens (D-115).
-3. Cut **v1.8.1 / vc19** from `main` via the Release UI — tag `v1.8.1`; release.yml builds + signs
+1. **Squash-merge PR #92** (1.8.1 / vc19, DA-018 + DA-019) once CI is green — the body becomes the
+   squash commit; no `[skip ci]`-class tokens (D-115).
+2. Cut **v1.8.1 / vc19** from `main` via the Release UI — tag `v1.8.1`; release.yml builds + signs
    the tagged commit; F-Droid `UpdateCheckMode: Tags` auto-builds the update.
-4. **Server-side rails (DA-006):** enable on GitHub — `main` branch protection (PRs required;
+3. **Server-side rails (DA-006):** enable on GitHub — `main` branch protection (PRs required;
    force-push + deletion blocked) + secret-scanning push protection. (Carried from 1.8.0.)
 
 **Open questions:** (none)
 
-**Incoming findings:** (none)
+**Incoming findings:**
+
+- 2026-07-24 — Owner on-device-verified the **DA-018** Resume fix (Tests A + B in
+  `RESUME_CONTEXT_TEST.md`): "Confirmed that it works." No regressions reported.
 
 ## Decided non-items (don't re-litigate without new evidence)
 

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -47,8 +47,6 @@ tests green; TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per `RUNBOOK.md`; de
    squash commit; no `[skip ci]`-class tokens (D-115).
 2. Cut **v1.8.1 / vc19** from `main` via the Release UI — tag `v1.8.1`; release.yml builds + signs
    the tagged commit; F-Droid `UpdateCheckMode: Tags` auto-builds the update.
-3. **Server-side rails (DA-006):** enable on GitHub — `main` branch protection (PRs required;
-   force-push + deletion blocked) + secret-scanning push protection. (Carried from 1.8.0.)
 
 **Open questions:** (none)
 
@@ -56,6 +54,8 @@ tests green; TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per `RUNBOOK.md`; de
 
 - 2026-07-24 — Owner on-device-verified the **DA-018** Resume fix (Tests A + B in
   `RESUME_CONTEXT_TEST.md`): "Confirmed that it works." No regressions reported.
+- 2026-07-24 — Owner confirmed the **server-side rails (DA-006)** are now enabled on GitHub
+  (`main` branch protection + secret-scanning push protection) — closes the carried 1.8.0 item.
 
 ## Decided non-items (don't re-litigate without new evidence)
 

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -24,14 +24,13 @@ tile, boot receiver). Privileges: **BASIC** `WRITE_SETTINGS` = full core pipelin
 
 ## Current state
 
-**Shipped: v1.7.0** (vc17, on `main`; live on F-Droid since 2026-07-24 — `fdroiddata!41202`).
-**Code-complete, awaiting owner release: 1.8.0 / vc18** — intent control (D-157), a11y +
-crash-log capture (D-156/D-158), IME (D-159), audit (D-160), force dark (D-172), curve-wizard
-top-K sort fix (DA-016), CI config-cache hang fix. Train tip `claude/linsui-merge-review-wy21zg`
-(supersets `…-2nnwmb` → `…-fmb35b`; pre-fmb35b branches deleted 2026-07-19). **Release PR #91
-open** (base `main`, whole train). No active work; no plan files. `PARITY_CHECKLIST.md`
-zero-`pending`; parity tests green; TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per
-`RUNBOOK.md`; deviations in `DEVIATIONS_LEDGER.md` (live `_A.md`).
+**Shipped: v1.8.0** (vc18, on `main` via PR #91 — intent control, a11y + crash-log, IME, audit,
+force dark, curve-wizard sort fix, D-156…D-176 + DA-001…DA-017). **Code-complete, awaiting owner
+release: 1.8.1 / vc19** — the **DA-018** Resume-context fix (this session), on branch
+`claude/resume-context-automation-stale-e0mw73` off `main`. Patch bump; F-Droid changelog
+`19.txt` added. No other active work; no plan files. `PARITY_CHECKLIST.md` zero-`pending`; parity
+tests green; TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per `RUNBOOK.md`; deviations in
+`DEVIATIONS_LEDGER.md` (live `_A.md`).
 
 ## Owner queue
 
@@ -41,22 +40,18 @@ zero-`pending`; parity tests green; TODO/FIXME 0; `parity_gaps.md` 0 open. Chang
 > findings** = owner on-device results. Items leave when done/answered/triaged (delete + record
 > as a Changelog line or D-row). Final chat message restates this queue.
 
-**Pending owner actions (the 1.8.0 release path):**
+**Pending owner actions (the 1.8.1 release path):**
 
-1. **Squash-merge release PR #91** once CI is green (base `main`, head
-   `claude/linsui-merge-review-wy21zg` = the whole train, D-156…D-176 + DA-001…DA-016). Title +
-   body are live on the PR and become the squash commit — no `[skip ci]`-class tokens (D-115).
-   F-Droid gate cleared: `fdroiddata!41202` (`com.tideo.autobrightness`) merged by linsui
-   2026-07-24 — reproducible `Binaries` build, recipe byte-for-byte, no AntiFeatures; reviewer
-   verified signing = pinned key, permission gating, zero traffic, VT 0/42, **no follow-up**;
-   declared `INTERNET` = the opt-in `ipwho.is` geo-IP fallback (D-105/D-121).
-2. After CI green: on-device `DEVICE_TEST_SCRIPT.md` **§§12–15**; findings → **Incoming
+1. **On-device verify the DA-018 Resume fix** with the debug APK sent this session (the
+   `RESUME_CONTEXT_TEST.md` script) — confirm Resume immediately applies a matching rule / reverts
+   to the last manually-loaded profile with the settings screens in sync; findings → **Incoming
    findings**.
-3. Cut **v1.8.0 / vc18** from `main` via the Release UI — tag `v1.8.0`; release.yml builds the
-   tagged commit and signs with the F-Droid-pinned key; F-Droid `UpdateCheckMode: Tags`
-   auto-builds the update.
+2. **Merge `claude/resume-context-automation-stale-e0mw73` → `main`** (1.8.1 / vc19, DA-018) once CI
+   is green — no `[skip ci]`-class tokens (D-115).
+3. Cut **v1.8.1 / vc19** from `main` via the Release UI — tag `v1.8.1`; release.yml builds + signs
+   the tagged commit; F-Droid `UpdateCheckMode: Tags` auto-builds the update.
 4. **Server-side rails (DA-006):** enable on GitHub — `main` branch protection (PRs required;
-   force-push + deletion blocked) + secret-scanning push protection.
+   force-push + deletion blocked) + secret-scanning push protection. (Carried from 1.8.0.)
 
 **Open questions:** (none)
 
@@ -98,7 +93,8 @@ One line per shipped change (newest first); detail in the D-rows and git history
   loaded profile (indicator/settings diverged). Fix: a dedicated `ACTION_RESUME_CONTEXT` verb runs a
   genuine `evaluate(RESUME)` then Set Initial Brightness (Tasker `_ContextResume` flow), and the resolver
   fallback is now the persisted `%AAB_ProfileUser` = last manually-loaded profile (`ContextBaseline` v2,
-  `userProfileName`). Rides on the train tip; folds into the pending 1.8.0/vc18.
+  `userProfileName`). Cut as **1.8.1 / vc19** (patch, on `main` after 1.8.0 shipped); debug APK + test
+  script sent to owner; awaiting owner on-device verify + release.
 - 2026-07-24 — **CI hang root-caused + fixed (DA-017)** (PR #91, two red runs):
   `ForceDarkControllerTest` spawned the runner's real `su`, whose password prompt blocked
   `rootExec`'s unbounded stdout read forever (named by run 2's jstack step; run 1's

--- a/docs/rebuild/architecture/datastore_map.md
+++ b/docs/rebuild/architecture/datastore_map.md
@@ -15,16 +15,18 @@ schema-drifted file in one never takes down the others. They are declared in
 | 6 | `userProfilesDataStore` | `aab_user_profiles.json` | typed JSON | `SavedProfiles` (named profiles) | **1** (`SavedProfiles.SCHEMA_VERSION`) | `SavedProfilesSerializer` | User-editable named profiles (built-ins seeded once). Context rules target these by name; kept apart so a profile-store problem can't corrupt the live settings. |
 | 7 | `powerDrawDataStore` | `power_draw` | Preferences | measured OLED power-draw dataset (task524) | n/a (schema-less) | — (Preferences) | The Tools power-draw calibration samples; overwritten on recalibration, disposable, key/value. Distinct lifetime from settings (S14). |
 | 8 | `controlPrefsDataStore` | `control_prefs` | Preferences | `external_control_enabled` (opt-in gate) | n/a (schema-less) | — (Preferences) | **D-157**: the opt-in flag for the external intent-control surface. Its OWN store — deliberately **not** an `AabSettings` field — so profile apply/import chokepoints (`applyProfile`/`replaceAll`/`resetDefaults`/legacy import) can never flip it. Single Boolean, key/value. |
-| 9 | `contextBaselineDataStore` | `aab_context_baseline.json` | typed JSON | `ContextBaseline` (nullable `AabSettings` snapshot) | **1** (`ContextBaseline.SCHEMA_VERSION`) | `ContextBaselineSerializer` | **D-170**: the pre-override baseline snapshot (Tasker task626 `_ContextResume` / `%AAB_ProfileUser` revert file). Context-rule loads write through to store 1; this holds what the no-match revert restores. Kept apart so the snapshot/clear cadence and a corrupt snapshot (degrades to "no revert reference") never touch the live settings file. |
+| 9 | `contextBaselineDataStore` | `aab_context_baseline.json` | typed JSON | `ContextBaseline` (nullable `AabSettings` snapshot + `userProfileName`) | **2** (`ContextBaseline.SCHEMA_VERSION`) | `ContextBaselineSerializer` | **D-170**: the pre-override baseline snapshot (Tasker task626 `_ContextResume` / `%AAB_ProfileUser` revert file). Context-rule loads write through to store 1; this holds what the no-match revert restores. Kept apart so the snapshot/clear cadence and a corrupt snapshot (degrades to "no revert reference") never touch the live settings file. **DA-018**: v2 added `userProfileName` — the persisted `%AAB_ProfileUser` name (the last manually-loaded profile, default `"Default"`), the no-match/Resume revert TARGET. It outlives the snapshot (a snapshot `clear()` preserves it via `copy`). Additive → v1 files decode with the default; no migration hook reads the constant. |
 
 ## Versioning policy
 
 - Each **typed-JSON** store declares a schema-version constant. `DataStoreSchemaVersionTest` asserts the
   constant matches the serializer's `defaultValue` (and, for `settings`, the model default).
 - `settings` is the only store with an in-payload `schemaVersion` field and a real migration chain
-  (D-008/G2R-F85). The other three typed stores are at **v1**: their `@Serializable` payloads evolve
-  additively (new fields with defaults, read with `ignoreUnknownKeys = true`), so no migration is needed
-  yet. Bump the `SCHEMA_VERSION` constant and add a migration only on a *breaking* shape change.
+  (D-008/G2R-F85). The other typed stores evolve additively (new fields with defaults, read with
+  `ignoreUnknownKeys = true`), so no migration is needed: `contextRules`/`overridePoints`/`userProfiles`
+  stay at **v1**, and `contextBaseline` is at **v2** (DA-018 added `userProfileName` additively — the
+  constant was bumped for honesty, not a migration). Bump the `SCHEMA_VERSION` constant and add a real
+  migration only on a *breaking* shape change.
 - The four **Preferences** stores (`service_health`, `experiment_prefs`, `power_draw`, `control_prefs`)
   are intentionally schema-less key/value bags (no serializer, no version); they hold disposable/optional
   data.

--- a/fastlane/metadata/android/en-US/changelogs/19.txt
+++ b/fastlane/metadata/android/en-US/changelogs/19.txt
@@ -1,0 +1,1 @@
+Fix "Resume context automation": pressing Resume now immediately re-evaluates your context rules — a matching rule applies at once, and with no match it reverts to your last manually-loaded profile — instead of leaving the settings screens showing the old profile while the label flipped to "Default".

--- a/scripts/ladder.sh
+++ b/scripts/ladder.sh
@@ -24,8 +24,9 @@
 #   5. D-citation integrity (D-173): every D-/DA-/DB-NNN cited in app/ domain/ platform/
 #      .github/ sources must resolve to a row in its ledger file; ledger row numbers must be
 #      unique; the rows' [cited] markers must match the citation set both ways (D-174).
-#      6. F-Droid changelog cap (D-173): the CURRENT versionCode's
-#      fastlane changelog must be <= 500 bytes (RUNBOOK §6; F-Droid flags longer whatsNew).
+#      6. F-Droid changelog cap (D-173, char count DA-019): the CURRENT versionCode's
+#      fastlane changelog must be <= 500 CHARACTERS (codepoints, not bytes — RUNBOOK §6;
+#      F-Droid flags a longer whatsNew by string length, so a multibyte note may exceed 500 B).
 #   2. D-115 skip-ci token scan over unmerged commit messages (origin/main..HEAD) — the
 #      same fixed-string token set release-preflight.yml enforces at PR time. Catching a
 #      token BEFORE push matters here: force-push is forbidden (CLAUDE.md git rules), so a
@@ -204,21 +205,26 @@ stale=$(comm -13 <(printf '%s\n' $cited | grep . | sort -u) <(printf '%s\n' $mar
 [ -z "$stale" ] || fail "ledger row(s) marked [cited] but no longer cited anywhere in scope: $(echo $stale) — remove the marker, or restore the lost citation (D-174)"
 echo "LADDER: D-citations OK ($(echo "$cited" | grep -c . || true) distinct, all resolve; [cited] markers in sync; no duplicate ledger rows)"
 
-# --- guard 6: F-Droid changelog cap (D-173) ---
-# RUNBOOK §6: changelogs/<versionCode>.txt must stay under 500 characters (whole file, wc -c)
-# or F-Droid's code-quality scan flags the whatsNew. Only the CURRENT versionCode's file is
-# checked — it is the one the next tag ships; historical files (e.g. the pre-rule 9.txt,
-# 1158 B) are shipped facts, not actionable. Existence is release-preflight.yml's job (it
-# knows whether the PR ships app code); this guard only rejects an oversize file.
+# --- guard 6: F-Droid changelog cap (D-173; char count DA-019) ---
+# RUNBOOK §6: changelogs/<versionCode>.txt must stay under 500 CHARACTERS (whole file incl. the
+# trailing newline) or F-Droid's code-quality scan flags the whatsNew. F-Droid measures string
+# LENGTH (codepoints), not bytes, so this counts characters — a note with multibyte glyphs
+# (em dashes, accents, emoji) may run past 500 bytes while still under the real 500-char limit.
+# Codepoint count, locale-independent: strip UTF-8 continuation bytes (0x80-0xBF) with LC_ALL=C
+# tr, then wc -c the remainder — one byte survives per codepoint (the lead byte / any ASCII byte).
+# Only the CURRENT versionCode's file is checked — it is the one the next tag ships; historical
+# files (e.g. the pre-rule 9.txt) are shipped facts, not actionable. Existence is
+# release-preflight.yml's job (it knows whether the PR ships app code); this guard only rejects
+# an oversize file.
 vc=$(grep -oE 'versionCode[[:space:]]*=[[:space:]]*[0-9]+' app/build.gradle.kts 2>/dev/null \
   | grep -oE '[0-9]+' | head -1 || true)
 if [ -n "$vc" ] && [ -f "fastlane/metadata/android/en-US/changelogs/${vc}.txt" ]; then
   cl="fastlane/metadata/android/en-US/changelogs/${vc}.txt"
-  cl_bytes=$(wc -c < "$cl" | tr -d '[:space:]')
-  if [ "$cl_bytes" -gt 500 ]; then
-    fail "$cl is ${cl_bytes} B — over the 500-char F-Droid whatsNew cap (RUNBOOK §6). Shorten it."
+  cl_chars=$(LC_ALL=C tr -d '\200-\277' < "$cl" | wc -c | tr -d '[:space:]')
+  if [ "$cl_chars" -gt 500 ]; then
+    fail "$cl is ${cl_chars} chars — over the 500-char F-Droid whatsNew cap (RUNBOOK §6). Shorten it."
   fi
-  echo "LADDER: F-Droid changelog OK ($cl, ${cl_bytes} B <= 500)"
+  echo "LADDER: F-Droid changelog OK ($cl, ${cl_chars} chars <= 500)"
 fi
 
 # --- guard 7: rule-review tripwire (DA-006; WARN-only, local-only — skipped under

--- a/scripts/test-ladder-guards.sh
+++ b/scripts/test-ladder-guards.sh
@@ -208,9 +208,16 @@ write_ledger 10
 # --- guard 6: F-Droid changelog cap ---------------------------------------------------------
 
 head -c 501 /dev/zero | tr '\0' 'x' > "$SANDBOX/$CHANGELOG_DIR/7.txt"
-check "guard 6: 501-byte changelog fails" 1 "over the 500-char F-Droid whatsNew cap"
+check "guard 6: 501-char (ASCII) changelog fails" 1 "over the 500-char F-Droid whatsNew cap"
 head -c 500 /dev/zero | tr '\0' 'x' > "$SANDBOX/$CHANGELOG_DIR/7.txt"
-check "guard 6: 500-byte changelog passes" 0 "F-Droid changelog OK"
+check "guard 6: 500-char (ASCII) changelog passes" 0 "F-Droid changelog OK"
+# DA-019: the guard counts CHARACTERS (codepoints), not bytes. A note of 250 em dashes is 750
+# bytes but only 250 chars — the old byte check failed it; the char check must PASS it.
+for _ in $(seq 250); do printf '\xe2\x80\x94'; done > "$SANDBOX/$CHANGELOG_DIR/7.txt"
+check "guard 6: >500 bytes but <=500 chars (multibyte) passes" 0 "F-Droid changelog OK"
+# ...and 501 multibyte chars (1503 bytes) must still FAIL — the cap is on characters, not bytes.
+for _ in $(seq 501); do printf '\xe2\x80\x94'; done > "$SANDBOX/$CHANGELOG_DIR/7.txt"
+check "guard 6: 501-char (multibyte) changelog fails" 1 "over the 500-char F-Droid whatsNew cap"
 printf 'Short changelog.\n' > "$SANDBOX/$CHANGELOG_DIR/7.txt"
 
 # --- guard 8: redact.sh self-test -----------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes the owner-reported "Resume context automation" bug (DA-018): the active-profile indicator flipped to "Default" but a matching rule wasn't applied and the parameter screens stayed on the loaded profile. Root causes: (1) Resume only republished the unlocked settings (`ContextEngine.reevaluate` + reapply) and never ran the resolver; (2) the no-match fallback was the hardcoded `"Default"` instead of the last manually-loaded profile. Now a dedicated `ACTION_RESUME_CONTEXT` verb runs a genuine `evaluate(RESUME)` then Set Initial Brightness (Tasker `_ContextResume` flow), and `%AAB_ProfileUser` = the last manually-loaded profile is persisted (`ContextBaseline` v1→v2) and used as the resolver fallback — so a matching rule applies immediately and a no-match reverts to that profile with the screens in sync. Covers **DA-018** and **DA-019**.

## Release impact
**versionName 1.8.0 → 1.8.1, versionCode 18 → 19** — patch (bug fix on top of the released 1.8.0; no new capability). F-Droid changelog: `fastlane/metadata/android/en-US/changelogs/19.txt` (302 chars, ships as the release "What's new" via release.yml, D-123).

## Verification
`scripts/ladder.sh` green — guards + `:domain`/`:platform`/`:app` tests + `assembleDebug` + `lintDebug`. New tests: `ContextEngineTest` ×2, `ProfileApplierTest` ×3, `AmbientMonitoringServiceTest` ×1 (RESUME_CONTEXT D-140 gate), `DataStoreSchemaVersionTest` (context-baseline v2); guard fixtures green (48 cases). Glue-review pass (in-context): clean. **Owner-verified on-device**: Resume immediately applies a matching rule / reverts to the last manually-loaded profile with the settings screens in sync (debug APK, `RESUME_CONTEXT_TEST.md`).

## Repo hygiene
**DA-019** (docs/process): ladder guard 6 measured the F-Droid changelog in bytes (`wc -c`) while the prose said "500 characters" — a prose/guard unit drift. It now counts codepoints (`LC_ALL=C tr -d '\200-\277' | wc -c`, matching F-Droid's Python `len`), so a multibyte note can't false-fail. Synced: RUNBOOK §6, the guard-6 header, the agent-agnostic `AGENTIC_HARNESS_PROMPT.md` `{{DOMAIN_GUARDS}}` example, and two multibyte fixtures in `test-ladder-guards.sh`. Also: `datastore_map.md` (contextBaseline v2), `STATE.md`, `DEVIATIONS_LEDGER_A.md` (DA-018/DA-019), and a new `docs/rebuild/RESUME_CONTEXT_TEST.md` on-device script. Rule-review (DA-005) was in-context — no fresh-context reviewer was spawned (harness no-subagent directive); owner directed the DA-019 change.

## Owner action
Squash-merge (this body becomes the squash commit — no `[skip ci]`-class tokens). Then cut **v1.8.1 / vc19** from `main` via the "Draft a new release" UI (tag `v1.8.1`); release.yml builds + signs the tagged commit and F-Droid auto-builds from the tag. No further on-device gates — the DA-018 fix is already owner-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLyBVwJpCA4DFaUfboMaq6

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLyBVwJpCA4DFaUfboMaq6)_