### PR TITLE
Harden release-preflight PR metadata lookup (DA-023)

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -19,7 +19,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 concurrency:
   group: release-preflight-${{ github.ref }}
@@ -28,7 +27,7 @@ concurrency:
 jobs:
   preflight:
     runs-on: ubuntu-latest
-    timeout-minutes: 10  # pure shell + gh, runs in seconds; cap a hung gh call
+    timeout-minutes: 10  # pure shell + local git diff/log; runs in seconds
     steps:
       - name: Checkout (full history + tags)
         uses: actions/checkout@v5
@@ -50,12 +49,15 @@ jobs:
       # ---------------------------------------------------------------------------------------------
       - name: Guard against skip-ci tokens (D-115)
         env:
-          GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          gh pr view "$PR" --json title,commits \
-            --jq '.title, (.commits[] | .messageHeadline, (.messageBody // ""))' > pr_text.txt
+          {
+            printf '%s\n' "$PR_TITLE"
+            git log --format='%s%n%b' "$BASE_SHA..$HEAD_SHA"
+          } > pr_text.txt
           # GitHub honors all of these on push/pull_request events.
           TOKENS=('[skip ci]' '[ci skip]' '[no ci]' '[skip actions]' '[actions skip]' '***NO_CI***')
           found=0
@@ -82,12 +84,13 @@ jobs:
       # ---------------------------------------------------------------------------------------------
       - name: Golden fixtures immutable unless STATE.md justifies (D-162)
         env:
-          GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          if ! FILES=$(gh pr view "$PR" --json files --jq '.files[].path' 2>/dev/null) || [ -z "$FILES" ]; then
-            echo "::warning::Could not list changed files; skipping the golden-fixture gate."
+          FILES=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
+          if [ -z "$FILES" ]; then
+            echo "No changed files found; skipping the golden-fixture gate."
             exit 0
           fi
           golden=false state=false
@@ -118,13 +121,14 @@ jobs:
       - name: Classify PR (ships app code?)
         id: classify
         env:
-          GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          if ! FILES=$(gh pr view "$PR" --json files --jq '.files[].path' 2>/dev/null) || [ -z "$FILES" ]; then
-            echo "::warning::Could not list changed files; enforcing the release-prep gate to be safe."
-            echo "ships=true" >> "$GITHUB_OUTPUT"
+          FILES=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
+          if [ -z "$FILES" ]; then
+            echo "No changed files found; release-prep gate skipped."
+            echo "ships=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "Changed files:"; printf '  %s\n' $FILES

--- a/docs/rebuild/DEVIATIONS_LEDGER_A.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER_A.md
@@ -595,3 +595,5 @@
   link — not in About, not in the menu — and the F-Droid metadata carries no `Donate:` field (that
   would be an MR against `fdroiddata`, still available any time the owner wants it). `[cited]`: none
   (the whole point is that no production code references this).
+
+- DA-023: Release-preflight PR metadata source hardened. PR #93 exposed a recurring CI failure where the `release-preflight.yml` guard depended on `gh pr view`/GitHub API calls for data already present in a full-history checkout (PR title from the event payload, commits from `git log base..head`, files from `git diff base...head`). The gate now uses local git plus `github.event.pull_request.*` SHAs, removing `pull-requests: read` and the external API hop while preserving the D-115 title+commit scan, golden-fixture gate, and ships-app-code classifier.

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -91,6 +91,7 @@ tests green; TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per `RUNBOOK.md`; de
 
 One line per shipped change (newest first); detail in the D-rows and git history.
 
+- 2026-07-25 — **DA-023** (PR #93 CI): release-preflight no longer calls the GitHub CLI/API to read PR title/commits/files; it derives the same data from the checked-out full-history repository (`github.event.pull_request.*` SHAs + local `git log`/`git diff`) so docs-only PRs are not blocked by repeated GitHub API/internal-server failures.
 - 2026-07-24 — **DA-021** (triage #7, owner-asked): assessed the "Claude 5 context engineering"
   rules against this harness — verdict no change (detail in the decided non-item above).
 - 2026-07-24 — **DA-020 → DA-022** (owner-requested, then owner-reversed pre-release): Ko-fi funding


### PR DESCRIPTION
### Motivation
- CI for PR #93 was intermittently failing because `release-preflight.yml` relied on `gh pr view` / GitHub API calls for PR title/commits/files, which can fail or be rate-limited; the data are already available in the checked-out full-history repo and the event payload. 
- The goal is to remove the external API hop and make the preflight guard deterministic and resilient by using local git + the event-provided PR SHAs.

### Description
- Reworked `.github/workflows/release-preflight.yml` so the skip-ci/title+commit scan uses `github.event.pull_request.title` + `git log $BASE_SHA..$HEAD_SHA` and changed-file gates use `git diff $BASE_SHA...$HEAD_SHA`, removing `gh pr view` usage.
- Removed the now-unneeded `pull-requests: read` permission and the `GH_TOKEN`/`gh` dependency, and updated the step comment to reflect the local git implementation.
- Added a `DA-023` entry to `docs/rebuild/STATE.md` and `docs/rebuild/DEVIATIONS_LEDGER_A.md` documenting the CI hardening.

### Testing
- `bash scripts/test-ladder-guards.sh` was run and passed (`GUARD TESTS PASS (48 cases)`).
- `scripts/ladder.sh --guards-only` was run and passed (expected local warning that `origin/main` is unavailable). 
- A Python assertion verified `release-preflight.yml` no longer contains `gh pr view`/`GH_TOKEN` and passed. 
- A smoke test of the replacement metadata commands using `BASE_SHA`/`HEAD_SHA` (local `git log`/`git diff`) succeeded; full Gradle ladder was not runnable locally because the container JDK is `25.0.2` which triggers Kotlin/Gradle pre-check failures, but CI config still sets up JDK 21 before Gradle so the change is expected to run normally in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64acac23c08321891159747576b4f9)