### PR TITLE
Audit Android permissions, backups, and release diagnostics

### DIFF
--- a/.github/workflows/fdroid-compat.yml
+++ b/.github/workflows/fdroid-compat.yml
@@ -21,7 +21,8 @@ name: F-Droid compatibility
 #
 # Node 24 runtime policy (see build.yml): every action pinned here is a major declaring
 # `runs.using: node24` — checkout@v5, setup-java@v5, setup-android@v4, cache@v5,
-# upload-artifact@v6, download-artifact@v6. Do NOT downgrade any of them.
+# upload-artifact@v6, download-artifact@v7. In particular, download-artifact v6 still declares (DA-035)
+# `runs.using: node20`; v7 is its Node 24 migration. Do NOT downgrade any of them.
 on:
   pull_request:
     paths:
@@ -245,13 +246,13 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download normal release build
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: normal-release-build
           path: normal/
 
       - name: Download F-Droid build
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: fdroid-release-build
           path: fdroid/
@@ -308,7 +309,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download normal release build
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: normal-release-build
           path: normal/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,6 +68,9 @@ android {
     }
 
     buildFeatures {
+        // Privacy audit (DA-034): AppProcessScope uses the variant constant to compile raw
+        // throwable logging out of release behavior while retaining actionable debug logs.
+        buildConfig = true
         compose = true
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,9 +18,9 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <!-- F89 audit: the context-rule location gate + once-a-day circadian sun refresh read location
          from the foreground service while the UI is backgrounded (specialUse FGS, not a location FGS),
-         which needs background-location access on API 29+. Declared so the capability exists; the
-         Background access is declared for that capability, but DA-034 found no implemented second-stage
-         "Allow all the time" request/deep-link; normal installs therefore run this path foreground-only. -->
+         which needs background-location access on API 29+. Declared so the capability exists, but
+         DA-034 found no implemented second-stage "Allow all the time" request/deep-link; normal
+         installs therefore run this path foreground-only. -->
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <!-- task528 panic: S.O.S. morse vibration pattern (prof769 → _PanicButton act0, code62). -->
     <uses-permission android:name="android.permission.VIBRATE" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
     <!-- F89 audit: the context-rule location gate + once-a-day circadian sun refresh read location
          from the foreground service while the UI is backgrounded (specialUse FGS, not a location FGS),
          which needs background-location access on API 29+. Declared so the capability exists; the
-         "Allow all the time" upgrade is offered from the Setup Location step (a Settings deep-link). -->
+         Background access is declared for that capability, but DA-034 found no implemented second-stage
+         "Allow all the time" request/deep-link; normal installs therefore run this path foreground-only. -->
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <!-- task528 panic: S.O.S. morse vibration pattern (prof769 → _PanicButton act0, code62). -->
     <uses-permission android:name="android.permission.VIBRATE" />

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AppProcessScope.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AppProcessScope.kt
@@ -2,6 +2,7 @@ package com.tideo.autobrightness.app.runtime
 
 import android.content.BroadcastReceiver
 import android.util.Log
+import com.tideo.autobrightness.BuildConfig
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,8 +16,9 @@ import kotlinx.coroutines.launch
  * Replaces the ad-hoc `CoroutineScope(Dispatchers.*)` instances that were previously allocated
  * per-call and never cancelled — each one a small structured-concurrency leak (its [Job] was rooted
  * nowhere and could neither be observed nor cancelled). A [SupervisorJob] keeps one failed child from
- * cancelling its siblings, and a logging [CoroutineExceptionHandler] surfaces a crash in detached
- * work instead of letting it vanish silently.
+ * cancelling its siblings. Detached failures are logged with their throwable only in debug builds:
+ * exception messages and stacks can contain URIs, package names, or system state and therefore must
+ * not become release-log diagnostics.
  *
  * Scope ownership policy (the audit, deliverable #1):
  *  - Use this for process-scoped fire-and-forget launches with no narrower owner — the
@@ -29,7 +31,9 @@ object AppProcessScope : CoroutineScope {
     private const val TAG = "AppProcessScope"
 
     private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
-        Log.e(TAG, "Uncaught exception in process-scoped coroutine", throwable)
+        if (BuildConfig.DEBUG) {
+            Log.e(TAG, "Uncaught exception in process-scoped coroutine", throwable)
+        }
     }
 
     override val coroutineContext = SupervisorJob() + Dispatchers.Default + exceptionHandler

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,7 +80,7 @@
     <string name="ssid_help_options">You can skip the Location requirement if the app can read the name directly:\n\n•  Shizuku or root — the app runs \"cmd wifi status\" (works with root too).\n•  Otherwise, grant DUMP over ADB and the app reads \"dumpsys wifi\":</string>
     <string name="ssid_help_copy_dump">Copy ADB command</string>
     <string name="ssid_help_copied">ADB command copied</string>
-    <string name="ssid_help_dump_security">DUMP is a read-only diagnostics permission you grant manually over ADB (revoked when you uninstall). This app uses it only to read the Wi-Fi name.</string>
+    <string name="ssid_help_dump_security">DUMP is a broad system-diagnostics permission you grant manually over ADB. Tideo uses it only for the read-only “dumpsys wifi” command and never stores the command output. You can revoke it over ADB at any time; uninstalling also revokes it.</string>
     <string name="ssid_help_regex_caveat">If your SSID contains \"SSID\", this will cause problems. Sorry, not sorry.</string>
     <string name="rule_priority_over_max">Above the 1–100 range — this will be saved as 100.</string>
     <!-- D-114: Tasker-style confirmations for destructive profile/rule actions. -->
@@ -351,7 +351,7 @@
     <string name="onboarding_done">Done</string>
     <string name="onboarding_skip">Skip for now</string>
     <string name="onboarding_restricted_body">Installed outside the Play Store, Android may block the \"Modify system settings\" toggle below (and \"Usage access\", for per-app rules) — it looks greyed out or shows \"Restricted setting\". Tap it anyway; that usually shows the unlock prompt. If not, open App info → ⋮ menu → \"Allow restricted settings\", then return here.</string>
-    <string name="onboarding_elevated_body">Enables super dimming below the dimming threshold. Choose any one channel — it is a one-time grant of WRITE_SECURE_SETTINGS.</string>
+    <string name="onboarding_elevated_body">Allows Tideo to change secure display settings used by super dimming and optional profile display toggles (Night Light, color correction/inversion, always-on display, stay-awake while charging, and force-SDR). Choose any one channel for the one-time WRITE_SECURE_SETTINGS grant; revoke it later with ADB or by uninstalling.</string>
     <string name="onboarding_shizuku_prompt">Shizuku is installed but not running — start the Shizuku app, then return here.</string>
     <string name="onboarding_restricted_title">Heads up: restricted settings</string>
     <string name="onboarding_open_app_info">Open App info</string>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,14 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-   Backup / device-transfer rules for Android 12+ (S12.9a: closes lint DataExtractionRules).
-   Stub: defaults back up all DataStore settings. Tighten with <include>/<exclude> if any
-   sensitive data is ever added (none today).
--->
+<!-- Privacy allowlist (DA-034). DataStore files live under files/datastore/.
+     Cloud receives only ordinary brightness configuration and saved profiles. Device transfer may
+     additionally carry user-authored context rules, including their SSIDs, app package names and
+     location geofences. Runtime telemetry, cached/fixed coordinates, learned override points,
+     power samples, default-off privacy-consent gates, context baselines, crash traces and app-private profile exports
+     are deliberately omitted from both destinations. See architecture/datastore_map.md. -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- Add <exclude> entries here if cloud backup should skip any files. -->
+        <include domain="file" path="datastore/aab_settings.json" />
+        <include domain="file" path="datastore/aab_user_profiles.json" />
     </cloud-backup>
     <device-transfer>
-        <!-- Add <exclude> entries here if device-to-device transfer should skip any files. -->
+        <include domain="file" path="datastore/aab_settings.json" />
+        <include domain="file" path="datastore/aab_user_profiles.json" />
+        <include domain="file" path="datastore/aab_context_rules.json" />
     </device-transfer>
 </data-extraction-rules>

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/DataExtractionRulesTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/DataExtractionRulesTest.kt
@@ -1,0 +1,38 @@
+package com.tideo.autobrightness.app
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import javax.xml.parsers.DocumentBuilderFactory
+
+/** Locks the privacy allowlists in data_extraction_rules.xml (DA-034). */
+class DataExtractionRulesTest {
+    @Test
+    fun cloudAndTransfer_allowOnlyReviewedDataStores() {
+        val xml = File("src/main/res/xml/data_extraction_rules.xml")
+        val document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(xml)
+
+        assertEquals(
+            setOf("datastore/aab_settings.json", "datastore/aab_user_profiles.json"),
+            includedPaths(document, "cloud-backup"),
+        )
+        assertEquals(
+            setOf(
+                "datastore/aab_settings.json",
+                "datastore/aab_user_profiles.json",
+                "datastore/aab_context_rules.json",
+            ),
+            includedPaths(document, "device-transfer"),
+        )
+    }
+
+    private fun includedPaths(document: org.w3c.dom.Document, section: String): Set<String> {
+        val root = document.getElementsByTagName(section).item(0) as org.w3c.dom.Element
+        val includes = root.getElementsByTagName("include")
+        return (0 until includes.length).map { index ->
+            val element = includes.item(index) as org.w3c.dom.Element
+            assertEquals("file", element.getAttribute("domain"))
+            element.getAttribute("path")
+        }.toSet()
+    }
+}

--- a/docs/rebuild/DEVIATIONS_LEDGER_A.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER_A.md
@@ -871,3 +871,11 @@
   `[cited]`: `app/src/main/res/xml/data_extraction_rules.xml` (privacy allowlists/comment),
   `app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AppProcessScope.kt` (debug-only throwable),
   and `app/src/test/kotlin/com/tideo/autobrightness/app/DataExtractionRulesTest.kt` (contract).
+
+- DA-035 [cited]: the F-Droid compatibility workflow's Node-24 policy named
+  `actions/download-artifact@v6` as Node 24 without checking the action's actual default runtime;
+  v6 still declares `runs.using: node20` and caused CI's deprecation notice. All three download steps
+  now use `actions/download-artifact@v7`, the action's explicit Node-24 migration (v7 otherwise keeps
+  the v4+ artifact contract used here). The workflow comment now records the precise v6/v7 boundary
+  so the policy describes the pin rather than merely asserting it.
+  `[cited]`: `.github/workflows/fdroid-compat.yml` (Node runtime policy and all download steps).

--- a/docs/rebuild/DEVIATIONS_LEDGER_A.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER_A.md
@@ -852,3 +852,22 @@
   select JDK 21 directly and must not source this removed repository path. This rollback does not
   modify that external configuration; it restores the existing repository SDK helper, session
   hook, ladder, README, and `CLAUDE.md` unchanged.
+
+- DA-034 [cited]: the permission/privacy audit replaced implicit backup and release-diagnostic
+  assumptions with enforceable minimization. Android 12+ extraction rules are now allowlists: cloud
+  receives only core settings + saved profiles; direct device transfer additionally receives
+  user-authored context rules; coordinates/cache, SSIDs/app identities in cloud, behavioral points,
+  health/power diagnostics, context baselines, device-local consent flags, crash traces and root
+  app-private profile exports transfer nowhere. The default-on service state is deliberately portable
+  (fresh installs also start enabled), while default-off geo-IP/external-control consent is not. A unit
+  test locks both allowlists. Every manifest
+  permission and the Accessibility binding now has a feature/request/disclosure/denial/revocation
+  trace; notably, `ACCESS_BACKGROUND_LOCATION` is declared but has no implemented second-stage grant
+  flow, so docs no longer claim it is offered. DUMP copy now acknowledges the broad permission while
+  bounding Tideo's use to discarded `dumpsys wifi` output; elevated copy enumerates its secure display
+  effects and revocation. Finally, release builds no longer send process-coroutine throwables to
+  logcat (`BuildConfig.DEBUG` gate); fixed profile outcome logs remain value-free, and crash stacks
+  remain explicit-copy, app-private diagnostics excluded from all migration.
+  `[cited]`: `app/src/main/res/xml/data_extraction_rules.xml` (privacy allowlists/comment),
+  `app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AppProcessScope.kt` (debug-only throwable),
+  and `app/src/test/kotlin/com/tideo/autobrightness/app/DataExtractionRulesTest.kt` (contract).

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -100,6 +100,8 @@ TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per `RUNBOOK.md`; deviations in
 
 ## Changelog
 
+- 2026-07-29 — DA-034 completed the manifest/privacy audit: permission request, disclosure, denial and revocation flows; explicit cloud/transfer allowlists for every personal-data category; stronger DUMP/elevated copy; and debug-only throwable logging with local crash diagnostics excluded from migration. Background location remains declared but has no second-stage in-app grant flow, now documented honestly.
+
 One line per shipped change (newest first); detail in the D-rows and git history.
 
 - 2026-07-29 — DA-033 reverted the unsanctioned DA-032 repository/container bootstrap changes;

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -100,6 +100,8 @@ TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per `RUNBOOK.md`; deviations in
 
 ## Changelog
 
+- 2026-07-29 — DA-035 corrected the F-Droid compatibility workflow’s last Node 20 action: all download-artifact steps move from v6 (still `node20`) to the explicit Node 24 v7 major, and the misleading policy comment now records that boundary. The DA-034 follow-up also corrected two review-copy defects without changing behavior.
+
 - 2026-07-29 — DA-034 completed the manifest/privacy audit: permission request, disclosure, denial and revocation flows; explicit cloud/transfer allowlists for every personal-data category; stronger DUMP/elevated copy; and debug-only throwable logging with local crash diagnostics excluded from migration. Background location remains declared but has no second-stage in-app grant flow, now documented honestly.
 
 One line per shipped change (newest first); detail in the D-rows and git history.

--- a/docs/rebuild/architecture/datastore_map.md
+++ b/docs/rebuild/architecture/datastore_map.md
@@ -1,4 +1,4 @@
-# DataStore map (S12.9c #5)
+# DataStore, personal-data, and backup map (DA-034)
 
 The rebuild deliberately uses **nine independent DataStores** instead of one mega-store. Each owns a
 single cohesive concern with its own lifetime, write cadence and failure mode, so a corrupt or
@@ -8,13 +8,13 @@ schema-drifted file in one never takes down the others. They are declared in
 | # | Store (extension) | File | Type | Payload | Schema ver | Serializer | Why independent |
 |---|---|---|---|---|---|---|---|
 | 1 | `settingsDataStore` | `aab_settings.json` | typed JSON | `AabSettings` (flat, 48 fields) | **3** (`CURRENT_SCHEMA_VERSION`) | `AabSettingsSerializer` | The core tuned curve/threshold/dimming parameters; versioned + migrated (v1→v2→v3; the 7 D-151/D-152 display-toggle fields joined additively at v3). High read frequency (every pipeline reapply). |
-| 2 | `serviceHealthDataStore` | `service_health` | Preferences | heartbeat/telemetry key-values | n/a (schema-less) | — (Preferences) | Volatile runtime health written by `MaintenanceWorker`; losing it is harmless, so it stays a cheap key/value store with no schema. |
-| 3 | `experimentPrefsDataStore` | `experiment_prefs` | Preferences | fixed date + lat/lon override | n/a (schema-less) | — (Preferences) | Circadian "Experiment" overrides (`%AAB_Date`/`Latitude`/`Longitude`); rarely set, optional, key/value. |
+| 2 | `serviceHealthDataStore` | `service_health.preferences_pb` | Preferences | heartbeat timestamps, degraded flag/reason | n/a (schema-less) | — (Preferences) | Volatile runtime diagnostics written by `MaintenanceWorker`; losing it is harmless. |
+| 3 | `experimentPrefsDataStore` | `experiment_prefs.preferences_pb` | Preferences | fixed date + lat/lon override, geo-IP opt-in, daily cached lat/lon/day | n/a (schema-less) | — (Preferences) | Circadian experiment and acquisition state. It contains precise coordinates and a privacy consent choice. |
 | 4 | `contextRulesDataStore` | `aab_context_rules.json` | typed JSON | `ContextOverrideConfig` (rule list) | **1** (`ContextOverrideConfig.SCHEMA_VERSION`) | `ContextRulesSerializer` | The context-override rule set; edited from the Contexts UI, read by `ContextEngine`. Tasker-JSON interop lives here, separate from settings. |
 | 5 | `overridePointsDataStore` | `aab_override_points.json` | typed JSON | `OverridePoints` (≤50 records) | **1** (`OverridePoints.SCHEMA_VERSION`) | `OverridePointsSerializer` | Runtime-captured manual-override training points for the curve wizard; append-mostly, capped at 50. Distinct lifetime from user settings. |
 | 6 | `userProfilesDataStore` | `aab_user_profiles.json` | typed JSON | `SavedProfiles` (named profiles) | **1** (`SavedProfiles.SCHEMA_VERSION`) | `SavedProfilesSerializer` | User-editable named profiles (built-ins seeded once). Context rules target these by name; kept apart so a profile-store problem can't corrupt the live settings. |
-| 7 | `powerDrawDataStore` | `power_draw` | Preferences | measured OLED power-draw dataset (task524) | n/a (schema-less) | — (Preferences) | The Tools power-draw calibration samples; overwritten on recalibration, disposable, key/value. Distinct lifetime from settings (S14). |
-| 8 | `controlPrefsDataStore` | `control_prefs` | Preferences | `external_control_enabled` (opt-in gate) | n/a (schema-less) | — (Preferences) | **D-157**: the opt-in flag for the external intent-control surface. Its OWN store — deliberately **not** an `AabSettings` field — so profile apply/import chokepoints (`applyProfile`/`replaceAll`/`resetDefaults`/legacy import) can never flip it. Single Boolean, key/value. |
+| 7 | `powerDrawDataStore` | `power_draw.preferences_pb` | Preferences | measured OLED current/power samples (task524) | n/a (schema-less) | — (Preferences) | Disposable device-specific diagnostic/calibration data. |
+| 8 | `controlPrefsDataStore` | `control_prefs.preferences_pb` | Preferences | `external_control_enabled` (opt-in gate) | n/a (schema-less) | — (Preferences) | **D-157**: the device-local consent flag for the external intent-control surface. Its OWN store — deliberately **not** an `AabSettings` field — so profile apply/import/reset can never flip it. |
 | 9 | `contextBaselineDataStore` | `aab_context_baseline.json` | typed JSON | `ContextBaseline` (nullable `AabSettings` snapshot + `userProfileName`) | **2** (`ContextBaseline.SCHEMA_VERSION`) | `ContextBaselineSerializer` | **D-170**: the pre-override baseline snapshot (Tasker task626 `_ContextResume` / `%AAB_ProfileUser` revert file). Context-rule loads write through to store 1; this holds what the no-match revert restores. Kept apart so the snapshot/clear cadence and a corrupt snapshot (degrades to "no revert reference") never touch the live settings file. **DA-018**: v2 added `userProfileName` — the persisted `%AAB_ProfileUser` name (the last manually-loaded profile, default `"Default"`), the no-match/Resume revert TARGET. It outlives the snapshot (a snapshot `clear()` preserves it via `copy`). Additive → v1 files decode with the default; no migration hook reads the constant. |
 
 ## Versioning policy
@@ -36,3 +36,48 @@ schema-drifted file in one never takes down the others. They are declared in
 A single store would couple unrelated write cadences (every-cycle health vs. rare profile edits),
 make one corrupt section fatal to all settings, and force one monolithic migration. The split keeps each
 concern's blast radius local — the guiding principle for this map.
+
+## Personal-data inventory
+
+The stores are app-private (ordinary apps cannot read them), but app-private does not mean suitable
+for cloud backup:
+
+- **Location:** `experiment_prefs.preferences_pb` contains user-pinned and daily cached latitude /
+  longitude. `aab_context_rules.json` can contain geofence centers/radii.
+- **Wi-Fi SSIDs and foreground-app identities:** only user-authored rule targets in
+  `aab_context_rules.json` are persisted. Live SSID and foreground package signals stay in memory;
+  raw `cmd wifi status` / `dumpsys wifi` output is parsed, bounded, and discarded.
+- **Names:** `aab_user_profiles.json` contains user-chosen profile names/settings;
+  `aab_context_rules.json` contains rule/profile names; `aab_context_baseline.json` contains the last
+  manually loaded profile name. These can reveal routines even without sensor values.
+- **Behavioral/system diagnostics:** `aab_override_points.json` contains learned lux/brightness
+  pairs; `power_draw.preferences_pb` contains device power measurements;
+  `service_health.preferences_pb` contains timestamps and degraded reasons. `files/crash/*.txt`
+  contains exception messages/stacks that may incidentally include URIs, package names or system
+  state. None is transmitted by the app; crash text leaves only after the user copies it.
+- **Profile documents:** user-selected SAF imports remain with their document provider. Historical
+  `exportToAppPrivate` output can create root `files/*.json` profile copies. Their content and names
+  are treated as user data, not diagnostics.
+
+## Cloud-backup and device-transfer decisions
+
+`data_extraction_rules.xml` is an **allowlist**, so unlisted present and future files do not silently
+enter backup. DataStore files resolve under the `file` domain at `datastore/<name>`.
+
+| Category / file | Cloud backup | Device transfer | Decision |
+|---|---:|---:|---|
+| Core settings (`aab_settings.json`) | **Yes** | **Yes** | User configuration is the expected restore payload; it contains no location, SSID, package identity or free-form profile name. It includes the default-on `serviceEnabled` operational state and other feature toggles. That state is deliberately portable (a fresh install also starts enabled), unlike the separate default-off geo-IP/external-control privacy consents. |
+| Named profiles (`aab_user_profiles.json`) | **Yes** | **Yes** | User-created work worth restoring. Names may be personal. Each record serializes a full `AabSettings` snapshot—including global fields such as service/debug/notification state—even though `ProfileApplier` preserves those globals rather than applying them. No location, SSID or app identity is present. |
+| Context rules (`aab_context_rules.json`) | **No** | **Yes** | Excluded from third-party cloud because it may combine coordinates, SSIDs, package identities and routine names. Included in direct device transfer because the user explicitly migrates devices and the rules are otherwise costly to recreate. Runtime permission/app-op grants still do not transfer. |
+| Circadian experiment/cache (`experiment_prefs.preferences_pb`) | **No** | **No** | Precise coordinates, cached acquisition state and the geo-IP opt-in share one file. Fail closed rather than transfer stale location or consent; circadian reacquires locally and geo-IP returns off. |
+| Context baseline (`aab_context_baseline.json`) | **No** | **No** | Derived restoration snapshot and profile name can be stale without the original runtime context. It is rebuilt as contexts run. |
+| Override points (`aab_override_points.json`) | **No** | **No** | Behavioral learning data (lux/brightness history), not required configuration. The new device learns fresh points. |
+| Service health (`service_health.preferences_pb`) | **No** | **No** | Volatile timestamps/reasons are diagnostics and meaningless after restore. |
+| Power draw (`power_draw.preferences_pb`) | **No** | **No** | Device-specific measurements must not be applied to different hardware. |
+| External-control gate (`control_prefs.preferences_pb`) | **No** | **No** | Consent is device-local and defaults off after restore/transfer; a migrated install must explicitly re-enable its exported control surface. |
+| Crash files (`crash/`) | **No** | **No** | Sensitive diagnostics are local-only and irrelevant on a replacement/restored install. |
+| App-private exported profiles (`files/*.json`) | **No** | **No** | Redundant copies with user-chosen names/content; users migrate explicitly exported SAF documents themselves. |
+
+Android runtime grants, Usage Access, Accessibility enablement, Shizuku/root state, and persisted SAF
+URI grants are OS/provider capabilities rather than these payloads; the app re-probes them and does
+not treat restored settings as proof of permission.

--- a/docs/rebuild/architecture/permission_audit.md
+++ b/docs/rebuild/architecture/permission_audit.md
@@ -64,9 +64,9 @@ not automatic logs or telemetry; clipboard export always follows an explicit tap
 ## Opt-in and disclosure result
 
 - Geo-IP defaults off and names `ipwho.is`; accessibility overlay, usage access, location, DUMP,
-  elevated access, external automation control, and the monitoring service all require separate user
-  action except that monitoring itself is intentionally default-on and visibly foregrounded. Context
-  collectors are feature/rule gated. There is no telemetry or automatic upload path.
+  elevated access and external automation control all require separate user action. Monitoring itself
+  is intentionally default-on and visibly foregrounded. Context collectors are feature/rule gated.
+  There is no telemetry or automatic upload path.
 - The revised elevated and DUMP copy describes actual capability rather than understating it. The
   accessibility metadata and UI disclose presentation-only behavior and prevent window-content read.
 - The incomplete background-location grant flow is the one disclosure/behavior gap found. Until a

--- a/docs/rebuild/architecture/permission_audit.md
+++ b/docs/rebuild/architecture/permission_audit.md
@@ -1,29 +1,74 @@
-# Permission audit (S12.9c #9)
+# Permission, consent, and revocation audit (DA-034)
 
-Every permission declared in `app/src/main/AndroidManifest.xml`, why it exists, the feature that needs
-it, whether it is in v1 scope, whether it is removable, and the S14 recommendation. **Docs only — S14
-decides actual removals / the release-grade permission set.**
+Source of truth: `app/src/main/AndroidManifest.xml`, its referenced component XML, and the call sites
+named below. “Denied” includes never granted; “revoked” means a previously working grant/app-op is
+removed. Every optional privacy-sensitive path fails closed or falls back; none uploads telemetry.
 
-| Permission | Use | Feature | v1 scope | Removable | S14 recommendation |
-|---|---|---|---|---|---|
-| `WRITE_SETTINGS` | write `Settings.System` screen brightness + brightness mode | Core pipeline (BASIC tier) | ✅ yes | ❌ no | **Keep.** Foundational; user-grantable. |
-| `WRITE_SECURE_SETTINGS` | write `Settings.Secure` `reduce_bright_colors` (super dimming) | Super dimming (ELEVATED tier) | ✅ yes | ❌ no (feature-defining) | **Keep.** `signature\|privileged`; granted via ADB/Shizuku/root, not at runtime. `tools:ignore=ProtectedPermissions` is expected. |
-| `POST_NOTIFICATIONS` | the ongoing FGS notification + override notification | Foreground service runtime | ✅ yes | ❌ no | **Keep.** Runtime-requested on API 33+; guarded by `< TIRAMISU` for 31/32. |
-| `FOREGROUND_SERVICE` | run `AmbientMonitoringService` | Service runtime | ✅ yes | ❌ no | **Keep.** |
-| `FOREGROUND_SERVICE_SPECIAL_USE` | the `specialUse` FGS subtype (continuous light monitoring) | Service runtime | ✅ yes | ❌ no | **Keep.** Verify the Play `specialUse` declaration/justification at release (S14). |
-| `RECEIVE_BOOT_COMPLETED` | restart monitoring after reboot | `BootCompletedReceiver` | ✅ yes | ⚠️ optional | **Keep** (expected UX: auto-start on boot). |
-| `PACKAGE_USAGE_STATS` | read the foreground app for per-app context rules | Context rules (app trigger) | ✅ yes (contexts) | ⚠️ yes, if per-app rules cut | **Keep.** appop; granted via the usage-access deep-link, not a dialog. Only meaningful when an app rule exists. |
-| `ACCESS_COARSE_LOCATION` | context location gate + circadian sunrise/sunset | Contexts + circadian | ✅ yes | ⚠️ yes, if location features cut | **Keep**, but make optional/lazy (already requested in the Setup Location step). |
-| `ACCESS_FINE_LOCATION` | precise location for the context location gate | Contexts | ✅ yes | ⚠️ yes | **Re-evaluate.** COARSE may suffice for the haversine gate radius; consider dropping FINE at S14 if precision isn't needed. |
-| `ACCESS_BACKGROUND_LOCATION` | location reads from the FGS while UI backgrounded (API 29+) | Contexts + daily sun refresh | ✅ yes | ⚠️ yes | **Re-evaluate.** Heaviest Play-policy item. Confirm it's truly needed vs. foreground-only reads; document justification or drop at S14. |
-| `VIBRATE` | panic S.O.S. morse pattern (task528 / prof769) | Panic button | ✅ yes | ⚠️ optional | **Keep** (cheap, normal permission). |
-| `INTERNET` | geo-IP location fallback (`ipwho.is`, HTTPS — D-121) when no Android fix (task90 act28) | Circadian location fallback + Circadian "Use current location" (D-120) | ✅ yes | ⚠️ yes | **Keep** (owner-binding fallback, D-069). Now **HTTPS** (D-121): the prior `ip-api.com` cleartext exception is removed. The fallback is opt-in/default-off (D-105). |
-| `DUMP` | in-process `dumpsys wifi` for the no-Location SSID read (DumpsysWifiSsidStrategy) | Wi-Fi context rules without Location (D-130) | ✅ yes (contexts) | ⚠️ optional | **Keep (declared, D-130).** `signature\|privileged` but ALSO `development`, so user-grantable over ADB (`pm grant … android.permission.DUMP`), exactly like `WRITE_SECURE_SETTINGS`. Ungranted the `dumpsys wifi` exec is permission-denied and the SSID read falls through (Shizuku/root `cmd wifi status` → Location). `tools:ignore=ProtectedPermissions` is expected. **Security:** read-only diagnostics, no writes/escalation; user-initiated ADB grant only (never requested at runtime), revoked on uninstall; the app invokes only `dumpsys wifi`. DUMP *in general* is a broad info-disclosure surface (other services' dumps), which is why it stays **opt-in** behind Shizuku/root/Location, not nudged. Low risk for an informed user granting it to this open-source build. |
+| Permission / binding | Exact feature and use | Request flow and user explanation | Denial behavior | Revocation behavior |
+|---|---|---|---|---|
+| `WRITE_SETTINGS` | BASIC-tier core: `ScreenBrightnessController` writes system brightness and brightness mode. | Setup opens `ACTION_MANAGE_WRITE_SETTINGS`; the required card says it grants brightness control and that the service otherwise cannot change brightness. This is a special-access screen, not a runtime dialog. | Tier is `NONE`; UI and service may run, but guarded writes fail/no-op rather than crash. Setup remains incomplete but is skippable. | `PrivilegeManager.refresh()` observes the loss. Later writes fail safely; Android retains whatever brightness/mode was last written until the user or system changes it. |
+| `WRITE_SECURE_SETTINGS` | ELEVATED tier: super dimming (`reduce_bright_colors`) and profile display toggles (Night Light/temperature, color correction, inversion, AOD, stay-awake while charging, force-SDR). Secure settings are written directly after the grant. | Optional Setup/Privileged Display cards disclose the secure-display effects. It cannot be runtime-requested: the user chooses ADB, one-tap Shizuku grant, or root; ADB is always shown. | BASIC brightness remains fully functional; every elevated write is gated/no-op. The profile preferences remain stored for a later grant. | Tier falls on the next refresh and future secure writes stop. Revocation does **not** restore prior system values; the last applied values remain system state. Revoke with `adb shell pm revoke … WRITE_SECURE_SETTINGS` or uninstall. |
+| `DUMP` | Optional no-Location SSID strategy runs only fixed `dumpsys wifi`, parses the connected SSID in memory, discards all other bounded output, then falls through to other strategies as needed. | Never requested or nudged during Setup. “Use current SSID” help appears only after other reads fail, describes DUMP as broad system diagnostics, states this app's fixed read-only command/no output retention, and offers a copyable ADB grant command. | `dumpsys` is permission-denied; SSID resolution falls through to Shizuku/root `cmd wifi status`, then the Location-gated network API. Wi-Fi rules receive no SSID if all fail. | Identical to denial on the next read; already persisted rule SSIDs are not deleted. Revoke with `adb shell pm revoke … DUMP` or uninstall. |
+| `PACKAGE_USAGE_STATS` | `UsageStatsManager` polls activity-resumed events for package identities used by per-app context rules. Identities are held in runtime state; user-selected package names also live in context rules. | Optional Setup step deep-links to `ACTION_USAGE_ACCESS_SETTINGS`. It becomes “needed” only when an app rule exists and explains foreground-app detection; the Context editor also provides the grant hint/link. | The app watcher is not started without an app rule and permission. App-trigger matching stays unavailable; other context dimensions and brightness continue. | Permission is checked when the watcher is configured/restarted; queries then return no usable events, so package matches stop. Stored app rules remain for a future re-grant. |
+| `ACCESS_COARSE_LOCATION` | Approximate Android location for circadian sunrise/sunset, location-radius rules, and the final platform SSID fallback. | Optional Setup runtime request asks coarse and fine together after explaining location rules and Wi-Fi-name fallback. Android may grant approximate only. The circadian screen separately discloses/controls the **network** fallback. | Android fixes are unavailable. Circadian uses its daily cache/default sun times (or opt-in geo-IP); location rules cannot match; SSID tries no-Location strategies first. | Readers catch the security failure/stop producing fixes. Existing context geofences and the last daily circadian cache remain stored, but no new Android location is acquired. |
+| `ACCESS_FINE_LOCATION` | Precise form of the same Android-location read, principally useful for small-radius geofences; Android may downgrade the combined request to approximate. | Same optional coarse+fine dialog; there is no separate fine-only prompt. The current Setup copy does not claim that precise location is mandatory. | With coarse granted, approximate fixes still drive the same features with reduced accuracy; with neither grant, coarse denial behavior applies. | Android can downgrade to approximate while the app runs; later reads use that accuracy. Stored coordinates are unchanged. |
+| `ACCESS_BACKGROUND_LOCATION` | Intended to allow location-rule and daily circadian acquisition while the special-use foreground service runs with the UI backgrounded. | **Declared but not requested by current code.** Setup requests only coarse/fine; there is no second-stage “Allow all the time” request or app-settings deep-link. Therefore normal installs do not grant it. This gap is documented rather than represented as consent obtained. | Foreground/UI location acquisition works; background delivery is OS-limited and background-dependent matches/refreshes may wait until the app returns foreground. The service and non-location rules continue. | Same as denial; no crash and no deletion of rules/caches. A grant, if manually made in App info, can be removed there at any time. |
+| `POST_NOTIFICATIONS` | Shows the ongoing foreground-service control/status notification and override/permission-needed notifications. | On API 33+, `MainActivity` may show the runtime dialog at launch and Setup provides a clearly labelled retry card. API 31–32 auto-grant it. | The foreground service may still run, but Android suppresses notification-drawer visibility; in-app status, tile/widget controls, and core brightness continue. | Later notification posts are suppressed. Service settings and runtime opt-in do not change. |
+| `FOREGROUND_SERVICE` | Base permission for `AmbientMonitoringService`, which continuously consumes the light sensor and controls brightness. | Normal install permission; no dialog. Monitoring is enabled by default to match the shipped Tasker behavior and starts on app bootstrap; the persistent notification makes operation visible and Dashboard/tile/widget/notification can stop it. | Install/platform policy failure prevents FGS start; the start path posts a permission-needed state rather than silently doing background work. | Not independently user-revocable; disabling/stopping the app/service ends collection and brightness writes. |
+| `FOREGROUND_SERVICE_SPECIAL_USE` | Declares the FGS subtype used for continuous ambient-light monitoring; the manifest property gives that exact justification. | Normal install permission, no dialog. The default-on master service setting, user controls, and ongoing notification provide the visible control surface; this is not represented as an opt-in permission. | If the platform refuses this type, monitoring cannot remain active in background. | Not independently user-revocable; stopping the service or app removes the behavior. |
+| `RECEIVE_BOOT_COMPLETED` | `BootCompletedReceiver` restarts monitoring after boot **only** when persisted `serviceEnabled` is true. | Normal install permission, no dialog. `serviceEnabled` defaults true and is persisted; the Dashboard/tile/widget/notification stop action changes it to false before the next boot. | No automatic restart; opening/starting the app manually still works. | Android does not offer a standalone revoke. Disabling master service prevents the receiver from starting it; force-stop also suppresses broadcasts until next launch. |
+| `VIBRATE` | Panic/reset gesture emits the Tasker S.O.S. vibration pattern after stopping automation and forcing safe brightness. | Normal install permission, no dialog; the Panic feature is user-triggered/configured. | Reset/maximum-brightness safety action still runs; only haptic confirmation is absent. | Not independently user-revocable on supported Android versions; system haptic/device policy may suppress output. |
+| `INTERNET` | Sole app network client is `GeoIpLocationClient`, an HTTPS request to `ipwho.is` for coarse coordinates when Android supplies no fix. No analytics, ads, profile sync, or command transport. Cleartext is disabled globally. | Normal install permission, no dialog. Network use is **default off** and enabled only by the circadian “IP fallback” switch, whose copy names the third party and purpose. | With the toggle off, no request is attempted. Offline/failed/invalid responses return unavailable; cached/default sun times remain and the brightness pipeline continues. | Not independently user-revocable by Android; turning the feature switch off immediately prevents future requests. Firewall/network loss follows denial behavior. |
+| `ACCESS_NETWORK_STATE` | `ConnectivityManager`/`NetworkCallback` observes Wi-Fi connectivity and reads `WifiInfo` for SSID matching; it does not inspect traffic. | Normal install permission, no dialog. The Context editor explains why the Wi-Fi name is needed and the Location/privileged alternatives. | The network callback path cannot resolve connectivity/SSID; privileged and Location strategies may still succeed. Other rules continue. | Not independently user-revocable; network disable/loss emits disconnected state and Wi-Fi rules stop matching. |
+| `BIND_ACCESSIBILITY_SERVICE` (service gate, held by Android rather than requested by the app) | Android alone may bind `AabToastAccessibilityService`, which draws diagnostic/context flashes over other apps. XML sets `canRetrieveWindowContent=false`; callback ignores all events and never reads/acts on UI content. | Default off. Live Debug clearly describes an optional presentation-only overlay and deep-links to system Accessibility settings; Android shows its own enablement confirmation. | Flashes remain inside Tideo (or use its foreground toast fallback); all automation works. | `onUnbind` removes the global presenter immediately; future flashes use in-app fallback. No data was persisted by this service. |
 
-## Notes
+## Findings and privacy conclusions
 
-- No `MANAGE_EXTERNAL_STORAGE` / broad storage permission — legacy config import uses SAF (a folder
-  grant), so none is needed (G2R-F16).
-- The heaviest Play-policy reviews at release will be `*_LOCATION` (esp. background) and the
-  `specialUse` FGS justification — flagged above for S14.
-- `<queries>` LAUNCHER (not a permission) backs the per-app context-rule picker (G2-F14).
+- `WRITE_SECURE_SETTINGS` and `DUMP` are powerful development permissions despite the app's narrow
+  call sites. They stay optional, have no automatic runtime prompt, and now disclose both the app's
+  exact operation and the user's revocation route. `DUMP` command output is bounded and never logged
+  or persisted.
+- Background location has a manifest declaration and runtime need but **no complete grant flow**.
+  The app must not claim otherwise. Adding a second-stage request is a future user-visible product
+  decision; today revocation/absence degrades location work as described above.
+- Usage access, Location, Accessibility, DUMP, elevated access, geo-IP and external broadcast control
+  are opt-in. The core BASIC pipeline requires only Modify System Settings; context signal collectors
+  are lazy-gated by relevant rules where applicable.
+- `MainActivity` currently prompts for notifications at launch before the Setup explanation is read;
+  Setup also provides disclosure and retry. This is the only privacy-adjacent prompt that is eager.
+- There is no broad storage permission. Profile import/export uses user-selected SAF documents/tree
+  grants. `<queries>` for launcher activities is package visibility, not an Android permission; it
+  populates the explicit app-rule picker and does not transmit the list.
+
+## Logging and diagnostic disclosure audit
+
+A source-wide search of `app/src/main` and `platform/src/main` found exactly two diagnostic sinks:
+Android logcat calls and the app-private crash ring.
+
+| Data class scrutinized | Finding |
+|---|---|
+| Imported profile content and parser failures | `ProfileImportExportManager` logs only fixed outcome strings. It never logs the content, parser exception, provider, display name, or URI. Parser exception messages remain transient typed result metadata and current UI maps typed failures to fixed user copy. |
+| URIs / SAF profile names | No URI or document name is logged. Some exceptional export/import paths can show the initiating user an exception message in the foreground UI; that is not background logging or transmission. Persisted SAF read grants remain Android-owned capability state. |
+| Package identities, SSIDs, coordinates | No logcat call receives these values. They can be deliberately shown to the user in foreground UI/toasts while selecting a rule (“connected to …”, acquired coordinates) and context/profile names can appear in opt-in debug flashes. Raw Wi-Fi command output is never logged or stored. |
+| Privileged command output/errors | Root, Shizuku and DUMP adapters return bounded typed success/data and discard stderr/unused stdout. They do not log argv, stdout, stderr, exit text or thrown exceptions. |
+| Exceptions | The process-scoped coroutine handler used to pass a raw throwable to `Log.e` in every build. It is now compiled behind `BuildConfig.DEBUG`; release builds emit neither its message nor stack. Profile logs omit exception objects. |
+| System-state values | The named Tasker debug categories render selected values only on the user-facing flash/debug surfaces when configured. `service_health` and power samples are app-private stores, not logs, and are excluded from backup/transfer. |
+| Crash diagnostics | `CrashLogStore` intentionally records the five newest uncaught stacks under app-private `files/crash`. Tools discloses that they stay on-device and requires an explicit Copy action to move one to the clipboard. The backup allowlist excludes them from cloud and transfer. This facility exists in release, so it can contain sensitive exception text; its local-only, user-mediated design is the control. |
+
+The remaining production `Log.w`/`Log.e` calls are fixed strings for profile read/format outcomes;
+they contain no user or system values. There is no logging API in `platform/src/main`. Android release
+builds are not minified, so this conclusion rests on call-site data minimization rather than assuming
+log stripping. User-facing curve-wizard reports and live diagnostics are deliberate foreground tools,
+not automatic logs or telemetry; clipboard export always follows an explicit tap/run.
+
+## Opt-in and disclosure result
+
+- Geo-IP defaults off and names `ipwho.is`; accessibility overlay, usage access, location, DUMP,
+  elevated access, external automation control, and the monitoring service all require separate user
+  action except that monitoring itself is intentionally default-on and visibly foregrounded. Context
+  collectors are feature/rule gated. There is no telemetry or automatic upload path.
+- The revised elevated and DUMP copy describes actual capability rather than understating it. The
+  accessibility metadata and UI disclose presentation-only behavior and prevent window-content read.
+- The incomplete background-location grant flow is the one disclosure/behavior gap found. Until a
+  dedicated second-stage flow is owner-approved, the honest behavior is foreground-only acquisition
+  plus graceful degradation—not an implied “Allow all the time” grant.


### PR DESCRIPTION
### Motivation

- Perform a privacy- and permissions-focused audit of the manifest, runtime request/consent flows, and diagnostic surfaces to reduce accidental exposure of sensitive values. 
- Replace a permissive default backup/transfer posture with reviewed allowlists so only intended user-visible config is migrated. 
- Prevent release builds from emitting raw exception stacks to logcat while preserving debug diagnostics and local crash capture for owner-driven reporting.

### Description

- Added an explicit privacy allowlist to `app/src/main/res/xml/data_extraction_rules.xml` and included only reviewed DataStore files for cloud and device-transfer (`aab_settings.json`, `aab_user_profiles.json`, plus `aab_context_rules.json` for device transfer). 
- Added `app/src/test/kotlin/com/tideo/autobrightness/app/DataExtractionRulesTest.kt` to lock the extraction-rule allowlists as a regression test. 
- Hardened release diagnostics by gating process-scoped coroutine throwable logging behind `BuildConfig.DEBUG` in `AppProcessScope` and turned on `buildConfig` in `app/build.gradle.kts` so the variant constant is available at compile time. 
- Clarified user-facing copy for high-impact permissions in `app/src/main/res/values/strings.xml` (notably `DUMP` and `WRITE_SECURE_SETTINGS`) and fixed the manifest comment to document that `ACCESS_BACKGROUND_LOCATION` is declared but no second-stage in-app “Allow all the time” flow is implemented. 
- Extended documentation: updated `docs/rebuild/architecture/permission_audit.md` and `docs/rebuild/architecture/datastore_map.md` to map each manifest permission to its feature, request/denial/revocation behavior and to inventory persisted personal data; added a DEVIATIONS entry describing the audit (DA-034). 

### Testing

- Ran the focused allowlist unit test: `./gradlew :app:testDebugUnitTest --tests com.tideo.autobrightness.app.DataExtractionRulesTest` (passed). 
- Built and verified main project checks: `./gradlew :domain:test :app:assembleDebug :app:assembleRelease :app:lintDebug` (succeeded). 
- Ran the ladder guards: `scripts/ladder.sh --guards-only` (guards passed). 
- Inspected release bytecode with `javap` to confirm the release coroutine exception handler contains no `Log.e` call (verified). 
- `:platform:test` (Robolectric) was attempted but a subset of platform Robolectric tests failed to run because Robolectric's artifact fetcher encountered a network `SocketException` fetching test artifacts; the failures are external-network related (not code regressions) and block the platform test matrix in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69f790d5a88321aa04e707c0770544)