### PR TITLE
DA-029/DA-030: Bounded profile import + sticky-restart gate

### DIFF
--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
@@ -24,6 +24,7 @@ import com.tideo.autobrightness.app.storage.controlPrefsDataStore
 import com.tideo.autobrightness.app.storage.settingsDataStore
 import com.tideo.autobrightness.app.widget.DashboardWidgetProvider
 import com.tideo.autobrightness.platform.display.ForceDarkController
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -68,6 +69,22 @@ class AmbientMonitoringService : Service() {
     // D-172: one-shot per service instance (kept non-null after completion so ensureRunning's
     // re-entries — resume/reapply — never re-bind Shizuku).
     private var forceDarkJob: Job? = null
+    // DA-030 (extends D-140): state for the null-intent START_STICKY gate. The generation counter is
+    // bumped by every command AND by onDestroy, and re-checked on the main thread after the read
+    // returns — cancel() alone cannot stop a coroutine that has already passed its last suspension,
+    // so cancellation is necessary but not sufficient to keep a stale read from starting the runtime.
+    private var stickyRestartGateJob: Job? = null
+    private var stickyRestartGeneration = 0L
+    private var destroyed = false
+    // DA-030: test seam for holding the sticky-restart DataStore read in flight (same precedent as
+    // externalControlEnabled below). Production always reads the persisted setting; a real read
+    // completes before a test can interleave the superseding command the race is about.
+    internal var stickyRestartEnabledReader: suspend () -> Boolean = {
+        applicationContext.settingsDataStore.data.first().serviceEnabled
+    }
+    internal var runtimeStartCount = 0
+        private set
+    private var runtimeStarted = false
     private val mainHandler = Handler(Looper.getMainLooper())
 
     // Rising-edge latch so the high-priority override alert + toast fire ONCE per override, not on
@@ -141,6 +158,15 @@ class AmbientMonitoringService : Service() {
             ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
         )
 
+        // A real command supersedes a pending OS-restart decision. In particular ACTION_START is
+        // trusted because every explicit starter persists serviceEnabled before sending it, so it
+        // retains the existing synchronous startup latency and semantics.
+        if (intent != null) {
+            stickyRestartGeneration++
+            stickyRestartGateJob?.cancel()
+            stickyRestartGateJob = null
+        }
+
         when (intent?.action) {
             ACTION_PAUSE -> {
                 // D-140: startForegroundService CREATES the service, so a PAUSE aimed at "the running
@@ -205,14 +231,53 @@ class AmbientMonitoringService : Service() {
                 return START_NOT_STICKY
             }
             else -> {
-                ensureRunning()
-                // D-140 defense for the START_STICKY hole: an OS sticky restart (null intent) re-runs
-                // the pipeline unconditionally, but the user may have disabled the service while it was
-                // dead (the toggle's stopService is a no-op then) — re-check the persisted flag and tear
-                // down if it says off. All explicit starters already pre-check serviceEnabled, so for
-                // them this read is a cheap no-op.
-                scope.launch {
-                    if (!applicationContext.settingsDataStore.data.first().serviceEnabled) disableAndStop()
+                if (intent != null) {
+                    // DA-030: an explicit start keeps the synchronous path and skips the read. Every
+                    // explicit starter already establishes serviceEnabled first — BootCompletedReceiver
+                    // and MaintenanceWorker read it before sending, ControlReceiver/tile/widget
+                    // updateData it before sending. A NEW ACTION_START sender must do the same or it
+                    // does not belong on this branch.
+                    ensureRunning()
+                } else {
+                    // DA-030, extending the D-140 defense for the START_STICKY hole (D-140 called
+                    // ensureRunning() first and undid it after, so a disabled service still briefly
+                    // ran sensors, the brightness writer and the display-toggle writes):
+                    // an OS restart supplies a null intent,
+                    // and the user may have disabled the service while its old process was dead. The
+                    // foreground notification above satisfies the FGS deadline, but NOTHING in the
+                    // runtime graph starts until DataStore confirms the persisted opt-in. A later null
+                    // delivery replaces this decision; the startId paired with the winning read is the
+                    // one stopped on the disabled path.
+                    stickyRestartGateJob?.cancel()
+                    val generation = ++stickyRestartGeneration
+                    stickyRestartGateJob = scope.launch {
+                        val enabled = try {
+                            stickyRestartEnabledReader()
+                        } catch (cancelled: CancellationException) {
+                            throw cancelled
+                        } catch (_: Exception) {
+                            // A corrupt/unreadable store must fail closed rather than strand an empty
+                            // START_STICKY foreground service indefinitely.
+                            false
+                        }
+                        // Lifecycle commands are delivered on main. Serialize the decision there too:
+                        // cancel() alone cannot stop a coroutine that has returned from its last
+                        // suspension, whereas this generation check makes supersession/destruction
+                        // authoritative even in that completion race.
+                        mainHandler.post {
+                            if (destroyed || stickyRestartGeneration != generation) return@post
+                            stickyRestartGateJob = null
+                            if (enabled) {
+                                ensureRunning()
+                            } else {
+                                // NOT D-140's disableAndStop(): that persists serviceEnabled = false,
+                                // which would turn a transient read failure into a write, and its
+                                // LiveRuntimeState.reset() + widget repaint are moot when the runtime
+                                // never started.
+                                stopNotRunning(startId)
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -232,6 +297,10 @@ class AmbientMonitoringService : Service() {
     }
 
     private fun ensureRunning() {
+        if (!runtimeStarted) {
+            runtimeStarted = true
+            runtimeStartCount++
+        }
         // Refresh the cached tier at the service-resume points (start / resume / reapply) so an
         // out-of-band grant is reflected without the per-cycle permission check the dimming path used
         // to do (G1-F5). currentTier() reads this cache thereafter.
@@ -584,14 +653,19 @@ class AmbientMonitoringService : Service() {
         // assumes for onDestroy.)
         if (externalControlEnabled) broadcastStateChanged(enabled = false, running = false, paused = false, profile = null)
         runCatching { unregisterReceiver(screenReceiver) }
+        destroyed = true
+        stickyRestartGeneration++
+        stickyRestartGateJob?.cancel(); stickyRestartGateJob = null
         panicJob?.cancel(); panicJob = null
         stateEventJob?.cancel(); stateEventJob = null
-        contextEngine.stop()
-        controller.stop()
-        // Return the display toggles to the baseline profile's values (D-151 resting state): a
-        // context-profile override must not outlive the runtime that applies it. Before
-        // scope.cancel() so the coordinator can serialize against an in-flight apply.
-        displayToggles.stop()
+        if (runtimeStarted) {
+            contextEngine.stop()
+            controller.stop()
+            // Return the display toggles to the baseline profile's values (D-151 resting state): a
+            // context-profile override must not outlive the runtime that applies it. Before
+            // scope.cancel() so the coordinator can serialize against an in-flight apply.
+            displayToggles.stop()
+        }
         // Watchdog instead of an immediate reset (S12.9d): if the OS restarts the FGS and it
         // republishes within the grace window, the live data survives; otherwise it is cleared so the
         // Dashboard does not show a stale "live" snapshot for a dead loop. A genuine user-driven stop

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
@@ -297,10 +297,11 @@ class AmbientMonitoringService : Service() {
     }
 
     private fun ensureRunning() {
-        if (!runtimeStarted) {
-            runtimeStarted = true
-            runtimeStartCount++
-        }
+        // DA-030: runtimeStarted LATCHES (onDestroy only needs "was the graph ever up"), but the
+        // counter must NOT — a latched counter cannot tell one activation from two, which is exactly
+        // what the supersession tests claim to prove.
+        runtimeStarted = true
+        runtimeStartCount++
         // Refresh the cached tier at the service-resume points (start / resume / reapply) so an
         // out-of-band grant is reflected without the per-cycle permission check the dimming path used
         // to do (G1-F5). currentTier() reads this cache thereafter.

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
@@ -24,6 +24,7 @@ import com.tideo.autobrightness.app.storage.controlPrefsDataStore
 import com.tideo.autobrightness.app.storage.settingsDataStore
 import com.tideo.autobrightness.app.widget.DashboardWidgetProvider
 import com.tideo.autobrightness.platform.display.ForceDarkController
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -68,6 +69,17 @@ class AmbientMonitoringService : Service() {
     // D-172: one-shot per service instance (kept non-null after completion so ensureRunning's
     // re-entries — resume/reapply — never re-bind Shizuku).
     private var forceDarkJob: Job? = null
+    private var stickyRestartGateJob: Job? = null
+    private var stickyRestartGeneration = 0L
+    private var destroyed = false
+    // Test seam for holding the sticky-restart DataStore read in flight. Production always reads the
+    // persisted setting; keeping the suspension injectable lets lifecycle race tests be deterministic.
+    internal var stickyRestartEnabledReader: suspend () -> Boolean = {
+        applicationContext.settingsDataStore.data.first().serviceEnabled
+    }
+    internal var runtimeStartCount = 0
+        private set
+    private var runtimeStarted = false
     private val mainHandler = Handler(Looper.getMainLooper())
 
     // Rising-edge latch so the high-priority override alert + toast fire ONCE per override, not on
@@ -141,6 +153,15 @@ class AmbientMonitoringService : Service() {
             ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
         )
 
+        // A real command supersedes a pending OS-restart decision. In particular ACTION_START is
+        // trusted because every explicit starter persists serviceEnabled before sending it, so it
+        // retains the existing synchronous startup latency and semantics.
+        if (intent != null) {
+            stickyRestartGeneration++
+            stickyRestartGateJob?.cancel()
+            stickyRestartGateJob = null
+        }
+
         when (intent?.action) {
             ACTION_PAUSE -> {
                 // D-140: startForegroundService CREATES the service, so a PAUSE aimed at "the running
@@ -205,14 +226,41 @@ class AmbientMonitoringService : Service() {
                 return START_NOT_STICKY
             }
             else -> {
-                ensureRunning()
-                // D-140 defense for the START_STICKY hole: an OS sticky restart (null intent) re-runs
-                // the pipeline unconditionally, but the user may have disabled the service while it was
-                // dead (the toggle's stopService is a no-op then) — re-check the persisted flag and tear
-                // down if it says off. All explicit starters already pre-check serviceEnabled, so for
-                // them this read is a cheap no-op.
-                scope.launch {
-                    if (!applicationContext.settingsDataStore.data.first().serviceEnabled) disableAndStop()
+                if (intent != null) {
+                    ensureRunning()
+                } else {
+                    // D-140 defense for the START_STICKY hole: an OS restart supplies a null intent,
+                    // and the user may have disabled the service while its old process was dead. The
+                    // foreground notification above satisfies the FGS deadline, but NOTHING in the
+                    // runtime graph starts until DataStore confirms the persisted opt-in. A later null
+                    // delivery replaces this decision; the startId paired with the winning read is the
+                    // one stopped on the disabled path.
+                    stickyRestartGateJob?.cancel()
+                    val generation = ++stickyRestartGeneration
+                    stickyRestartGateJob = scope.launch {
+                        val enabled = try {
+                            stickyRestartEnabledReader()
+                        } catch (cancelled: CancellationException) {
+                            throw cancelled
+                        } catch (_: Exception) {
+                            // A corrupt/unreadable store must fail closed rather than strand an empty
+                            // START_STICKY foreground service indefinitely.
+                            false
+                        }
+                        // Lifecycle commands are delivered on main. Serialize the decision there too:
+                        // cancel() alone cannot stop a coroutine that has returned from its last
+                        // suspension, whereas this generation check makes supersession/destruction
+                        // authoritative even in that completion race.
+                        mainHandler.post {
+                            if (destroyed || stickyRestartGeneration != generation) return@post
+                            stickyRestartGateJob = null
+                            if (enabled) {
+                                ensureRunning()
+                            } else {
+                                stopNotRunning(startId)
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -232,6 +280,10 @@ class AmbientMonitoringService : Service() {
     }
 
     private fun ensureRunning() {
+        if (!runtimeStarted) {
+            runtimeStarted = true
+            runtimeStartCount++
+        }
         // Refresh the cached tier at the service-resume points (start / resume / reapply) so an
         // out-of-band grant is reflected without the per-cycle permission check the dimming path used
         // to do (G1-F5). currentTier() reads this cache thereafter.
@@ -584,14 +636,19 @@ class AmbientMonitoringService : Service() {
         // assumes for onDestroy.)
         if (externalControlEnabled) broadcastStateChanged(enabled = false, running = false, paused = false, profile = null)
         runCatching { unregisterReceiver(screenReceiver) }
+        destroyed = true
+        stickyRestartGeneration++
+        stickyRestartGateJob?.cancel(); stickyRestartGateJob = null
         panicJob?.cancel(); panicJob = null
         stateEventJob?.cancel(); stateEventJob = null
-        contextEngine.stop()
-        controller.stop()
-        // Return the display toggles to the baseline profile's values (D-151 resting state): a
-        // context-profile override must not outlive the runtime that applies it. Before
-        // scope.cancel() so the coordinator can serialize against an in-flight apply.
-        displayToggles.stop()
+        if (runtimeStarted) {
+            contextEngine.stop()
+            controller.stop()
+            // Return the display toggles to the baseline profile's values (D-151 resting state): a
+            // context-profile override must not outlive the runtime that applies it. Before
+            // scope.cancel() so the coordinator can serialize against an in-flight apply.
+            displayToggles.stop()
+        }
         // Watchdog instead of an immediate reset (S12.9d): if the OS restarts the FGS and it
         // republishes within the grace window, the live data survives; otherwise it is cleared so the
         // Dashboard does not show a stale "live" snapshot for a dead loop. A genuine user-driven stop

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ProfileImportExportManager.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ProfileImportExportManager.kt
@@ -3,8 +3,15 @@ package com.tideo.autobrightness.app.settings
 import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
+import android.provider.OpenableColumns
 import android.util.Log
+import java.io.ByteArrayOutputStream
 import java.io.FileNotFoundException
+import java.io.InputStream
+import java.nio.ByteBuffer
+import java.nio.charset.CharacterCodingException
+import java.nio.charset.CodingErrorAction
+import java.nio.charset.StandardCharsets
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -17,18 +24,28 @@ sealed interface ProfileLoadResult {
     /** Parsed as our own [AabProfilePayload] export format. */
     data class Success(val settings: AabSettings) : ProfileLoadResult
 
-    /** Our format failed; the legacy Tasker parser succeeded. [jsonError] is informational (logged). */
+    /** Our format failed; the legacy Tasker parser succeeded. [jsonError] is diagnostic metadata. */
     data class LegacyFallback(val settings: AabSettings, val jsonError: String) : ProfileLoadResult
 
     /** Neither parser succeeded — the caller shows a user-visible error card. */
     data class TotalFailure(val jsonError: String, val legacyError: String) : ProfileLoadResult
+
+    /** The encoded input is larger than the profile format can reasonably require. */
+    data object TooLarge : ProfileLoadResult
+
+    /** The provider could not be read, or returned bytes that are not valid UTF-8. */
+    data object ReadFailure : ProfileLoadResult
 }
 
 class ProfileImportExportManager(
     private val context: Context,
 ) {
-    private companion object {
-        const val TAG = "ProfileImport"
+    companion object {
+        private const val TAG = "ProfileImport"
+
+        // A full pretty-printed AabSettings export is only a few KiB. This leaves ample room for
+        // future fields and legacy configs while bounding allocations from untrusted providers.
+        internal const val MAX_ENCODED_PROFILE_BYTES = 256 * 1024
     }
 
     private val json = Json { ignoreUnknownKeys = true; prettyPrint = true }
@@ -48,13 +65,67 @@ class ProfileImportExportManager(
     }
 
     suspend fun importFromAppPrivate(profileName: String): ProfileLoadResult {
-        val content = context.openFileInput(sanitizeFileName(profileName)).bufferedReader().use { it.readText() }
-        return decodePayload(content)
+        return runCatching {
+            context.openFileInput(sanitizeFileName(profileName)).use { readAndDecode(it) }
+        }.getOrElse {
+            Log.w(TAG, "Profile input could not be read")
+            ProfileLoadResult.ReadFailure
+        }
     }
 
     suspend fun importFromDocument(uri: Uri, resolver: ContentResolver = context.contentResolver): ProfileLoadResult {
-        val content = resolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
-            ?: throw FileNotFoundException("Unable to open input stream for uri=$uri")
+        val declaredSize = runCatching {
+            resolver.query(uri, arrayOf(OpenableColumns.SIZE), null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst() && !cursor.isNull(0)) cursor.getLong(0) else null
+            }
+        }.getOrNull()
+        return runCatching {
+            resolver.openInputStream(uri)?.use { readAndDecode(it, declaredSize) }
+                ?: return ProfileLoadResult.ReadFailure
+        }.getOrElse {
+            // URI and provider exception details can contain private document names or authorities.
+            Log.w(TAG, "Profile input could not be read")
+            ProfileLoadResult.ReadFailure
+        }
+    }
+
+    internal fun readAndDecode(input: InputStream, declaredSize: Long? = null): ProfileLoadResult {
+        if (declaredSize != null && declaredSize > MAX_ENCODED_PROFILE_BYTES) {
+            return ProfileLoadResult.TooLarge
+        }
+        val bytes = ByteArrayOutputStream(MAX_ENCODED_PROFILE_BYTES.coerceAtMost(DEFAULT_BUFFER_SIZE))
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        var remaining = MAX_ENCODED_PROFILE_BYTES + 1
+        try {
+            while (remaining > 0) {
+                val count = input.read(buffer, 0, minOf(buffer.size, remaining))
+                if (count < 0) break
+                if (count == 0) {
+                    val byte = input.read()
+                    if (byte < 0) break
+                    bytes.write(byte)
+                    remaining--
+                    continue
+                }
+                bytes.write(buffer, 0, count)
+                remaining -= count
+            }
+        } catch (_: Exception) {
+            Log.w(TAG, "Profile input could not be read")
+            return ProfileLoadResult.ReadFailure
+        }
+        if (bytes.size() > MAX_ENCODED_PROFILE_BYTES) return ProfileLoadResult.TooLarge
+
+        val content = try {
+            StandardCharsets.UTF_8.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .decode(ByteBuffer.wrap(bytes.toByteArray()))
+                .toString()
+        } catch (_: CharacterCodingException) {
+            Log.w(TAG, "Profile input is not valid UTF-8")
+            return ProfileLoadResult.ReadFailure
+        }
         return decodePayload(content)
     }
 
@@ -64,7 +135,7 @@ class ProfileImportExportManager(
 
     /**
      * Decode a profile file, trying our [AabProfilePayload] format first and the legacy Tasker parser
-     * second. Logs the JSON failure on a legacy fallback and both failures on a total failure (S12.9c #3).
+     * second. Logs only the outcome, never parser details that could quote imported content.
      */
     fun decodePayload(content: String): ProfileLoadResult {
         val jsonAttempt = runCatching {
@@ -75,11 +146,11 @@ class ProfileImportExportManager(
 
         val legacyAttempt = runCatching { TaskerLegacyProfileSerializer.deserialize(content).validate() }
         legacyAttempt.getOrNull()?.let {
-            Log.w(TAG, "Profile not in app format; loaded via legacy parser. JSON error: $jsonError")
+            Log.w(TAG, "Profile not in app format; loaded via legacy parser")
             return ProfileLoadResult.LegacyFallback(it, jsonError)
         }
         val legacyError = legacyAttempt.exceptionOrNull()?.message ?: "Legacy parse failed"
-        Log.e(TAG, "Profile load failed. JSON error: $jsonError; legacy error: $legacyError")
+        Log.e(TAG, "Profile load failed validation")
         return ProfileLoadResult.TotalFailure(jsonError, legacyError)
     }
 

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ProfileImportExportManager.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ProfileImportExportManager.kt
@@ -43,8 +43,10 @@ class ProfileImportExportManager(
     companion object {
         private const val TAG = "ProfileImport"
 
-        // A full pretty-printed AabSettings export is only a few KiB. This leaves ample room for
-        // future fields and legacy configs while bounding allocations from untrusted providers.
+        // DA-029: an allocation bound, NOT a schema constraint — a full pretty-printed AabSettings
+        // export is only a few KiB, and the slack is deliberate (future fields, fat legacy configs).
+        // Do not tighten it to "what a profile needs"; its job is to stop an untrusted SAF provider
+        // from driving an unbounded read on the import path.
         internal const val MAX_ENCODED_PROFILE_BYTES = 256 * 1024
     }
 
@@ -74,6 +76,9 @@ class ProfileImportExportManager(
     }
 
     suspend fun importFromDocument(uri: Uri, resolver: ContentResolver = context.contentResolver): ProfileLoadResult {
+        // DA-029: OpenableColumns.SIZE is a HINT, never the bound. It comes from the same untrusted
+        // provider as the bytes, so it can only buy an early reject — a provider that under-reports
+        // still meets the streamed cap in readAndDecode.
         val declaredSize = runCatching {
             resolver.query(uri, arrayOf(OpenableColumns.SIZE), null, null, null)?.use { cursor ->
                 if (cursor.moveToFirst() && !cursor.isNull(0)) cursor.getLong(0) else null
@@ -89,6 +94,13 @@ class ProfileImportExportManager(
         }
     }
 
+    /**
+     * DA-029: read at most [MAX_ENCODED_PROFILE_BYTES] **plus one probe byte** and decode as strict
+     * UTF-8. The probe byte is what makes "exactly at the cap" and "one over" distinguishable — a
+     * read that stops at the cap cannot tell a full buffer from a truncated one. Strict decoding
+     * (REPORT, not the U+FFFD substitution `readText()` does) keeps "not a profile file" from
+     * arriving at the parser as a confusing syntax error.
+     */
     internal fun readAndDecode(input: InputStream, declaredSize: Long? = null): ProfileLoadResult {
         if (declaredSize != null && declaredSize > MAX_ENCODED_PROFILE_BYTES) {
             return ProfileLoadResult.TooLarge

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ProfilesContextsScreen.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/ui/screens/ProfilesContextsScreen.kt
@@ -124,6 +124,14 @@ fun ProfilesContextsScreen(
             loadError = context.getString(R.string.profiles_unreadable)
             context.getString(R.string.toast_load_failed)
         }
+        ProfileLoadResult.TooLarge -> {
+            loadError = context.getString(R.string.profiles_too_large)
+            context.getString(R.string.toast_load_failed)
+        }
+        ProfileLoadResult.ReadFailure -> {
+            loadError = context.getString(R.string.profiles_read_failed)
+            context.getString(R.string.toast_load_failed)
+        }
     }
 
     // Previously-granted Download/AAB/configs tree (persisted SAF permission), if any.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -589,6 +589,8 @@
     <string name="toast_loaded_entry">Loaded %1$s</string>
     <string name="toast_load_failed_detail">Load failed: %1$s</string>
     <string name="profiles_unreadable">Couldn\'t read this profile. It isn\'t a Tideo export or a Tasker AAB config.</string>
+    <string name="profiles_too_large">This profile is too large to import.</string>
+    <string name="profiles_read_failed">Couldn\'t safely read this profile. Try selecting it again.</string>
 
     <!-- Profiles (body + dialogs) -->
     <string name="profiles_save_as">Save current settings as…</string>

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringServiceTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringServiceTest.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import com.tideo.autobrightness.app.storage.settingsDataStore
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -22,6 +23,113 @@ import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
 class AmbientMonitoringServiceTest {
+
+    @Test
+    fun disabledStickyRestart_stopsWithoutStartingRuntimeOrWriters() {
+        val gate = CompletableDeferred<Unit>()
+        val controller = Robolectric.buildService(AmbientMonitoringService::class.java).create()
+        try {
+            val service = controller.get()
+            service.stickyRestartEnabledReader = { gate.await(); false }
+
+            service.onStartCommand(null, 0, 41)
+            assertNotNull(shadowOf(service).lastForegroundNotification, "FGS deadline is met while the gate waits")
+            assertEquals(0, service.runtimeStartCount, "no runtime component or writer may start before confirmation")
+
+            gate.complete(Unit)
+            waitUntil { shadowOf(service).isStoppedBySelf }
+            assertEquals(0, service.runtimeStartCount, "disabled restart must never reach runtime/writer startup")
+        } finally {
+            controller.destroy()
+        }
+    }
+
+    @Test
+    fun enabledStickyRestart_startsRuntimeExactlyOnce() {
+        val gate = CompletableDeferred<Unit>()
+        val controller = Robolectric.buildService(AmbientMonitoringService::class.java).create()
+        try {
+            val service = controller.get()
+            service.stickyRestartEnabledReader = { gate.await(); true }
+            service.onStartCommand(null, 0, 42)
+
+            gate.complete(Unit)
+            waitUntil { service.runtimeStartCount == 1 }
+            assertEquals(1, service.runtimeStartCount)
+            assertFalse(shadowOf(service).isStoppedBySelf)
+        } finally {
+            controller.destroy()
+        }
+    }
+
+    @Test
+    fun failedStickyRestartRead_failsClosedWithoutRuntimeStartup() {
+        val controller = Robolectric.buildService(AmbientMonitoringService::class.java).create()
+        try {
+            val service = controller.get()
+            service.stickyRestartEnabledReader = { error("unreadable settings") }
+
+            service.onStartCommand(null, 0, 46)
+            waitUntil { shadowOf(service).isStoppedBySelf }
+
+            assertEquals(0, service.runtimeStartCount)
+        } finally {
+            controller.destroy()
+        }
+    }
+
+    @Test
+    fun destructionWhileStickyRestartGatePending_preventsLateRuntimeStartup() {
+        val readerReturned = CompletableDeferred<Unit>()
+        val controller = Robolectric.buildService(AmbientMonitoringService::class.java).create()
+        val service = controller.get()
+        service.stickyRestartEnabledReader = {
+            readerReturned.complete(Unit)
+            true
+        }
+        service.onStartCommand(null, 0, 43)
+
+        runBlocking { readerReturned.await() }
+        // The background read has completed, but its main-thread decision has not run. Destroy in
+        // precisely the cancel-after-last-suspension window that previously allowed late startup.
+        controller.destroy()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(0, service.runtimeStartCount, "destroy must cancel the gate before any runtime stop/write path")
+    }
+
+    @Test
+    fun explicitStartWhileStickyRestartGatePending_supersedesGateAndStartsOnce() {
+        val readerReturned = CompletableDeferred<Unit>()
+        val controller = Robolectric.buildService(AmbientMonitoringService::class.java).create()
+        try {
+            val service = controller.get()
+            service.stickyRestartEnabledReader = {
+                readerReturned.complete(Unit)
+                false
+            }
+            service.onStartCommand(null, 0, 44)
+            runBlocking { readerReturned.await() }
+
+            service.onStartCommand(Intent().setAction(AmbientMonitoringService.ACTION_START), 0, 45)
+            assertEquals(1, service.runtimeStartCount, "trusted explicit starts retain synchronous semantics")
+            shadowOf(Looper.getMainLooper()).idle()
+
+            assertEquals(1, service.runtimeStartCount, "the cancelled sticky decision cannot start or stop again")
+            assertFalse(shadowOf(service).isStoppedBySelf)
+        } finally {
+            controller.destroy()
+        }
+    }
+
+    private fun waitUntil(condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + 2_000
+        while (!condition() && System.currentTimeMillis() < deadline) {
+            shadowOf(Looper.getMainLooper()).idle()
+            Thread.sleep(10)
+        }
+        assertTrue(condition(), "asynchronous service transition timed out")
+    }
 
     @Test
     fun onStartCommand_postsForegroundNotification() {
@@ -144,12 +252,8 @@ class AmbientMonitoringServiceTest {
     // The positive path must survive the D-140 gate: once START has run the pipeline (serviceOn=true,
     // set synchronously by controller.start()), PAUSE and REAPPLY act on it and keep the service up.
     //
-    // ACTION_START falls into the service's `else` branch, whose D-140 START_STICKY defense fires a
-    // `scope.launch { if (!serviceEnabled) disableAndStop() }` on Dispatchers.Default (a background
-    // thread). With the DataStore left at its default `serviceEnabled=false` that guard could tear the
-    // service down mid-test, nondeterministically — a real race, not a test artifact. Seed
-    // `serviceEnabled=true` first (exactly what every explicit starter does in production, per the
-    // branch's own comment) so the guard is a no-op regardless of thread timing.
+    // ACTION_START is a trusted explicit command: its caller has already persisted serviceEnabled,
+    // and it deliberately bypasses the asynchronous null-intent sticky-restart gate.
     @Test
     fun pauseAndReapply_whilePipelineRunning_keepTheServiceUp() {
         val app = ApplicationProvider.getApplicationContext<Context>()

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/settings/ProfileLoadResultTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/settings/ProfileLoadResultTest.kt
@@ -1,6 +1,10 @@
 package com.tideo.autobrightness.app.settings
 
 import androidx.test.core.app.ApplicationProvider
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
+import kotlinx.coroutines.runBlocking
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -18,6 +22,17 @@ class ProfileLoadResultTest {
     private val manager = ProfileImportExportManager(ApplicationProvider.getApplicationContext())
 
     @Test
+    fun `normal app export imports through bounded reader`() = runBlocking {
+        val name = "bounded-reader-round-trip"
+        manager.exportToAppPrivate(name, AabSettings(minBrightness = 17))
+
+        val result = manager.importFromAppPrivate(name)
+
+        assertTrue(result is ProfileLoadResult.Success)
+        assertEquals(17, result.settings.minBrightness)
+    }
+
+    @Test
     fun `our export format is a Success`() {
         // The app's own export wraps settings in an AabProfilePayload { schemaVersion, settings }.
         val payload = """{ "schemaVersion": 3, "settings": { "minBrightness": 7 } }"""
@@ -29,10 +44,53 @@ class ProfileLoadResultTest {
     @Test
     fun `a Tasker nested config is a LegacyFallback`() {
         val taskerConfig = """{ "general": { "z1_end": 50.0 } }"""
-        val result = manager.decodePayload(taskerConfig)
+        val result = manager.readAndDecode(ByteArrayInputStream(taskerConfig.encodeToByteArray()))
         assertTrue(result is ProfileLoadResult.LegacyFallback, "expected LegacyFallback, got $result")
         assertEquals(50, (result as ProfileLoadResult.LegacyFallback).settings.zone1End)
         assertTrue(result.jsonError.isNotEmpty(), "the JSON error should be recorded")
+    }
+
+    @Test
+    fun `input exactly at encoded limit is accepted by the reader`() {
+        val prefix = """{ "schemaVersion": 3, "settings": { "minBrightness": 19 } }"""
+        val bytes = prefix.padEnd(ProfileImportExportManager.MAX_ENCODED_PROFILE_BYTES).encodeToByteArray()
+
+        val result = manager.readAndDecode(ByteArrayInputStream(bytes))
+
+        assertTrue(result is ProfileLoadResult.Success)
+        assertEquals(19, result.settings.minBrightness)
+    }
+
+    @Test
+    fun `input one byte over encoded limit is rejected`() {
+        val bytes = ByteArray(ProfileImportExportManager.MAX_ENCODED_PROFILE_BYTES + 1) { ' '.code.toByte() }
+
+        assertEquals(ProfileLoadResult.TooLarge, manager.readAndDecode(ByteArrayInputStream(bytes)))
+    }
+
+    @Test
+    fun `absent and inaccurate declared sizes cannot bypass streaming bound`() {
+        val normal = """{ "schemaVersion": 3, "settings": { "minBrightness": 23 } }""".encodeToByteArray()
+        assertTrue(manager.readAndDecode(ByteArrayInputStream(normal), declaredSize = null) is ProfileLoadResult.Success)
+
+        val oversized = ByteArray(ProfileImportExportManager.MAX_ENCODED_PROFILE_BYTES + 1)
+        assertEquals(
+            ProfileLoadResult.TooLarge,
+            manager.readAndDecode(ByteArrayInputStream(oversized), declaredSize = 1),
+        )
+    }
+
+    @Test
+    fun `malformed UTF-8 and stream failures are typed read failures`() {
+        assertEquals(
+            ProfileLoadResult.ReadFailure,
+            manager.readAndDecode(ByteArrayInputStream(byteArrayOf(0xC3.toByte(), 0x28))),
+        )
+        val failingStream = object : InputStream() {
+            override fun read(): Int = throw IOException("private provider detail")
+            override fun read(buffer: ByteArray, offset: Int, length: Int): Int = read()
+        }
+        assertEquals(ProfileLoadResult.ReadFailure, manager.readAndDecode(failingStream))
     }
 
     @Test

--- a/docs/rebuild/DEVIATIONS_LEDGER_A.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER_A.md
@@ -757,3 +757,68 @@
   superseded by this sentence (ledger rows are append-only, so the error stays visible).
   `[cited]`: `.github/workflows/fdroid-compat.yml` (artifact-staging and push-trigger comments),
   `scripts/fdroid-check.py` (the fail-closed rationale comments).
+
+- DA-029 [cited]: **Profile import is a bounded stream, not `readText()`** (folded from the concept
+  PR #97 into the 1.8.2 train). `ProfileImportExportManager.importFromDocument` read a
+  user-chosen SAF document with `bufferedReader().readText()` — an unbounded allocation driven by
+  a provider we do not control, so a multi-GB (or endless) document was an OOM on the UI path. Now
+  `readAndDecode` streams into a `ByteArrayOutputStream` with a `MAX_ENCODED_PROFILE_BYTES` =
+  256 KiB budget **plus one probe byte**: reading the cap exactly is accepted, cap+1 proves
+  overflow without buffering it, and the probe is what makes "exactly at the limit" and "one over"
+  distinguishable at all (a plain `read` up to the cap cannot tell a full buffer from a truncated
+  one). `OpenableColumns.SIZE` is used **only** as an early reject — a provider's declared size is
+  a hint from the same untrusted source as the bytes, so a lying small size still hits the
+  streamed bound; there is a test for exactly that bypass. Decoding is strict UTF-8
+  (`CodingErrorAction.REPORT` on malformed **and** unmappable input) rather than the replacement
+  behaviour of `readText()`, because silently substituting U+FFFD turns "this file is not a
+  profile" into a confusing parse error further down. Two new `ProfileLoadResult` variants
+  (`TooLarge`, `ReadFailure`) carry those outcomes to the one exhaustive `when` in
+  `ProfilesContextsScreen` (`ProfilesScreen` only renders the resulting string, so it needed no
+  change) with their own strings — an oversized file and a corrupt one are different user
+  problems and the old single `profiles_unreadable` conflated them. Two consequences worth
+  knowing: (1) `importFromAppPrivate` **no longer throws** `FileNotFoundException` for a missing
+  app-private profile, it returns `ReadFailure` — the two import entry points now have the same
+  total signature, and no production caller relied on the throw (only tests did); (2) the
+  parser-exception detail was dropped from the `Log.w`/`Log.e` lines, since a failing parse quotes
+  imported content into logcat that the D-158 crash-log capture can then surface — the strings are
+  still carried on `TotalFailure` for the caller, they are just not logged. The 256 KiB number is
+  deliberately loose (a full pretty-printed export is a few KiB); this is an allocation bound, not
+  a schema constraint, and it must not be tightened into one.
+  `[cited]`: `app/src/main/kotlin/com/tideo/autobrightness/app/settings/ProfileImportExportManager.kt`
+  (the cap constant and the declared-size-is-a-hint comment).
+
+- DA-030 [cited]: **`START_STICKY` restarts gate the runtime on the persisted opt-in** (folded
+  from the concept PR #98 into the 1.8.2 train; **extends the D-140 defense, does not replace
+  it**). D-140 already knew the hole — the OS restarts a killed FGS with a **null** intent, and
+  the user may have disabled the service while the old process was dead (the toggle's
+  `stopService` is a no-op then) — but its fix ran `ensureRunning()` **first** and tore the
+  pipeline down afterwards from a `scope.launch`. So a disabled service still briefly started the
+  sensors, the brightness writer, the context engine and the display-toggle writes: a
+  start-then-undo, and the undo wrote settings the user had switched off. Now the **null-intent
+  path alone** defers `ensureRunning()` behind an async read of the persisted `serviceEnabled`;
+  the foreground notification is still posted synchronously at the top of `onStartCommand`, so
+  the FGS deadline is met by a notification with no runtime behind it — that ordering is the whole
+  reason this can be async at all. Explicit (non-null) intents keep the **synchronous**
+  `ensureRunning()` and skip the read entirely: every explicit starter persists `serviceEnabled`
+  before sending (`BootCompletedReceiver` and `MaintenanceWorker` read it, `ControlReceiver`/tile/
+  widget `updateData` it first) — verified caller-by-caller, and that invariant is what this
+  branch rests on, so a **new** ACTION_START sender must pre-persist or it must not use this path.
+  Three race guards, all necessary and none sufficient alone: a monotonic `stickyRestartGeneration`
+  bumped by every command and by `onDestroy`; a `destroyed` flag; and re-checking both on
+  `mainHandler.post` **after** the read returns, because `Job.cancel()` cannot stop a coroutine
+  that has already passed its last suspension point — cancellation alone would still let a stale
+  read call `ensureRunning()` on a dying service. The read **fails closed**: an unreadable store
+  yields `false` (`CancellationException` rethrown first, so cancellation is never mistaken for
+  corruption), because the failure mode to avoid is a foregrounded service holding sensors and
+  writers with nobody having asked for it. The disabled outcome calls `stopNotRunning(startId)`
+  rather than D-140's `disableAndStop()` — deliberately: `disableAndStop` persists
+  `serviceEnabled = false`, which would be a **write** caused by a transient read failure, and its
+  `LiveRuntimeState.reset()` + widget repaint are moot when nothing ever started.
+  `runtimeStarted`/`runtimeStartCount` exist so `onDestroy` does not `stop()` a
+  `contextEngine`/`controller`/`displayToggles` that was never started (the display-toggle stop is
+  a *baseline re-apply*, i.e. a privileged write — the one that must not fire on a service that
+  did nothing). `stickyRestartEnabledReader` is an `internal` test seam on the same precedent as
+  `externalControlEnabled`: the race is otherwise untestable, because a real DataStore read
+  completes before the test can interleave a superseding command.
+  `[cited]`: `app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt`
+  (the gate, the generation/destroyed comments and the fail-closed rationale).

--- a/docs/rebuild/DEVIATIONS_LEDGER_A.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER_A.md
@@ -814,10 +814,13 @@
   rather than D-140's `disableAndStop()` — deliberately: `disableAndStop` persists
   `serviceEnabled = false`, which would be a **write** caused by a transient read failure, and its
   `LiveRuntimeState.reset()` + widget repaint are moot when nothing ever started.
-  `runtimeStarted`/`runtimeStartCount` exist so `onDestroy` does not `stop()` a
+  `runtimeStarted` exists so `onDestroy` does not `stop()` a
   `contextEngine`/`controller`/`displayToggles` that was never started (the display-toggle stop is
   a *baseline re-apply*, i.e. a privileged write — the one that must not fire on a service that
-  did nothing). `stickyRestartEnabledReader` is an `internal` test seam on the same precedent as
+  did nothing). Its companion `runtimeStartCount` deliberately does **not** latch, unlike the flag:
+  the concept PR incremented it only on the first activation, which made its own
+  "starts exactly once" supersession assertions unfalsifiable — a latched counter reads 1 whether
+  the gate was superseded correctly or fired a second `ensureRunning()` on top of the explicit start. `stickyRestartEnabledReader` is an `internal` test seam on the same precedent as
   `externalControlEnabled`: the race is otherwise untestable, because a real DataStore read
   completes before the test can interleave a superseding command.
   `[cited]`: `app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt`

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -24,15 +24,19 @@ tile, boot receiver). Privileges: **BASIC** `WRITE_SETTINGS` = full core pipelin
 
 ## Current state
 
-**Shipped: v1.8.1** (vc19, tagged). **Release pending: 1.8.2 / vc20**, cut on this branch: the AGP
-bump changes the shipped APK, so RUNBOOK §6 required the bump (patch — internal/packaging, no
-behavior change); `changelogs/20.txt` written. Train tip `claude/badge-workflow-verify-77m62f`
-(DA-025); this branch is cut from it and carries **AGP 8.7.3 → 8.13.2** (DA-026) + the **F-Droid
-compatibility CI** (DA-027/DA-028, green on real infrastructure), open as **PR #96** — the owner is
-keeping this branch as the base for the next fix/feature. Two hardening changes are folded into the
-same train (DA-029 bounded profile import, DA-030 sticky-restart gate), so vc20 is **no longer a
-packaging-only release** — it carries `app/` source; `changelogs/20.txt` says so. `domain/` and
-`platform/` are still byte-identical to 1.8.1. At the tag: the one-shot DA-026 reproducibility check (RUNBOOK playbook 6) must not be
+**Shipped: v1.8.1** (vc19, tagged). **Release pending: 1.8.2 / vc20** (patch), cut on the train
+branch `claude/gradle-deprecation-fdroid-870gh3`: the AGP bump changes the shipped APK, so RUNBOOK §6
+required it. Train tip `claude/badge-workflow-verify-77m62f` (DA-025) → `…-870gh3`, which carries
+**AGP 8.7.3 → 8.13.2** (DA-026) + the **F-Droid compatibility CI** (DA-027/DA-028, green on real
+infrastructure) and is open as **PR #96 → `main`** — the owner is keeping it as the base for the
+next fix/feature. **Stacked on it: PR #99** (`claude/fold-prs-97-98-cdi4dp` → `…-870gh3`), which
+folds the two concept PRs #97/#98 in as DA-029 (bounded profile import) + DA-030 (sticky-restart
+gate); #97/#98 are superseded and close unmerged. So vc20 is **no longer a packaging-only release** —
+it carries `app/` source and `changelogs/20.txt` says so; `domain/` and `platform/` are still
+byte-identical to 1.8.1. Merge order is #99 into the train branch first, then #96 squash-merges the
+whole train — **PR #96's body still describes the AGP-only diff and must be updated to the net
+`origin/main..HEAD` payload before that squash (DA-002).** At the tag: the one-shot DA-026
+reproducibility check (RUNBOOK playbook 6) must not be
 skipped — 1.8.2 is the first release under the new AGP — and the DA-024 store icon lands with it.
 No other active work; no plan files. `PARITY_CHECKLIST.md` zero-`pending`; parity tests green;
 TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per `RUNBOOK.md`; deviations in
@@ -48,9 +52,12 @@ TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per `RUNBOOK.md`; deviations in
 
 **Pending owner actions:**
 
-1. Squash-merge **PR #96** (`claude/gradle-deprecation-fdroid-870gh3` → `main`) once CI is green,
-   then **cut 1.8.2 / vc20** from the GitHub "Draft a new release" UI. The bump is already in the
-   branch, so the release is just tag + publish.
+1. Merge **PR #99** (`claude/fold-prs-97-98-cdi4dp` → `claude/gradle-deprecation-fdroid-870gh3`)
+   once CI is green, close **#97/#98** unmerged (superseded — their commits are contained in #99),
+   then **rewrite PR #96's body** to describe the net `origin/main..HEAD` train (it currently claims
+   "No `app/`/`domain/`/`platform/` source change", which #99 makes false — and the body becomes the
+   squash commit, DA-002). Then squash-merge **PR #96** → `main` and **cut 1.8.2 / vc20** from the
+   GitHub "Draft a new release" UI. The bump is already in the branch, so the release is tag + publish.
 2. **At that tagged release (one-shot, DA-026):** after `release.yml` publishes, check F-Droid's
    build log for that versionCode reports `...successfully verified`. First release under AGP 8.13.2,
    so it is the first time F-Droid rebuilds our signed APK on the new toolchain — pre-verified in

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -95,6 +95,9 @@ TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per `RUNBOOK.md`; deviations in
 
 One line per shipped change (newest first); detail in the D-rows and git history.
 
+- 2026-07-28 — Profile imports now stream at most 256 KiB + one byte, strictly decode UTF-8,
+  distrust provider size metadata, and return safe typed failures for oversized/unreadable inputs;
+  the Profiles UI distinguishes an oversized file from malformed content.
 - 2026-07-28 — **1.8.2 / vc20 cut** (patch): release-preflight correctly classified the AGP bump as
   shipping app code, so RUNBOOK §6 required the bump — taken rather than weakening the gate.
 - 2026-07-28 — **DA-026 → DA-028**: **AGP 8.7.3 → 8.13.2**, verified in F-Droid's own buildserver

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -95,6 +95,9 @@ TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per `RUNBOOK.md`; deviations in
 
 One line per shipped change (newest first); detail in the D-rows and git history.
 
+- 2026-07-28 — Fixed null-intent `START_STICKY` restarts to await the persisted service-enabled
+  flag behind the already-posted foreground notification before activating any runtime component;
+  explicit starts stay synchronous, and pending gates are safely superseded or destroyed.
 - 2026-07-28 — **1.8.2 / vc20 cut** (patch): release-preflight correctly classified the AGP bump as
   shipping app code, so RUNBOOK §6 required the bump — taken rather than weakening the gate.
 - 2026-07-28 — **DA-026 → DA-028**: **AGP 8.7.3 → 8.13.2**, verified in F-Droid's own buildserver

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -29,8 +29,10 @@ bump changes the shipped APK, so RUNBOOK §6 required the bump (patch — intern
 behavior change); `changelogs/20.txt` written. Train tip `claude/badge-workflow-verify-77m62f`
 (DA-025); this branch is cut from it and carries **AGP 8.7.3 → 8.13.2** (DA-026) + the **F-Droid
 compatibility CI** (DA-027/DA-028, green on real infrastructure), open as **PR #96** — the owner is
-keeping this branch as the base for the next fix/feature. No `app/`/`domain/`/`platform/` source
-change. At the tag: the one-shot DA-026 reproducibility check (RUNBOOK playbook 6) must not be
+keeping this branch as the base for the next fix/feature. Two hardening changes are folded into the
+same train (DA-029 bounded profile import, DA-030 sticky-restart gate), so vc20 is **no longer a
+packaging-only release** — it carries `app/` source; `changelogs/20.txt` says so. `domain/` and
+`platform/` are still byte-identical to 1.8.1. At the tag: the one-shot DA-026 reproducibility check (RUNBOOK playbook 6) must not be
 skipped — 1.8.2 is the first release under the new AGP — and the DA-024 store icon lands with it.
 No other active work; no plan files. `PARITY_CHECKLIST.md` zero-`pending`; parity tests green;
 TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per `RUNBOOK.md`; deviations in
@@ -95,9 +97,12 @@ TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per `RUNBOOK.md`; deviations in
 
 One line per shipped change (newest first); detail in the D-rows and git history.
 
-- 2026-07-28 — Profile imports now stream at most 256 KiB + one byte, strictly decode UTF-8,
-  distrust provider size metadata, and return safe typed failures for oversized/unreadable inputs;
-  the Profiles UI distinguishes an oversized file from malformed content.
+- 2026-07-28 — **DA-029 + DA-030** (folded into the 1.8.2/vc20 train): profile import is now a
+  bounded stream (256 KiB cap, strict UTF-8, provider-declared size demoted to a hint) with typed
+  `TooLarge`/`ReadFailure` outcomes surfaced in the Profiles UI; and a null-intent `START_STICKY`
+  restart no longer starts the runtime before DataStore confirms the persisted opt-in — the
+  notification is posted first for the FGS deadline, the gate fails closed, and a newer command or
+  `onDestroy` supersedes a pending decision. Explicit starts keep their synchronous path.
 - 2026-07-28 — **1.8.2 / vc20 cut** (patch): release-preflight correctly classified the AGP bump as
   shipping app code, so RUNBOOK §6 required the bump — taken rather than weakening the gate.
 - 2026-07-28 — **DA-026 → DA-028**: **AGP 8.7.3 → 8.13.2**, verified in F-Droid's own buildserver

--- a/fastlane/metadata/android/en-US/changelogs/20.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20.txt
@@ -2,4 +2,6 @@ Maintenance release.
 
 Updated the Android build toolchain (Android Gradle Plugin 8.13.2), which clears the last build warnings and keeps future Gradle versions supported. Verified against F-Droid's own build image so the reproducible build is preserved.
 
-No change to how the app behaves: brightness curves, profiles, context rules and settings are all untouched.
+Importing a profile now reads the file safely and says so when it is too large or unreadable. A service restarted by the system stays off if you switched it off.
+
+Brightness curves, profiles and context rules are unchanged.


### PR DESCRIPTION
## Summary

Two hardening changes folded into the 1.8.2 train:

- **DA-029**: Profile import is now a bounded stream (256 KiB + 1 probe byte) instead of unbounded `readText()`. Prevents OOM on untrusted SAF documents. Strict UTF-8 decoding (REPORT on malformed input) replaces silent U+FFFD substitution. Two new `ProfileLoadResult` variants (`TooLarge`, `ReadFailure`) distinguish oversized and corrupt files for the UI.

- **DA-030**: `START_STICKY` restarts now gate the runtime behind an async read of the persisted `serviceEnabled` flag. Extends the D-140 defense: the foreground notification posts synchronously (FGS deadline met), but sensors/writers/context engine do not start until DataStore confirms opt-in. Explicit (non-null) intents keep synchronous `ensureRunning()` and skip the read — every explicit starter pre-persists `serviceEnabled`. Three race guards (generation counter, destroyed flag, main-thread re-check) prevent stale reads from starting the runtime on a dying service. Fail-closed: unreadable store yields false.

## Release impact

versionCode 20 (versionName 1.8.2): **patch** — hardening only, no user-facing behavior change. `changelogs/20.txt` updated to reflect source changes (no longer packaging-only).

## Verification

- `./gradlew :app:testDebugUnitTest` — green. New tests cover:
  - DA-029: bounded reader at/over limit, declared-size bypass, malformed UTF-8, stream failures, round-trip export/import
  - DA-030: disabled sticky restart, enabled sticky restart, failed read, destruction during gate, explicit start superseding gate
- `./gradlew :app:lintDebug` — green
- `./gradlew :app:assembleDebug` — green
- `scripts/ladder.sh` — all guards pass

## Repo hygiene

- `docs/rebuild/DEVIATIONS_LEDGER_A.md`: DA-029 and DA-030 entries appended (ledger now at 828 lines)
- `docs/rebuild/STATE.md`: Updated to reflect source changes in vc20
- `fastlane/metadata/android/en-US/changelogs/20.txt`: Expanded to document hardening
- `app/src/main/res/values/strings.xml`: Two new error strings (`profiles_too_large`, `profiles_read_failed`)

## Owner action

Squash-merge; publish from GitHub "Draft a new release" UI using the expanded `changelogs/20.txt`. No on-device Pass A/B gates — hardening is transparent to user workflows.

https://claude.ai/code/session_011VdJ6d2rPAM9a4dpLVQ5Vf