### PR TITLE
Harden profile import/export and saved-profile persistence boundaries

### DIFF
--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/AabSettingsSerializer.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/AabSettingsSerializer.kt
@@ -16,7 +16,8 @@ object AabSettingsSerializer : Serializer<AabSettings> {
     override suspend fun readFrom(input: InputStream): AabSettings {
         return runCatching {
             val raw = json.decodeFromString(AabSettings.serializer(), input.readBytes().decodeToString())
-            migrate(raw)
+            require(raw.schemaVersion in 1..CURRENT_SCHEMA_VERSION)
+            migrate(raw).validate()
         }.getOrDefault(defaultValue)
     }
 

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ImportStructureGuard.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ImportStructureGuard.kt
@@ -1,0 +1,68 @@
+package com.tideo.autobrightness.app.settings
+
+/** DA-036: cheap, non-recursive limits applied before kotlinx.serialization sees untrusted JSON. */
+internal object ImportStructureGuard {
+    const val MAX_DEPTH = 32
+    const val MAX_CONTAINER_ENTRIES = 256
+    const val MAX_STRING_CHARS = 16_384
+
+    fun requireBoundedJson(raw: String) {
+        data class Frame(
+            val objectLike: Boolean,
+            var entries: Int = 1,
+            var expectingKey: Boolean = objectLike,
+            val keys: MutableSet<String> = mutableSetOf(),
+        )
+
+        val stack = ArrayDeque<Frame>()
+        var inString = false
+        var escaped = false
+        var stringChars = 0
+        var stringIsKey = false
+        val key = StringBuilder()
+        raw.forEach { character ->
+            if (inString) {
+                when {
+                    escaped -> {
+                        if (stringIsKey) throw IllegalArgumentException("Escaped JSON field names are not accepted")
+                        escaped = false
+                    }
+                    character == '\\' -> escaped = true
+                    character == '"' -> {
+                        inString = false
+                        if (stringIsKey && !stack.last().keys.add(key.toString())) {
+                            throw IllegalArgumentException("Duplicate JSON field")
+                        }
+                    }
+                    else -> {
+                        if (stringIsKey) key.append(character)
+                        if (++stringChars > MAX_STRING_CHARS) {
+                            throw IllegalArgumentException("JSON string is too long")
+                        }
+                    }
+                }
+            } else {
+                when (character) {
+                    '"' -> {
+                        inString = true
+                        stringChars = 0
+                        stringIsKey = stack.lastOrNull()?.let { it.objectLike && it.expectingKey } == true
+                        key.clear()
+                    }
+                    '{', '[' -> {
+                        if (stack.size >= MAX_DEPTH) throw IllegalArgumentException("JSON nesting is too deep")
+                        stack.addLast(Frame(objectLike = character == '{'))
+                    }
+                    '}', ']' -> if (stack.isNotEmpty()) stack.removeLast()
+                    ':' -> stack.lastOrNull()?.let { if (it.objectLike) it.expectingKey = false }
+                    ',' -> stack.lastOrNull()?.let {
+                        if (++it.entries > MAX_CONTAINER_ENTRIES) {
+                            throw IllegalArgumentException("JSON container has too many entries")
+                        }
+                        if (it.objectLike) it.expectingKey = true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/LegacyConfigImporter.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/LegacyConfigImporter.kt
@@ -20,6 +20,7 @@ data class LegacyConfigEntry(val name: String, val uri: Uri)
  * is the supported way to reach it.
  */
 object LegacyConfigImporter {
+    internal const val MAX_LISTED_CONFIGS = 256
 
     /** Persist the long-lived read permission on a tree URI returned by `OpenDocumentTree`. */
     fun persistGrant(context: Context, treeUri: Uri) {
@@ -49,7 +50,7 @@ object LegacyConfigImporter {
                 ),
                 null, null, null,
             )?.use { cursor ->
-                while (cursor.moveToNext()) {
+                while (out.size < MAX_LISTED_CONFIGS && cursor.moveToNext()) {
                     val id = cursor.getString(0)
                     val name = cursor.getString(1) ?: continue
                     if (!name.endsWith(".json", ignoreCase = true)) continue

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ProfileApplier.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ProfileApplier.kt
@@ -38,7 +38,7 @@ class ProfileApplier(
      * unknown name is a no-op (external callers may send an arbitrary string).
      */
     suspend fun applyProfile(name: String) {
-        val profile = userProfiles.get(name) ?: DefaultProfiles.all[name] ?: return
+        val profile = (userProfiles.get(name) ?: DefaultProfiles.all[name] ?: return).validate()
         // The manual choice becomes the new baseline — drop any pre-override snapshot (D-170).
         // Clear BEFORE the settings write: a death in between means the load simply didn't take
         // (benign), whereas write-then-clear could leave a stale snapshot that a later revert

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ProfileImportExportManager.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ProfileImportExportManager.kt
@@ -12,8 +12,10 @@ import java.nio.ByteBuffer
 import java.nio.charset.CharacterCodingException
 import java.nio.charset.CodingErrorAction
 import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 
 /**
  * Outcome of loading a profile file (S12.9c #3). Replaces the old silent
@@ -50,7 +52,7 @@ class ProfileImportExportManager(
         internal const val MAX_ENCODED_PROFILE_BYTES = 256 * 1024
     }
 
-    private val json = Json { ignoreUnknownKeys = true; prettyPrint = true }
+    private val json = Json { ignoreUnknownKeys = false; prettyPrint = true }
 
     suspend fun exportToAppPrivate(profileName: String, settings: AabSettings): String {
         val fileName = sanitizeFileName(profileName)
@@ -150,11 +152,27 @@ class ProfileImportExportManager(
      * second. Logs only the outcome, never parser details that could quote imported content.
      */
     fun decodePayload(content: String): ProfileLoadResult {
+        runCatching { ImportStructureGuard.requireBoundedJson(content) }.exceptionOrNull()?.let {
+            return ProfileLoadResult.TotalFailure(it.message ?: "JSON structure rejected", "Legacy parse not attempted")
+        }
         val jsonAttempt = runCatching {
-            json.decodeFromString(AabProfilePayload.serializer(), content).settings.validate()
+            val payload = json.decodeFromString(AabProfilePayload.serializer(), content)
+            require(payload.schemaVersion in 1..CURRENT_SCHEMA_VERSION) { "Unsupported profile schema" }
+            require(payload.settings.schemaVersion in 1..CURRENT_SCHEMA_VERSION) { "Unsupported settings schema" }
+            AabSettingsSerializer.migrate(payload.settings).validate()
         }
         jsonAttempt.getOrNull()?.let { return ProfileLoadResult.Success(it) }
         val jsonError = jsonAttempt.exceptionOrNull()?.message ?: "JSON parse failed"
+
+        // A payload that identifies itself as the native format must never be reinterpreted as the
+        // deliberately tolerant legacy format. Otherwise a future/invalid native schema could turn
+        // into an all-default "successful" legacy import and bypass its schema decision.
+        val nativeShape = runCatching {
+            (json.parseToJsonElement(content) as? JsonObject)?.keys?.any { it == "schemaVersion" || it == "settings" }
+        }.getOrNull() == true
+        if (nativeShape) {
+            return ProfileLoadResult.TotalFailure(jsonError, "Native payload is not eligible for legacy fallback")
+        }
 
         val legacyAttempt = runCatching { TaskerLegacyProfileSerializer.deserialize(content).validate() }
         legacyAttempt.getOrNull()?.let {
@@ -166,14 +184,23 @@ class ProfileImportExportManager(
         return ProfileLoadResult.TotalFailure(jsonError, legacyError)
     }
 
-    private fun sanitizeFileName(profileName: String): String {
-        val safeName = profileName.trim().replace(Regex("[^a-zA-Z0-9._-]"), "_")
-        return if (safeName.endsWith(".json")) safeName else "$safeName.json"
+    internal fun sanitizeFileName(profileName: String): String {
+        val trimmed = profileName.trim().removeSuffix(".json")
+        val normalized = trimmed.replace(Regex("[^a-zA-Z0-9._-]"), "_")
+            .trim('.', '_', '-')
+            .take(96)
+        val base = normalized.ifBlank { "profile" }
+        // Names that normalize to the same visible stem get different private files.
+        val suffix = if (base == trimmed) "" else "-${profileName.sha256Prefix()}"
+        return "$base$suffix.json"
     }
+
+    private fun String.sha256Prefix(): String = MessageDigest.getInstance("SHA-256")
+        .digest(encodeToByteArray()).take(6).joinToString("") { "%02x".format(it) }
 }
 
 @Serializable
-private data class AabProfilePayload(
+internal data class AabProfilePayload(
     val schemaVersion: Int = CURRENT_SCHEMA_VERSION,
     val settings: AabSettings,
 )

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/TaskerLegacyProfileSerializer.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/TaskerLegacyProfileSerializer.kt
@@ -41,6 +41,7 @@ object TaskerLegacyProfileSerializer {
             throw LegacyProfileParseException("Empty legacy profile input")
         }
         if (trimmed.startsWith("{")) {
+            ImportStructureGuard.requireBoundedJson(trimmed)
             val root = runCatching { json.parseToJsonElement(trimmed) as? JsonObject }.getOrNull()
             if (root != null) return deserializeJson(root)
             // Looked like JSON but did not parse to an object — fall through to the key=value attempt.
@@ -113,6 +114,9 @@ object TaskerLegacyProfileSerializer {
             .lineSequence()
             .map { it.trim() }
             .filter { it.startsWith("%AAB_") && it.contains('=') }
+            .take(ImportStructureGuard.MAX_CONTAINER_ENTRIES + 1)
+            .toList()
+            .also { require(it.size <= ImportStructureGuard.MAX_CONTAINER_ENTRIES) { "Too many legacy fields" } }
             .associate { line ->
                 val index = line.indexOf('=')
                 line.substring(0, index).trim() to line.substring(index + 1).trim()
@@ -191,17 +195,19 @@ object TaskerLegacyProfileSerializer {
     // fields the rebuild models as Int. The old `toIntOrNull()` returned null on a decimal string, so
     // the field silently kept its default — the "Form1A didn't stick" symptom. Round instead (matching
     // the nested-JSON path's `intRound`). A plain integer string ("5") rounds to itself.
-    private fun String.asRoundedInt(): Int? = trim().toDoubleOrNull()?.let { Math.round(it).toInt() }
-    private fun String.asRoundedLong(): Long? = trim().toDoubleOrNull()?.let { Math.round(it) }
+    private fun String.asRoundedInt(): Int? = trim().toDoubleOrNull()?.takeIf { it.isFinite() }
+        ?.let { Math.round(it).takeIf { rounded -> rounded in Int.MIN_VALUE..Int.MAX_VALUE }?.toInt() }
+    private fun String.asRoundedLong(): Long? = trim().toDoubleOrNull()?.takeIf { it.isFinite() }?.let { Math.round(it) }
 
     // --- nested-JSON value readers (tolerant: numbers stored as JSON doubles, booleans as JSON bools
     //     by performSave's getG/getI/getB, but accept "On"/"Off"/"1" string variants too) ---
 
     private fun JsonObject.prim(key: String): JsonPrimitive? = this[key] as? JsonPrimitive
-    private fun JsonObject.dbl(key: String): Double? = prim(key)?.doubleOrNull
-    private fun JsonObject.flt(key: String): Float? = prim(key)?.doubleOrNull?.toFloat()
-    private fun JsonObject.intRound(key: String): Int? = prim(key)?.doubleOrNull?.let { Math.round(it).toInt() }
-    private fun JsonObject.longRound(key: String): Long? = prim(key)?.doubleOrNull?.let { Math.round(it) }
+    private fun JsonObject.dbl(key: String): Double? = prim(key)?.doubleOrNull?.takeIf { it.isFinite() }
+    private fun JsonObject.flt(key: String): Float? = dbl(key)?.toFloat()?.takeIf { it.isFinite() }
+    private fun JsonObject.intRound(key: String): Int? = dbl(key)?.let { Math.round(it) }
+        ?.takeIf { it in Int.MIN_VALUE..Int.MAX_VALUE }?.toInt()
+    private fun JsonObject.longRound(key: String): Long? = dbl(key)?.let { Math.round(it) }
     private fun JsonObject.bool(key: String): Boolean? {
         val p = prim(key) ?: return null
         p.booleanOrNull?.let { return it }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/UserProfileStore.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/UserProfileStore.kt
@@ -43,7 +43,15 @@ object SavedProfilesSerializer : Serializer<SavedProfiles> {
 
     override suspend fun readFrom(input: InputStream): SavedProfiles =
         runCatching {
-            json.decodeFromString(SavedProfiles.serializer(), input.readBytes().decodeToString())
+            val decoded = json.decodeFromString(SavedProfiles.serializer(), input.readBytes().decodeToString())
+            require(decoded.profiles.size <= UserProfileStore.MAX_PROFILES)
+            decoded.copy(
+                profiles = decoded.profiles.map {
+                    require(it.name.isNotBlank() && it.name != "." && it.name != ".." &&
+                        it.name.length <= UserProfileStore.MAX_PROFILE_NAME_CHARS)
+                    it.copy(settings = it.settings.validate())
+                }.distinctBy { it.name },
+            )
         }.getOrDefault(defaultValue)
 
     override suspend fun writeTo(t: SavedProfiles, output: OutputStream) {
@@ -63,6 +71,11 @@ object SavedProfilesSerializer : Serializer<SavedProfiles> {
  */
 class UserProfileStore(private val dataStore: DataStore<SavedProfiles>) {
 
+    companion object {
+        internal const val MAX_PROFILES = 128
+        internal const val MAX_PROFILE_NAME_CHARS = 96
+    }
+
     /** The saved profiles in display order (built-ins first), seeding lazily on collect. */
     fun profilesFlow(): Flow<List<SavedProfile>> = dataStore.data.map { seedIfNeeded(it).profiles }
 
@@ -75,7 +88,7 @@ class UserProfileStore(private val dataStore: DataStore<SavedProfiles>) {
     suspend fun names(): List<String> = profiles().map { it.name }
 
     /** Resolve a profile NAME to its parameter set, or null if unknown (catalog fallback handles that). */
-    suspend fun get(name: String): AabSettings? = profiles().firstOrNull { it.name == name }?.settings
+    suspend fun get(name: String): AabSettings? = profiles().firstOrNull { it.name == name }?.settings?.validate()
 
     /** Seed the five built-ins exactly once. Idempotent after the first call. */
     suspend fun ensureSeeded() {
@@ -87,13 +100,17 @@ class UserProfileStore(private val dataStore: DataStore<SavedProfiles>) {
      * [SavedProfile.builtIn] flag (so an edited built-in is still "factory" for restore purposes).
      */
     suspend fun save(name: String, settings: AabSettings) {
+        val safeName = name.trim()
+        require(safeName.isNotBlank() && safeName != "." && safeName != ".." &&
+            safeName.length <= MAX_PROFILE_NAME_CHARS) { "Invalid profile name" }
         dataStore.updateData { raw ->
             val current = seedIfNeeded(raw)
-            val exists = current.profiles.any { it.name == name }
+            val exists = current.profiles.any { it.name == safeName }
+            require(exists || current.profiles.size < MAX_PROFILES) { "Too many saved profiles" }
             val profiles = if (exists) {
-                current.profiles.map { if (it.name == name) it.copy(settings = settings) else it }
+                current.profiles.map { if (it.name == safeName) it.copy(settings = settings.validate()) else it }
             } else {
-                current.profiles + SavedProfile(name = name, settings = settings, builtIn = false)
+                current.profiles + SavedProfile(name = safeName, settings = settings.validate(), builtIn = false)
             }
             current.copy(profiles = profiles)
         }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/state/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/state/SettingsViewModel.kt
@@ -13,6 +13,7 @@ import com.tideo.autobrightness.app.settings.ProfileApplier
 import com.tideo.autobrightness.app.settings.SavedProfile
 import com.tideo.autobrightness.app.settings.SettingsValidator
 import com.tideo.autobrightness.app.settings.UserProfileStore
+import com.tideo.autobrightness.app.settings.validate
 import com.tideo.autobrightness.app.storage.contextBaselineDataStore
 import com.tideo.autobrightness.app.storage.settingsDataStore
 import com.tideo.autobrightness.domain.brightness.BrightnessFormulae
@@ -113,12 +114,25 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 // Preserve the live service flag + the global DetectOverrides (G2-F8) and debugLevel
                 // (G2R-F9) preferences — neither belongs to an imported profile's parameter set. An
                 // import is also a manual load → latch the context lock (G2R-F30).
-                newSettings.copy(
+                newSettings.validate().copy(
                     serviceEnabled = current.serviceEnabled,
                     detectOverrides = current.detectOverrides,
                     debugLevel = current.debugLevel,
                     panicSensitivity = current.panicSensitivity,
                     contextOverride = true,
+                    // Import has no per-capability preview. Keep every secure/elevated field at its
+                    // current value so choosing a document cannot silently opt the user into secure
+                    // display writes. A legacy profile saved to the catalog can still carry these
+                    // fields; applying it later goes through the visible profile preview.
+                    dimmingEnabled = current.dimmingEnabled,
+                    nightLightEnabled = current.nightLightEnabled,
+                    nightLightTemperature = current.nightLightTemperature,
+                    nightLightCircadianEnabled = current.nightLightCircadianEnabled,
+                    daltonizerMode = current.daltonizerMode,
+                    inversionEnabled = current.inversionEnabled,
+                    alwaysOnDisplayEnabled = current.alwaysOnDisplayEnabled,
+                    stayAwakeChargingEnabled = current.stayAwakeChargingEnabled,
+                    hdrForceSdrEnabled = current.hdrForceSdrEnabled,
                 )
             }
             if (updated.serviceEnabled) AutoBrightnessRuntime.reapply(app)

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/settings/ProfileLoadResultTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/settings/ProfileLoadResultTest.kt
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 /**
@@ -91,6 +92,42 @@ class ProfileLoadResultTest {
             override fun read(buffer: ByteArray, offset: Int, length: Int): Int = read()
         }
         assertEquals(ProfileLoadResult.ReadFailure, manager.readAndDecode(failingStream))
+    }
+
+    @Test
+    fun `zero byte bulk reads cannot stall or bypass the cap`() {
+        var remaining = ProfileImportExportManager.MAX_ENCODED_PROFILE_BYTES + 1
+        val hostile = object : InputStream() {
+            override fun read(buffer: ByteArray, offset: Int, length: Int): Int = 0
+            override fun read(): Int = if (remaining-- > 0) ' '.code else -1
+        }
+        assertEquals(ProfileLoadResult.TooLarge, manager.readAndDecode(hostile))
+    }
+
+    @Test
+    fun `native payload rejects unsupported schemas unknown fields and excessive structure`() {
+        listOf(
+            """{ "schemaVersion": 999, "settings": {} }""",
+            """{ "schemaVersion": 3, "unexpected": true, "settings": {} }""",
+            """{ "schemaVersion": 3, "settings": { "unexpected": true } }""",
+            """{ "schemaVersion": 3, "schemaVersion": 3, "settings": {} }""",
+            "[".repeat(ImportStructureGuard.MAX_DEPTH + 1) + "0" +
+                "]".repeat(ImportStructureGuard.MAX_DEPTH + 1),
+        ).forEach { input ->
+            assertTrue(manager.decodePayload(input) is ProfileLoadResult.TotalFailure, input.take(80))
+        }
+    }
+
+    @Test
+    fun `private filename normalization rejects dot aliases and avoids collisions`() {
+        val dot = manager.sanitizeFileName(".")
+        val dotDot = manager.sanitizeFileName("..")
+        val blank = manager.sanitizeFileName("   ")
+        assertTrue(dot.startsWith("profile-") && dot.endsWith(".json"))
+        assertTrue(dotDot.startsWith("profile-") && dotDot.endsWith(".json"))
+        assertTrue(blank.startsWith("profile-") && blank.endsWith(".json"))
+        assertNotEquals(dot, dotDot)
+        assertNotEquals(manager.sanitizeFileName("a?"), manager.sanitizeFileName("a!"))
     }
 
     @Test

--- a/docs/rebuild/DEVIATIONS_LEDGER_A.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER_A.md
@@ -879,3 +879,17 @@
   the v4+ artifact contract used here). The workflow comment now records the precise v6/v7 boundary
   so the policy describes the pin rather than merely asserting it.
   `[cited]`: `.github/workflows/fdroid-compat.yml` (Node runtime policy and all download steps).
+
+- DA-036 [cited]: the profile import review closed the validation boundaries around DA-029's
+  byte-stream cap. Native payloads now reject unknown fields, duplicate keys, future/invalid schema
+  versions, excessive nesting/container sizes, and overlong strings before recursive JSON parsing;
+  a rejected native-shaped payload cannot fall through to the tolerant legacy parser. Legacy
+  numeric conversion rejects non-finite/overflowing rounded values and bounds flat fields, while
+  folder enumeration and the saved-profile catalog have collection/name limits. Every store/save/get/
+  apply/import persistence boundary validates settings, and direct document import preserves secure
+  display/super-dimming choices until the user uses the existing named-profile preview. Private export
+  names trim dot aliases, bound stems, and add a hash when normalization could collide. The existing
+  256 KiB streamed cap, plus-one probe, strict UTF-8 decoder, false size-hint handling, zero-read
+  progress, nullable-stream failure, and value-free exception logs remain the outer transport guard.
+  `[cited]`: `ProfileImportExportManager.kt`, `ImportStructureGuard.kt`, `UserProfileStore.kt`, and
+  `SettingsViewModel.kt` (native/legacy boundary, structural/store bounds, validation and consent).

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -100,6 +100,11 @@ TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per `RUNBOOK.md`; deviations in
 
 ## Changelog
 
+- 2026-07-29 — DA-036 completed the profile import/export adversarial review: bounded JSON and
+  legacy structures/numbers/catalogs, strict native schemas and fields, collision-safe private
+  filenames, validation at every persistence/apply boundary, and secure toggles preserved on direct
+  import until the existing named-profile preview supplies informed consent.
+
 - 2026-07-29 — DA-035 corrected the F-Droid compatibility workflow’s last Node 20 action: all download-artifact steps move from v6 (still `node20`) to the explicit Node 24 v7 major, and the misleading policy comment now records that boundary. The DA-034 follow-up also corrected two review-copy defects without changing behavior.
 
 - 2026-07-29 — DA-034 completed the manifest/privacy audit: permission request, disclosure, denial and revocation flows; explicit cloud/transfer allowlists for every personal-data category; stronger DUMP/elevated copy; and debug-only throwable logging with local crash diagnostics excluded from migration. Background location remains declared but has no second-stage in-app grant flow, now documented honestly.


### PR DESCRIPTION
### Motivation

- Prevent untrusted SAF/ContentResolver providers or crafted files from driving unbounded reads, surprising decoding, or enabling elevated device behavior during import.
- Close the native-vs-legacy parsing gap so a malformed or future native JSON cannot slip through as a benign legacy import.
- Ensure every persistence/read/save/apply boundary validates and clamps settings so no persisted value can bypass range checks or create pathological schedules.
- Make app-private profile filenames safe and collision-resistant to avoid `.`/`..`/blank-name surprises and opaque collisions.

### Description

- Added a non-recursive `ImportStructureGuard` that rejects excessive JSON nesting (`MAX_DEPTH = 32`), oversized containers (`MAX_CONTAINER_ENTRIES = 256`), overlong strings, duplicate keys, and escaped field-name ambiguity before calling the JSON parser.
- Made native parsing strict by turning off tolerant unknown-key decoding for native payloads, checking `schemaVersion` ranges, migrating and validating `AabSettings`, and refusing to fallback to the legacy parser when the payload looks native.
- Hardened legacy parsing and stores by bounding legacy key-value lists, rejecting non-finite/overflowing numeric conversions, capping listed legacy files, enforcing `UserProfileStore` limits (`MAX_PROFILES = 128`, name-length limits), and validating settings on read/save/get/apply.
- Prevented direct document imports from silently enabling secure/elevated display fields by preserving the current device-elevated fields during `replaceAll` imports and normalized app-private export names to safe stems with a short deterministic hash suffix to avoid collisions.

### Testing

- `scripts/ladder.sh --guards-only` ran and passed the guards (note: origin/main advisory skipped when remote was unavailable). ✅
- Targeted unit tests `./gradlew :app:testDebugUnitTest --tests '*UserProfileStoreTest' --tests '*LegacyProfileParseTest' --no-daemon` passed locally. ✅
- Local build and static checks `./gradlew :app:assembleDebug :app:lintDebug` completed successfully. ✅
- Full Robolectric-backed import/test runs (`:app:testDebugUnitTest` and `scripts/ladder.sh`) were attempted but the environment failed to fetch some external test artifacts, causing network `SocketException` failures in the test runtime; those failures are environmental (artifact fetch) and not indicative of the code-level unit test assertions added here. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a045bbdd48321a8d1aa43477e6a58)