### PR TITLE
Bound profile imports and report oversized files

### DIFF
--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ProfileImportExportManager.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ProfileImportExportManager.kt
@@ -3,8 +3,15 @@ package com.tideo.autobrightness.app.settings
 import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
+import android.provider.OpenableColumns
 import android.util.Log
+import java.io.ByteArrayOutputStream
 import java.io.FileNotFoundException
+import java.io.InputStream
+import java.nio.ByteBuffer
+import java.nio.charset.CharacterCodingException
+import java.nio.charset.CodingErrorAction
+import java.nio.charset.StandardCharsets
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -17,18 +24,28 @@ sealed interface ProfileLoadResult {
     /** Parsed as our own [AabProfilePayload] export format. */
     data class Success(val settings: AabSettings) : ProfileLoadResult
 
-    /** Our format failed; the legacy Tasker parser succeeded. [jsonError] is informational (logged). */
+    /** Our format failed; the legacy Tasker parser succeeded. [jsonError] is diagnostic metadata. */
     data class LegacyFallback(val settings: AabSettings, val jsonError: String) : ProfileLoadResult
 
     /** Neither parser succeeded — the caller shows a user-visible error card. */
     data class TotalFailure(val jsonError: String, val legacyError: String) : ProfileLoadResult
+
+    /** The encoded input is larger than the profile format can reasonably require. */
+    data object TooLarge : ProfileLoadResult
+
+    /** The provider could not be read, or returned bytes that are not valid UTF-8. */
+    data object ReadFailure : ProfileLoadResult
 }
 
 class ProfileImportExportManager(
     private val context: Context,
 ) {
-    private companion object {
-        const val TAG = "ProfileImport"
+    companion object {
+        private const val TAG = "ProfileImport"
+
+        // A full pretty-printed AabSettings export is only a few KiB. This leaves ample room for
+        // future fields and legacy configs while bounding allocations from untrusted providers.
+        internal const val MAX_ENCODED_PROFILE_BYTES = 256 * 1024
     }
 
     private val json = Json { ignoreUnknownKeys = true; prettyPrint = true }
@@ -48,13 +65,67 @@ class ProfileImportExportManager(
     }
 
     suspend fun importFromAppPrivate(profileName: String): ProfileLoadResult {
-        val content = context.openFileInput(sanitizeFileName(profileName)).bufferedReader().use { it.readText() }
-        return decodePayload(content)
+        return runCatching {
+            context.openFileInput(sanitizeFileName(profileName)).use { readAndDecode(it) }
+        }.getOrElse {
+            Log.w(TAG, "Profile input could not be read")
+            ProfileLoadResult.ReadFailure
+        }
     }
 
     suspend fun importFromDocument(uri: Uri, resolver: ContentResolver = context.contentResolver): ProfileLoadResult {
-        val content = resolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
-            ?: throw FileNotFoundException("Unable to open input stream for uri=$uri")
+        val declaredSize = runCatching {
+            resolver.query(uri, arrayOf(OpenableColumns.SIZE), null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst() && !cursor.isNull(0)) cursor.getLong(0) else null
+            }
+        }.getOrNull()
+        return runCatching {
+            resolver.openInputStream(uri)?.use { readAndDecode(it, declaredSize) }
+                ?: return ProfileLoadResult.ReadFailure
+        }.getOrElse {
+            // URI and provider exception details can contain private document names or authorities.
+            Log.w(TAG, "Profile input could not be read")
+            ProfileLoadResult.ReadFailure
+        }
+    }
+
+    internal fun readAndDecode(input: InputStream, declaredSize: Long? = null): ProfileLoadResult {
+        if (declaredSize != null && declaredSize > MAX_ENCODED_PROFILE_BYTES) {
+            return ProfileLoadResult.TooLarge
+        }
+        val bytes = ByteArrayOutputStream(MAX_ENCODED_PROFILE_BYTES.coerceAtMost(DEFAULT_BUFFER_SIZE))
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        var remaining = MAX_ENCODED_PROFILE_BYTES + 1
+        try {
+            while (remaining > 0) {
+                val count = input.read(buffer, 0, minOf(buffer.size, remaining))
+                if (count < 0) break
+                if (count == 0) {
+                    val byte = input.read()
+                    if (byte < 0) break
+                    bytes.write(byte)
+                    remaining--
+                    continue
+                }
+                bytes.write(buffer, 0, count)
+                remaining -= count
+            }
+        } catch (_: Exception) {
+            Log.w(TAG, "Profile input could not be read")
+            return ProfileLoadResult.ReadFailure
+        }
+        if (bytes.size() > MAX_ENCODED_PROFILE_BYTES) return ProfileLoadResult.TooLarge
+
+        val content = try {
+            StandardCharsets.UTF_8.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .decode(ByteBuffer.wrap(bytes.toByteArray()))
+                .toString()
+        } catch (_: CharacterCodingException) {
+            Log.w(TAG, "Profile input is not valid UTF-8")
+            return ProfileLoadResult.ReadFailure
+        }
         return decodePayload(content)
     }
 
@@ -64,7 +135,7 @@ class ProfileImportExportManager(
 
     /**
      * Decode a profile file, trying our [AabProfilePayload] format first and the legacy Tasker parser
-     * second. Logs the JSON failure on a legacy fallback and both failures on a total failure (S12.9c #3).
+     * second. Logs only the outcome, never parser details that could quote imported content.
      */
     fun decodePayload(content: String): ProfileLoadResult {
         val jsonAttempt = runCatching {
@@ -75,11 +146,11 @@ class ProfileImportExportManager(
 
         val legacyAttempt = runCatching { TaskerLegacyProfileSerializer.deserialize(content).validate() }
         legacyAttempt.getOrNull()?.let {
-            Log.w(TAG, "Profile not in app format; loaded via legacy parser. JSON error: $jsonError")
+            Log.w(TAG, "Profile not in app format; loaded via legacy parser")
             return ProfileLoadResult.LegacyFallback(it, jsonError)
         }
         val legacyError = legacyAttempt.exceptionOrNull()?.message ?: "Legacy parse failed"
-        Log.e(TAG, "Profile load failed. JSON error: $jsonError; legacy error: $legacyError")
+        Log.e(TAG, "Profile load failed validation")
         return ProfileLoadResult.TotalFailure(jsonError, legacyError)
     }
 

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ProfilesContextsScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ProfilesContextsScreen.kt
@@ -124,6 +124,14 @@ fun ProfilesContextsScreen(
             loadError = context.getString(R.string.profiles_unreadable)
             context.getString(R.string.toast_load_failed)
         }
+        ProfileLoadResult.TooLarge -> {
+            loadError = context.getString(R.string.profiles_too_large)
+            context.getString(R.string.toast_load_failed)
+        }
+        ProfileLoadResult.ReadFailure -> {
+            loadError = context.getString(R.string.profiles_read_failed)
+            context.getString(R.string.toast_load_failed)
+        }
     }
 
     // Previously-granted Download/AAB/configs tree (persisted SAF permission), if any.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -589,6 +589,8 @@
     <string name="toast_loaded_entry">Loaded %1$s</string>
     <string name="toast_load_failed_detail">Load failed: %1$s</string>
     <string name="profiles_unreadable">Couldn\'t read this profile. It isn\'t a Tideo export or a Tasker AAB config.</string>
+    <string name="profiles_too_large">This profile is too large to import.</string>
+    <string name="profiles_read_failed">Couldn\'t safely read this profile. Try selecting it again.</string>
 
     <!-- Profiles (body + dialogs) -->
     <string name="profiles_save_as">Save current settings as…</string>

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/settings/ProfileLoadResultTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/settings/ProfileLoadResultTest.kt
@@ -1,6 +1,10 @@
 package com.tideo.autobrightness.app.settings
 
 import androidx.test.core.app.ApplicationProvider
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
+import kotlinx.coroutines.runBlocking
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -18,6 +22,17 @@ class ProfileLoadResultTest {
     private val manager = ProfileImportExportManager(ApplicationProvider.getApplicationContext())
 
     @Test
+    fun `normal app export imports through bounded reader`() = runBlocking {
+        val name = "bounded-reader-round-trip"
+        manager.exportToAppPrivate(name, AabSettings(minBrightness = 17))
+
+        val result = manager.importFromAppPrivate(name)
+
+        assertTrue(result is ProfileLoadResult.Success)
+        assertEquals(17, result.settings.minBrightness)
+    }
+
+    @Test
     fun `our export format is a Success`() {
         // The app's own export wraps settings in an AabProfilePayload { schemaVersion, settings }.
         val payload = """{ "schemaVersion": 3, "settings": { "minBrightness": 7 } }"""
@@ -29,10 +44,53 @@ class ProfileLoadResultTest {
     @Test
     fun `a Tasker nested config is a LegacyFallback`() {
         val taskerConfig = """{ "general": { "z1_end": 50.0 } }"""
-        val result = manager.decodePayload(taskerConfig)
+        val result = manager.readAndDecode(ByteArrayInputStream(taskerConfig.encodeToByteArray()))
         assertTrue(result is ProfileLoadResult.LegacyFallback, "expected LegacyFallback, got $result")
         assertEquals(50, (result as ProfileLoadResult.LegacyFallback).settings.zone1End)
         assertTrue(result.jsonError.isNotEmpty(), "the JSON error should be recorded")
+    }
+
+    @Test
+    fun `input exactly at encoded limit is accepted by the reader`() {
+        val prefix = """{ "schemaVersion": 3, "settings": { "minBrightness": 19 } }"""
+        val bytes = prefix.padEnd(ProfileImportExportManager.MAX_ENCODED_PROFILE_BYTES).encodeToByteArray()
+
+        val result = manager.readAndDecode(ByteArrayInputStream(bytes))
+
+        assertTrue(result is ProfileLoadResult.Success)
+        assertEquals(19, result.settings.minBrightness)
+    }
+
+    @Test
+    fun `input one byte over encoded limit is rejected`() {
+        val bytes = ByteArray(ProfileImportExportManager.MAX_ENCODED_PROFILE_BYTES + 1) { ' '.code.toByte() }
+
+        assertEquals(ProfileLoadResult.TooLarge, manager.readAndDecode(ByteArrayInputStream(bytes)))
+    }
+
+    @Test
+    fun `absent and inaccurate declared sizes cannot bypass streaming bound`() {
+        val normal = """{ "schemaVersion": 3, "settings": { "minBrightness": 23 } }""".encodeToByteArray()
+        assertTrue(manager.readAndDecode(ByteArrayInputStream(normal), declaredSize = null) is ProfileLoadResult.Success)
+
+        val oversized = ByteArray(ProfileImportExportManager.MAX_ENCODED_PROFILE_BYTES + 1)
+        assertEquals(
+            ProfileLoadResult.TooLarge,
+            manager.readAndDecode(ByteArrayInputStream(oversized), declaredSize = 1),
+        )
+    }
+
+    @Test
+    fun `malformed UTF-8 and stream failures are typed read failures`() {
+        assertEquals(
+            ProfileLoadResult.ReadFailure,
+            manager.readAndDecode(ByteArrayInputStream(byteArrayOf(0xC3.toByte(), 0x28))),
+        )
+        val failingStream = object : InputStream() {
+            override fun read(): Int = throw IOException("private provider detail")
+            override fun read(buffer: ByteArray, offset: Int, length: Int): Int = read()
+        }
+        assertEquals(ProfileLoadResult.ReadFailure, manager.readAndDecode(failingStream))
     }
 
     @Test

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -95,6 +95,9 @@ TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per `RUNBOOK.md`; deviations in
 
 One line per shipped change (newest first); detail in the D-rows and git history.
 
+- 2026-07-28 — Profile imports now stream at most 256 KiB + one byte, strictly decode UTF-8,
+  distrust provider size metadata, and return safe typed failures for oversized/unreadable inputs;
+  the Profiles UI distinguishes an oversized file from malformed content.
 - 2026-07-28 — **1.8.2 / vc20 cut** (patch): release-preflight correctly classified the AGP bump as
   shipping app code, so RUNBOOK §6 required the bump — taken rather than weakening the gate.
 - 2026-07-28 — **DA-026 → DA-028**: **AGP 8.7.3 → 8.13.2**, verified in F-Droid's own buildserver


### PR DESCRIPTION
### Motivation

- Prevent unbounded allocations and OOMs when importing profiles from untrusted document providers by replacing `readText()` with a bounded streaming reader.
- Do not trust provider-declared sizes (`OpenableColumns.SIZE`) as authoritative; allow it only as an early rejection hint and always enforce the actual streamed limit. 
- Fail safely and privately on malformed UTF-8 or read errors and surface size-specific/reading errors to the UI without logging provider contents or sensitive details.

### Description

- Introduce a conservative encoded-size limit `MAX_ENCODED_PROFILE_BYTES = 256 * 1024` and add new `ProfileLoadResult` variants: `TooLarge` and `ReadFailure`.
- Replace the previous `readText()` usage with a streaming helper `readAndDecode(input: InputStream, declaredSize: Long? = null)` that reads up to the configured limit plus one byte (overflow probe), rejects oversized input as `TooLarge`, and strictly decodes UTF-8 (rejecting malformed input as `ReadFailure`).
- Use `OpenableColumns.SIZE` only as an early rejection if present; always enforce the bound against the actual stream and handle provider/read exceptions by returning `ReadFailure` while logging only a privacy-safe outcome.
- Reduce log detail from parser exceptions to avoid quoting imported content; `decodePayload` logs only the high-level outcome.
- Update import entry points: `importFromAppPrivate` and `importFromDocument` now call `readAndDecode` and return typed failures instead of throwing or allocating the whole content.
- Update the import UI in `ProfilesContextsScreen.kt` to map `ProfileLoadResult.TooLarge` and `ProfileLoadResult.ReadFailure` to user-visible error messages and add localized strings `profiles_too_large` and `profiles_read_failed`.
- Add unit tests in `ProfileLoadResultTest.kt` covering: normal app export/import round-trip via the bounded reader, legacy-profile fallback path via the streaming reader, input exactly at the byte limit accepted, input one byte over the limit rejected, declared size absent/inaccurate cannot bypass the streaming bound, and malformed UTF-8/stream failures produce `ReadFailure`.
- Record the maintenance change in `docs/rebuild/STATE.md`.

### Testing

- `git diff --check` — passed.
- `scripts/ladder.sh --guards-only` — passed (local guards OK; `origin/main` advisory skipped because the remote was unavailable in this environment).
- Attempted `./gradlew :app:testDebugUnitTest --tests com.tideo.autobrightness.app.settings.ProfileLoadResultTest` in this environment failed due to dependency resolution for the Android Gradle plugin and repository/network limits, so the new unit tests were added but could not be executed end-to-end here.
- The change is covered by the added unit tests in `app/src/test/kotlin/com/tideo/autobrightness/app/settings/ProfileLoadResultTest.kt`, which exercise normal export, legacy fallback, exact/over-limit boundaries, declared-size bypass attempts, malformed UTF-8, and failing streams (tests are present in the branch but not resolved by the local Gradle run due to plugin resolution failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68dd9ad57883219d22c77c8d594de9)