### PR TITLE
Gate START_STICKY restarts on persisted enablement, delay runtime startup until confirmed

### DIFF
--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
@@ -24,6 +24,7 @@ import com.tideo.autobrightness.app.storage.controlPrefsDataStore
 import com.tideo.autobrightness.app.storage.settingsDataStore
 import com.tideo.autobrightness.app.widget.DashboardWidgetProvider
 import com.tideo.autobrightness.platform.display.ForceDarkController
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -68,6 +69,17 @@ class AmbientMonitoringService : Service() {
     // D-172: one-shot per service instance (kept non-null after completion so ensureRunning's
     // re-entries — resume/reapply — never re-bind Shizuku).
     private var forceDarkJob: Job? = null
+    private var stickyRestartGateJob: Job? = null
+    private var stickyRestartGeneration = 0L
+    private var destroyed = false
+    // Test seam for holding the sticky-restart DataStore read in flight. Production always reads the
+    // persisted setting; keeping the suspension injectable lets lifecycle race tests be deterministic.
+    internal var stickyRestartEnabledReader: suspend () -> Boolean = {
+        applicationContext.settingsDataStore.data.first().serviceEnabled
+    }
+    internal var runtimeStartCount = 0
+        private set
+    private var runtimeStarted = false
     private val mainHandler = Handler(Looper.getMainLooper())
 
     // Rising-edge latch so the high-priority override alert + toast fire ONCE per override, not on
@@ -141,6 +153,15 @@ class AmbientMonitoringService : Service() {
             ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
         )
 
+        // A real command supersedes a pending OS-restart decision. In particular ACTION_START is
+        // trusted because every explicit starter persists serviceEnabled before sending it, so it
+        // retains the existing synchronous startup latency and semantics.
+        if (intent != null) {
+            stickyRestartGeneration++
+            stickyRestartGateJob?.cancel()
+            stickyRestartGateJob = null
+        }
+
         when (intent?.action) {
             ACTION_PAUSE -> {
                 // D-140: startForegroundService CREATES the service, so a PAUSE aimed at "the running
@@ -205,14 +226,41 @@ class AmbientMonitoringService : Service() {
                 return START_NOT_STICKY
             }
             else -> {
-                ensureRunning()
-                // D-140 defense for the START_STICKY hole: an OS sticky restart (null intent) re-runs
-                // the pipeline unconditionally, but the user may have disabled the service while it was
-                // dead (the toggle's stopService is a no-op then) — re-check the persisted flag and tear
-                // down if it says off. All explicit starters already pre-check serviceEnabled, so for
-                // them this read is a cheap no-op.
-                scope.launch {
-                    if (!applicationContext.settingsDataStore.data.first().serviceEnabled) disableAndStop()
+                if (intent != null) {
+                    ensureRunning()
+                } else {
+                    // D-140 defense for the START_STICKY hole: an OS restart supplies a null intent,
+                    // and the user may have disabled the service while its old process was dead. The
+                    // foreground notification above satisfies the FGS deadline, but NOTHING in the
+                    // runtime graph starts until DataStore confirms the persisted opt-in. A later null
+                    // delivery replaces this decision; the startId paired with the winning read is the
+                    // one stopped on the disabled path.
+                    stickyRestartGateJob?.cancel()
+                    val generation = ++stickyRestartGeneration
+                    stickyRestartGateJob = scope.launch {
+                        val enabled = try {
+                            stickyRestartEnabledReader()
+                        } catch (cancelled: CancellationException) {
+                            throw cancelled
+                        } catch (_: Exception) {
+                            // A corrupt/unreadable store must fail closed rather than strand an empty
+                            // START_STICKY foreground service indefinitely.
+                            false
+                        }
+                        // Lifecycle commands are delivered on main. Serialize the decision there too:
+                        // cancel() alone cannot stop a coroutine that has returned from its last
+                        // suspension, whereas this generation check makes supersession/destruction
+                        // authoritative even in that completion race.
+                        mainHandler.post {
+                            if (destroyed || stickyRestartGeneration != generation) return@post
+                            stickyRestartGateJob = null
+                            if (enabled) {
+                                ensureRunning()
+                            } else {
+                                stopNotRunning(startId)
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -232,6 +280,10 @@ class AmbientMonitoringService : Service() {
     }
 
     private fun ensureRunning() {
+        if (!runtimeStarted) {
+            runtimeStarted = true
+            runtimeStartCount++
+        }
         // Refresh the cached tier at the service-resume points (start / resume / reapply) so an
         // out-of-band grant is reflected without the per-cycle permission check the dimming path used
         // to do (G1-F5). currentTier() reads this cache thereafter.
@@ -584,14 +636,19 @@ class AmbientMonitoringService : Service() {
         // assumes for onDestroy.)
         if (externalControlEnabled) broadcastStateChanged(enabled = false, running = false, paused = false, profile = null)
         runCatching { unregisterReceiver(screenReceiver) }
+        destroyed = true
+        stickyRestartGeneration++
+        stickyRestartGateJob?.cancel(); stickyRestartGateJob = null
         panicJob?.cancel(); panicJob = null
         stateEventJob?.cancel(); stateEventJob = null
-        contextEngine.stop()
-        controller.stop()
-        // Return the display toggles to the baseline profile's values (D-151 resting state): a
-        // context-profile override must not outlive the runtime that applies it. Before
-        // scope.cancel() so the coordinator can serialize against an in-flight apply.
-        displayToggles.stop()
+        if (runtimeStarted) {
+            contextEngine.stop()
+            controller.stop()
+            // Return the display toggles to the baseline profile's values (D-151 resting state): a
+            // context-profile override must not outlive the runtime that applies it. Before
+            // scope.cancel() so the coordinator can serialize against an in-flight apply.
+            displayToggles.stop()
+        }
         // Watchdog instead of an immediate reset (S12.9d): if the OS restarts the FGS and it
         // republishes within the grace window, the live data survives; otherwise it is cleared so the
         // Dashboard does not show a stale "live" snapshot for a dead loop. A genuine user-driven stop

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringServiceTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringServiceTest.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import com.tideo.autobrightness.app.storage.settingsDataStore
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -22,6 +23,113 @@ import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
 class AmbientMonitoringServiceTest {
+
+    @Test
+    fun disabledStickyRestart_stopsWithoutStartingRuntimeOrWriters() {
+        val gate = CompletableDeferred<Unit>()
+        val controller = Robolectric.buildService(AmbientMonitoringService::class.java).create()
+        try {
+            val service = controller.get()
+            service.stickyRestartEnabledReader = { gate.await(); false }
+
+            service.onStartCommand(null, 0, 41)
+            assertNotNull(shadowOf(service).lastForegroundNotification, "FGS deadline is met while the gate waits")
+            assertEquals(0, service.runtimeStartCount, "no runtime component or writer may start before confirmation")
+
+            gate.complete(Unit)
+            waitUntil { shadowOf(service).isStoppedBySelf }
+            assertEquals(0, service.runtimeStartCount, "disabled restart must never reach runtime/writer startup")
+        } finally {
+            controller.destroy()
+        }
+    }
+
+    @Test
+    fun enabledStickyRestart_startsRuntimeExactlyOnce() {
+        val gate = CompletableDeferred<Unit>()
+        val controller = Robolectric.buildService(AmbientMonitoringService::class.java).create()
+        try {
+            val service = controller.get()
+            service.stickyRestartEnabledReader = { gate.await(); true }
+            service.onStartCommand(null, 0, 42)
+
+            gate.complete(Unit)
+            waitUntil { service.runtimeStartCount == 1 }
+            assertEquals(1, service.runtimeStartCount)
+            assertFalse(shadowOf(service).isStoppedBySelf)
+        } finally {
+            controller.destroy()
+        }
+    }
+
+    @Test
+    fun failedStickyRestartRead_failsClosedWithoutRuntimeStartup() {
+        val controller = Robolectric.buildService(AmbientMonitoringService::class.java).create()
+        try {
+            val service = controller.get()
+            service.stickyRestartEnabledReader = { error("unreadable settings") }
+
+            service.onStartCommand(null, 0, 46)
+            waitUntil { shadowOf(service).isStoppedBySelf }
+
+            assertEquals(0, service.runtimeStartCount)
+        } finally {
+            controller.destroy()
+        }
+    }
+
+    @Test
+    fun destructionWhileStickyRestartGatePending_preventsLateRuntimeStartup() {
+        val readerReturned = CompletableDeferred<Unit>()
+        val controller = Robolectric.buildService(AmbientMonitoringService::class.java).create()
+        val service = controller.get()
+        service.stickyRestartEnabledReader = {
+            readerReturned.complete(Unit)
+            true
+        }
+        service.onStartCommand(null, 0, 43)
+
+        runBlocking { readerReturned.await() }
+        // The background read has completed, but its main-thread decision has not run. Destroy in
+        // precisely the cancel-after-last-suspension window that previously allowed late startup.
+        controller.destroy()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(0, service.runtimeStartCount, "destroy must cancel the gate before any runtime stop/write path")
+    }
+
+    @Test
+    fun explicitStartWhileStickyRestartGatePending_supersedesGateAndStartsOnce() {
+        val readerReturned = CompletableDeferred<Unit>()
+        val controller = Robolectric.buildService(AmbientMonitoringService::class.java).create()
+        try {
+            val service = controller.get()
+            service.stickyRestartEnabledReader = {
+                readerReturned.complete(Unit)
+                false
+            }
+            service.onStartCommand(null, 0, 44)
+            runBlocking { readerReturned.await() }
+
+            service.onStartCommand(Intent().setAction(AmbientMonitoringService.ACTION_START), 0, 45)
+            assertEquals(1, service.runtimeStartCount, "trusted explicit starts retain synchronous semantics")
+            shadowOf(Looper.getMainLooper()).idle()
+
+            assertEquals(1, service.runtimeStartCount, "the cancelled sticky decision cannot start or stop again")
+            assertFalse(shadowOf(service).isStoppedBySelf)
+        } finally {
+            controller.destroy()
+        }
+    }
+
+    private fun waitUntil(condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + 2_000
+        while (!condition() && System.currentTimeMillis() < deadline) {
+            shadowOf(Looper.getMainLooper()).idle()
+            Thread.sleep(10)
+        }
+        assertTrue(condition(), "asynchronous service transition timed out")
+    }
 
     @Test
     fun onStartCommand_postsForegroundNotification() {
@@ -144,12 +252,8 @@ class AmbientMonitoringServiceTest {
     // The positive path must survive the D-140 gate: once START has run the pipeline (serviceOn=true,
     // set synchronously by controller.start()), PAUSE and REAPPLY act on it and keep the service up.
     //
-    // ACTION_START falls into the service's `else` branch, whose D-140 START_STICKY defense fires a
-    // `scope.launch { if (!serviceEnabled) disableAndStop() }` on Dispatchers.Default (a background
-    // thread). With the DataStore left at its default `serviceEnabled=false` that guard could tear the
-    // service down mid-test, nondeterministically — a real race, not a test artifact. Seed
-    // `serviceEnabled=true` first (exactly what every explicit starter does in production, per the
-    // branch's own comment) so the guard is a no-op regardless of thread timing.
+    // ACTION_START is a trusted explicit command: its caller has already persisted serviceEnabled,
+    // and it deliberately bypasses the asynchronous null-intent sticky-restart gate.
     @Test
     fun pauseAndReapply_whilePipelineRunning_keepTheServiceUp() {
         val app = ApplicationProvider.getApplicationContext<Context>()

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -95,6 +95,9 @@ TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per `RUNBOOK.md`; deviations in
 
 One line per shipped change (newest first); detail in the D-rows and git history.
 
+- 2026-07-28 — Fixed null-intent `START_STICKY` restarts to await the persisted service-enabled
+  flag behind the already-posted foreground notification before activating any runtime component;
+  explicit starts stay synchronous, and pending gates are safely superseded or destroyed.
 - 2026-07-28 — **1.8.2 / vc20 cut** (patch): release-preflight correctly classified the AGP bump as
   shipping app code, so RUNBOOK §6 required the bump — taken rather than weakening the gate.
 - 2026-07-28 — **DA-026 → DA-028**: **AGP 8.7.3 → 8.13.2**, verified in F-Droid's own buildserver


### PR DESCRIPTION
### Motivation

- Prevent an OS `START_STICKY` (null-intent) service restart from unconditionally bringing up the runtime when the user has since disabled the service in persisted settings.  
- Maintain the foreground-service deadline by posting the notification immediately while delaying any brightness pipeline, sensors, context engine, display toggles, panic detector, or force-dark reapply until the persisted `serviceEnabled` is confirmed true.  
- Preserve the synchronous semantics and latency of trusted explicit start intents while making null-intent restarts safe and cancelable by newer commands or destruction.  

### Description

- Post the foreground notification immediately in `onStartCommand`, and only run the persisted opt-in check for null-intent (OS sticky) restarts via an asynchronous gate before calling `ensureRunning()`; explicit non-null intents continue to call `ensureRunning()` synchronously.  
- Added an injectable test seam `stickyRestartEnabledReader: suspend () -> Boolean`, a `stickyRestartGateJob`, a generation counter and `destroyed` flag, and main-thread serialization so stale/late reads cannot start or stop the runtime after a newer command or teardown supersedes them.  
- Make read failures fail-closed (treat unreadable settings as `false`) so an unreadable store does not leave a foreground service running with writers/sensors active.  
- Track `runtimeStarted` / `runtimeStartCount` to avoid calling `contextEngine.stop()`, `controller.stop()`, or display writer paths when the runtime was never activated.  
- Added Robolectric tests in `AmbientMonitoringServiceTest` that exercise: disabled sticky restart (never starts runtime/writers), enabled sticky restart (starts runtime exactly once), failed-read behavior (fails closed), destruction during the pending gate (prevents late startup), and explicit start superseding a pending gate.  
- Updated repository session `STATE.md` to record the change.  

### Testing

- Ran `git diff --check` (clean) and `scripts/ladder.sh --guards-only` (guards-only passed).  
- Performed an adversarial fresh-context glue review and fixed lifecycle/race issues discovered during the review; re-review passed after fixes.  
- Added Robolectric unit tests covering the disabled/enabled restart paths and race/failure cases, but running `:app:testDebugUnitTest` in this environment failed because the Android Gradle Plugin (AGP 8.13.2) could not be resolved and the SDK bootstrap returned HTTP 403, so JVM/Robolectric tests could not be executed here.  
- On-device / owner verification remains the final acceptance step per project policy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68dd99249c83218b73b0b887880051)