### PR TITLE
Harden geo-IP fallback privacy and failure boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,13 @@ request, and only as a last resort:
 
 - **IP-geolocation fallback (optional, off by default, HTTPS).** Circadian scaling needs an approximate location to compute local sunrise/sunset. Tideo tries, in order: a fixed latitude/longitude you pin → the device's
   last-known location → a fresh GPS/network fix. Only if *all* of those are unavailable does it fall
-  back to a single `GET https://ipwho.is/` (HTTPS) to estimate your city
-  from your public IP. **You can turn it off** under
+  back to a single `GET https://ipwho.is/` (HTTPS), disclosing your public IP to that third party so it
+  can estimate your city. **You can turn it off** under
   **Circadian → Date & location → "IP-based location fallback"**, and it is **off until you opt in**. When
-  it is off, Tideo never contacts ipwho.is. The same opt-in fallback also backs the Circadian **"Use
-  current location"** button when no on-device fix is available.
+  it is off, Tideo never contacts ipwho.is. Automatic acquisition is attempted at most once per day;
+  successful approximate coordinates are stored only in the app's on-device preferences so circadian
+  state survives a restart. The same opt-in fallback also backs the Circadian **"Use current location"**
+  button when no on-device fix is available; each user tap can make one additional request.
 
 Everything else runs entirely on-device.
 

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/AppModule.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/AppModule.kt
@@ -115,6 +115,8 @@ class AppModule(context: Context) {
             // instead of falling back to TimeContext defaults until re-acquired (Tasker %AAB_SunLat/…).
             loadCachedLocation = { experimentPrefs.readCachedSunLocation() },
             persistLocation = { lat, lon, day -> experimentPrefs.writeCachedSunLocation(lat, lon, day) },
+            loadGeoIpAttemptDay = { experimentPrefs.readGeoIpAttemptDay() },
+            persistGeoIpAttemptDay = { day -> experimentPrefs.writeGeoIpAttemptDay(day) },
         )
 
         val controller = BrightnessPipelineController(

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/CircadianWindowProvider.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/CircadianWindowProvider.kt
@@ -6,6 +6,7 @@ import com.tideo.autobrightness.domain.circadian.SolarCalculator
 import com.tideo.autobrightness.platform.context.LocationReader
 import com.tideo.autobrightness.platform.context.LocationResult
 import com.tideo.autobrightness.platform.context.LocationSnapshot
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
@@ -88,6 +89,8 @@ class CircadianWindowProvider(
     private val loadCachedLocation: suspend () -> CachedSunLocation? = { null },
     private val persistLocation: suspend (latitude: Double, longitude: Double, day: Long) -> Unit =
         { _, _, _ -> },
+    private val loadGeoIpAttemptDay: suspend () -> Long? = { null },
+    private val persistGeoIpAttemptDay: suspend (day: Long) -> Unit = {},
     private val clock: () -> Long = System::currentTimeMillis,
     // F73: offset at the TARGET instant, not "now" — covers DST and fixed dates in another season.
     private val tzOffsetForDate: (dateEpochSec: Long) -> Double = { dateEpochSec ->
@@ -106,6 +109,8 @@ class CircadianWindowProvider(
     // F83: the once-a-day acquired location (Android or geo-IP), keyed by the day it was acquired for.
     @Volatile private var resolvedLoc: LocationSnapshot? = null
     @Volatile private var resolvedDay: Long = Long.MIN_VALUE
+    @Volatile private var attemptedDay: Long = Long.MIN_VALUE
+    @Volatile private var acquisitionReady = false
     private val acquiring = AtomicBoolean(false)
 
     // D-110: fired when a location resolves AFTER construction (cache seed or a fresh acquire) so the
@@ -125,7 +130,7 @@ class CircadianWindowProvider(
         get() = _onWindowsRefreshed
         set(value) {
             _onWindowsRefreshed = value
-            if (resolvedLoc != null) value()
+            if (resolvedLoc != null || acquisitionReady) value()
         }
 
     /** D-110: the location backing the live circadian modifier + its freshness, for the UI staleness
@@ -138,6 +143,7 @@ class CircadianWindowProvider(
         // F39 override drives the windows; invalidate the cache (and force a re-acquire) when it changes.
         scope.launch {
             overrideFlow.collect {
+                if (it == override) return@collect
                 override = it
                 cacheKey = null
                 resolvedDay = Long.MIN_VALUE
@@ -148,15 +154,17 @@ class CircadianWindowProvider(
         // instead of falling back to TimeContext defaults. Don't clobber a fresher in-memory fix that
         // a concurrent acquire may already have set. current() still re-acquires when the day rolls.
         scope.launch {
-            val cached = runCatching { loadCachedLocation() }.getOrNull() ?: return@launch
-            if (resolvedLoc == null) {
-                resolvedLoc = LocationSnapshot(cached.latitude, cached.longitude)
+            val cached = cancellableOrNull { loadCachedLocation() }
+            val cachedSnapshot = cached?.let { LocationSnapshot(it.latitude, it.longitude) }
+            if (resolvedLoc == null && cachedSnapshot?.hasValidCoordinates() == true) {
+                resolvedLoc = cachedSnapshot
                 resolvedDay = cached.day
                 cacheKey = null
-                // D-110: recompute now that a (possibly day-old) cached location is available — the
-                // initial brightness may already have been set with the default windows in stable light.
-                onWindowsRefreshed()
             }
+            cancellableOrNull { loadGeoIpAttemptDay() }?.let { attemptedDay = it }
+            acquisitionReady = true
+            // Recompute from a cache, or re-enter current() now that the persisted attempt gate is known.
+            onWindowsRefreshed()
         }
     }
 
@@ -177,7 +185,7 @@ class CircadianWindowProvider(
             LocationSnapshot(ov.latitude!!, ov.longitude!!)
         } else {
             // F83: acquire (once a day, async) when we have no fix or the day rolled over.
-            if (resolvedLoc == null || resolvedDay != day) triggerAcquire(day)
+            if (acquisitionReady && (resolvedLoc == null || resolvedDay != day)) triggerAcquire(day, todayDay)
             // D-110: fall back to the last resolved location even when the day has rolled over and no
             // fresh fix is available (location + geo-IP off) — recompute TODAY's windows with the cached
             // coordinates instead of returning null → the default-window 0.85. status records the age so
@@ -200,19 +208,27 @@ class CircadianWindowProvider(
     }
 
     // F83: task90 act5–41 acquisition order, async — Android last-known → fresh fix → ipwho.is.
-    private fun triggerAcquire(day: Long) {
+    private fun triggerAcquire(locationDay: Long, attemptDay: Long) {
+        if (attemptedDay == attemptDay) return
         if (!acquiring.compareAndSet(false, true)) return
+        // DA-037: success or failure, bound automatic acquisition to once per real calendar day.
+        // The manual UI action remains separately user-triggered and can retry once per tap.
+        attemptedDay = attemptDay
         scope.launch {
             try {
+                // Persist before any network work. Failure still leaves the in-process bound intact.
+                cancellableOrNull { persistGeoIpAttemptDay(attemptDay) }
                 val snap = location.lastKnownLocation()
-                    ?: (runCatching { location.currentLocation() }.getOrNull() as? LocationResult.Available)?.snapshot
+                    ?: (cancellableOrNull { location.currentLocation() } as? LocationResult.Available)?.snapshot
                     ?: geoIpFallback()
-                if (snap != null) {
+                // DA-037: every acquisition source is untrusted at this boundary. An invalid endpoint
+                // response or corrupt system/cache value must not replace the last safe circadian state.
+                if (snap != null && snap.hasValidCoordinates()) {
                     resolvedLoc = snap
-                    resolvedDay = day
+                    resolvedDay = locationDay
                     cacheKey = null // recompute windows with the freshly acquired location
                     // D-103: persist so the next cold start reuses it before re-acquiring.
-                    runCatching { persistLocation(snap.latitude, snap.longitude, day) }
+                    cancellableOrNull { persistLocation(snap.latitude, snap.longitude, locationDay) }
                     // D-110: a fresh fix landed asynchronously — recompute so the modifier updates even
                     // if the light is steady (no sensor cycle would otherwise call current() again).
                     onWindowsRefreshed()
@@ -221,6 +237,19 @@ class CircadianWindowProvider(
                 acquiring.set(false)
             }
         }
+    }
+
+    private fun LocationSnapshot.hasValidCoordinates(): Boolean =
+        latitude.isFinite() && latitude in -90.0..90.0 &&
+            longitude.isFinite() && longitude in -180.0..180.0 &&
+            (latitude != 0.0 || longitude != 0.0)
+
+    private suspend fun <T> cancellableOrNull(block: suspend () -> T): T? = try {
+        block()
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (_: Exception) {
+        null
     }
 
     companion object {

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ExperimentPrefsStore.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/settings/ExperimentPrefsStore.kt
@@ -79,16 +79,26 @@ class ExperimentPrefsStore(private val dataStore: DataStore<Preferences>) {
         val lat = prefs[SUN_LAT]
         val lon = prefs[SUN_LON]
         val day = prefs[SUN_DAY]
-        if (lat != null && lon != null && day != null) CachedSunLocation(lat, lon, day) else null
+        if (lat != null && lon != null && day != null && validCoordinates(lat, lon)) {
+            CachedSunLocation(lat, lon, day)
+        } else null
     }
 
     /** Persist the daily-resolved location (D-103). */
     suspend fun writeCachedSunLocation(latitude: Double, longitude: Double, day: Long) {
+        if (!validCoordinates(latitude, longitude)) return
         dataStore.edit { prefs ->
             prefs[SUN_LAT] = latitude
             prefs[SUN_LON] = longitude
             prefs[SUN_DAY] = day
         }
+    }
+
+    /** DA-037: persisted disclosure bound, so process death cannot repeat an automatic lookup today. */
+    suspend fun readGeoIpAttemptDay(): Long? = dataStore.data.first()[GEO_IP_ATTEMPT_DAY]
+
+    suspend fun writeGeoIpAttemptDay(day: Long) {
+        dataStore.edit { it[GEO_IP_ATTEMPT_DAY] = day }
     }
 
     /** Revert to live data (today + current location) — mirrors `_ExperimentClearDate`. */
@@ -109,6 +119,12 @@ class ExperimentPrefsStore(private val dataStore: DataStore<Preferences>) {
         val SUN_LAT = doublePreferencesKey("sun_cached_lat")
         val SUN_LON = doublePreferencesKey("sun_cached_lon")
         val SUN_DAY = longPreferencesKey("sun_cached_day")
+        val GEO_IP_ATTEMPT_DAY = longPreferencesKey("geo_ip_attempt_day")
+
+        fun validCoordinates(latitude: Double, longitude: Double): Boolean =
+            latitude.isFinite() && latitude in -90.0..90.0 &&
+                longitude.isFinite() && longitude in -180.0..180.0 &&
+                (latitude != 0.0 || longitude != 0.0)
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -578,7 +578,7 @@
     <string name="help_scale_transition">Duration of the dawn/dusk transition.</string>
     <string name="help_taper_midpoint">Brightness level where compression centres.</string>
     <string name="help_taper_steepness">Slope of the dynamic-range compression.</string>
-    <string name="help_circadian_ip_fallback">Off by default. When GPS/network gives no fix and no fixed location is set, turn this on to look up an approximate location from your public IP via ipwho.is (HTTPS). This also powers \"Use current location\" below when no on-device fix is available.</string>
+    <string name="help_circadian_ip_fallback">Off by default. Only when GPS/network gives no fix and no fixed location is set, this sends your public IP to ipwho.is over HTTPS to look up approximate coordinates. The automatic lookup runs at most once per day and saves the coordinates on this device; \"Use current location\" can also make one lookup each time you tap it after on-device location fails.</string>
 
     <!-- Profiles import/export status (shown as a toast) -->
     <string name="toast_exported">Exported.</string>

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/CircadianWindowProviderTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/CircadianWindowProviderTest.kt
@@ -219,6 +219,80 @@ class CircadianWindowProviderTest {
         scope.cancel()
     }
 
+    @Test
+    fun invalidGeoIpFix_isNotPersistedOrApplied() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        var persisted = false
+        val provider = CircadianWindowProvider(
+            scope = scope,
+            overrideFlow = MutableStateFlow(ExperimentDateLocation()),
+            location = FakeLocationReader(),
+            geoIpFallback = { LocationSnapshot(91.0, 5.0) },
+            persistLocation = { _, _, _ -> persisted = true },
+            clock = { midJuneEpochSec() * 1000L },
+            tzOffsetForDate = { 2.0 },
+        )
+
+        assertNull(provider.current(transitionFactor), "invalid fallback must preserve fail-closed defaults")
+        assertFalse(persisted, "invalid coordinates must not corrupt the persisted circadian cache")
+        scope.cancel()
+    }
+
+    @Test
+    fun failedAutomaticAcquisition_isAttemptedOnlyOncePerDay() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        var requests = 0
+        val provider = CircadianWindowProvider(
+            scope = scope,
+            overrideFlow = MutableStateFlow(ExperimentDateLocation()),
+            location = FakeLocationReader(),
+            geoIpFallback = { requests++; null },
+            clock = { midJuneEpochSec() * 1000L },
+            tzOffsetForDate = { 2.0 },
+        )
+
+        repeat(10) { assertNull(provider.current(transitionFactor)) }
+        assertEquals(1, requests, "pipeline evaluations must not repeatedly disclose the public IP")
+        scope.cancel()
+    }
+
+    @Test
+    fun persistedAttemptDay_preventsRetryAfterProcessRestart() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val today = midJuneEpochSec() / 86_400L
+        var requests = 0
+        val provider = CircadianWindowProvider(
+            scope = scope,
+            overrideFlow = MutableStateFlow(ExperimentDateLocation()),
+            location = FakeLocationReader(),
+            geoIpFallback = { requests++; null },
+            loadGeoIpAttemptDay = { today },
+            clock = { midJuneEpochSec() * 1000L },
+            tzOffsetForDate = { 2.0 },
+        )
+
+        repeat(3) { assertNull(provider.current(transitionFactor)) }
+        assertEquals(0, requests, "persisted daily gate must survive process death")
+        scope.cancel()
+    }
+
+    @Test
+    fun corruptPersistedLocation_isRejected() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val provider = CircadianWindowProvider(
+            scope = scope,
+            overrideFlow = MutableStateFlow(ExperimentDateLocation()),
+            location = FakeLocationReader(),
+            geoIpFallback = { null },
+            loadCachedLocation = { CachedSunLocation(Double.NaN, 5.0, midJuneEpochSec() / 86_400L) },
+            clock = { midJuneEpochSec() * 1000L },
+            tzOffsetForDate = { 2.0 },
+        )
+
+        assertNull(provider.current(transitionFactor), "corrupt cache must not enter circadian state")
+        scope.cancel()
+    }
+
     // ----- D-103: persist/restore the once-a-day location across process restarts -----
 
     @Test

--- a/docs/rebuild/DEVIATIONS_LEDGER_A.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER_A.md
@@ -893,3 +893,19 @@
   progress, nullable-stream failure, and value-free exception logs remain the outer transport guard.
   `[cited]`: `ProfileImportExportManager.kt`, `ImportStructureGuard.kt`, `UserProfileStore.kt`, and
   `SettingsViewModel.kt` (native/legacy boundary, structural/store bounds, validation and consent).
+
+- DA-037 [cited]: the geo-IP security/privacy review retained the explicit default-off feature but
+  closed its untrusted-network and retry boundaries. `GeoIpLocationClient` now refuses redirects,
+  bounds declared and streamed bodies to 16 KiB, uses a structural JSON parser requiring literal
+  `success:true` plus finite in-range numeric coordinates, disconnects on coroutine cancellation, and
+  propagates cancellation. `CircadianWindowProvider` independently validates every acquired snapshot
+  before state/persistence and records an attempt for the day even on failure, preventing sensor cycles
+  from repeatedly spending battery or disclosing the public IP. Failures preserve the last safe cached
+  location/default windows. TLS deliberately trusts Android's platform CAs without pinning; the fixed
+  HTTPS endpoint, app-wide cleartext ban, disabled redirects, strict low-impact response contract, and
+  fail-closed semantics make pin-rotation availability risk unjustified. UI/store/README disclosures now
+  name the third party, public-IP disclosure, automatic daily bound, per-tap manual request, and local
+  coordinate persistence; no coordinate logging exists and backup rules exclude this DataStore.
+  `[cited]`: `GeoIpLocationClient.kt` and `CircadianWindowProvider.kt` (transport/parser/cancellation and
+  consumer/retry boundaries, including a persisted daily attempt marker); full caller, policy, persistence and trust assessment in
+  `architecture/geo_ip_audit.md`.

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -100,6 +100,12 @@ TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per `RUNBOOK.md`; deviations in
 
 ## Changelog
 
+- 2026-07-29 — DA-037 completed the geo-IP fallback review: retained explicit default-off consent and
+  local-first ordering; added redirect refusal, a 16 KiB response cap, structural JSON and strict
+  coordinate validation, cancellation propagation/disconnect, fail-closed consumer validation, and a
+  once-per-day failed-attempt bound; expanded UI/privacy copy for public-IP disclosure, manual-request
+  frequency and on-device coordinate persistence.
+
 - 2026-07-29 — DA-036 completed the profile import/export adversarial review: bounded JSON and
   legacy structures/numbers/catalogs, strict native schemas and fields, collision-safe private
   filenames, validation at every persistence/apply boundary, and secure toggles preserved on direct

--- a/docs/rebuild/architecture/geo_ip_audit.md
+++ b/docs/rebuild/architecture/geo_ip_audit.md
@@ -1,0 +1,45 @@
+# Geo-IP fallback security and privacy audit
+
+The sole network feature is an explicit, persisted opt-in whose default is `false`. Both callers
+check that gate. Runtime acquisition skips all location work for fixed coordinates, then tries
+Android last-known and current fixes before geo-IP. The user-triggered **Use current location** action
+tries an active Android fix first and can call geo-IP only after that fails.
+
+## Transport and endpoint trust
+
+- The fixed endpoint is `https://ipwho.is/`. App-wide cleartext is disabled. The client requires an
+  `HttpsURLConnection`, disables redirects, and accepts only HTTP 200, so neither downgrade nor
+  cross-host redirect can move the public-IP disclosure.
+- TLS uses Android's platform trust store and hostname verification. There is deliberately no
+  certificate pinning: pin expiry/rotation could disable a best-effort feature, while a compromised
+  public CA could observe or alter only approximate coordinates. Strict parsing/range checks and the
+  fail-closed consumer boundary prevent such a response from corrupting circadian state.
+- Connect and read timeouts remain 30 seconds each for Tasker parity. Cancellation disconnects the
+  blocking connection and is rethrown rather than converted to an ordinary network failure.
+
+## Input and state bounds
+
+- Responses are limited to 16 KiB, including chunked/unknown-length bodies; an oversized declared
+  content length is rejected before reading. JSON must be a real object with Boolean `success:true`
+  and numeric `latitude`/`longitude`. Coordinates must be finite and within latitude `[-90, 90]` and
+  longitude `[-180, 180]`; `(0,0)` remains rejected.
+- The runtime validates every acquired snapshot again before applying or persisting it. Network,
+  parse, cancellation-independent lookup failure, and invalid data publish nothing: existing cached
+  coordinates remain intact, or the pipeline continues with its documented default windows.
+
+## Frequency, disclosure, logging, and persistence
+
+Automatic acquisition is guarded and its attempted day is persisted whether it succeeds or fails; a
+successful coordinate is also stored in app-private DataStore for reuse after process death. This prevents
+sensor-driven pipeline evaluations from repeatedly spending battery or disclosing the public IP during
+an outage, and prevents process restarts from making more than one automatic attempt that day. The 30-second
+timeouts bound an attempt. The interactive action can make one additional
+request per tap after its 20-second active local fix attempt. No background polling loop exists.
+
+The request necessarily reveals the user's public IP to ipwho.is and the TLS/network providers; it
+sends no app identifier or stored coordinates. Neither failures nor coordinates are logged. Successful
+coordinates and their acquisition day are persisted app-private, excluded from backup/device transfer,
+and reused to avoid unnecessary requests. The UI help, README privacy section, and store description
+name ipwho.is, HTTPS, the opt-in/default-off gate, ordering, daily automatic behavior, interactive
+requests, and on-device coordinate persistence. With those additions the disclosure is adequate for
+retaining this optional feature.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -55,8 +55,10 @@ Tideo is local-first with no analytics, ads, or accounts. It makes one outbound
 network request, and only as a last resort: if you opt in and enable circadian
 scaling and no on-device location is available, it falls back to a single HTTPS
 request to ipwho.is to estimate your city from your public IP. This fallback is off
-by default and can be turned off under Circadian > Date & location. Everything else
-runs entirely on-device.
+by default and can be turned off under Circadian > Date & location. Automatic lookup
+runs at most once per day, and the resolved coordinates are saved only on-device;
+the user-triggered Use current location action can make an additional request after
+on-device location fails. Everything else runs entirely on-device.
 
 Tideo is a ground-up Kotlin/Compose rebuild of the Advanced Auto Brightness Tasker
 project, ported with exact behavioural parity. It is not affiliated with Tasker.

--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -36,6 +36,7 @@ android {
 dependencies {
     implementation(project(":domain"))
     implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.kotlinx.serialization.json)
     implementation(libs.shizuku.api)
 
     testImplementation(libs.kotlin.test)

--- a/platform/src/main/kotlin/com/tideo/autobrightness/platform/context/GeoIpLocationClient.kt
+++ b/platform/src/main/kotlin/com/tideo/autobrightness/platform/context/GeoIpLocationClient.kt
@@ -1,9 +1,20 @@
 package com.tideo.autobrightness.platform.context
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.job
 import kotlinx.coroutines.withContext
-import java.net.HttpURLConnection
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
 import java.net.URL
+import javax.net.ssl.HttpsURLConnection
+import kotlin.coroutines.coroutineContext
 
 /**
  * Geo-IP location fallback — the **final** step of task90's location-acquisition chain (act27–30:
@@ -21,44 +32,76 @@ import java.net.URL
  * without a real network.
  */
 class GeoIpLocationClient(
-    private val fetch: () -> String? = ::fetchGeoIp,
+    private val fetch: suspend () -> String? = ::fetchGeoIp,
 ) {
     /** Resolve an approximate location from the device's public IP, or null on failure. */
     suspend fun resolve(): LocationSnapshot? = withContext(Dispatchers.IO) {
-        runCatching { fetch() }.getOrNull()?.let { parse(it) }
+        try {
+            fetch()?.let { parse(it) }
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (_: Exception) {
+            null
+        }
     }
 
     companion object {
         private const val URL_GEO_IP = "https://ipwho.is/"
         private const val TIMEOUT_MS = 30_000 // task90 act28 timeout=30
-        private val LAT = Regex("\"latitude\"\\s*:\\s*(-?\\d+(?:\\.\\d+)?)")
-        private val LON = Regex("\"longitude\"\\s*:\\s*(-?\\d+(?:\\.\\d+)?)")
-        private val FAIL = Regex("\"success\"\\s*:\\s*false")
+        internal const val MAX_RESPONSE_BYTES = 16 * 1024
+        private val JSON = Json { ignoreUnknownKeys = true }
 
         /** Parse ipwho.is's `{"success":true,...,"latitude":52.09,"longitude":5.12,...}` body. */
         fun parse(json: String): LocationSnapshot? {
-            if (FAIL.containsMatchIn(json)) return null
-            val lat = LAT.find(json)?.groupValues?.get(1)?.toDoubleOrNull() ?: return null
-            val lon = LON.find(json)?.groupValues?.get(1)?.toDoubleOrNull() ?: return null
+            val body = runCatching { JSON.parseToJsonElement(json).jsonObject }.getOrNull() ?: return null
+            if (body["success"]?.jsonPrimitive?.booleanOrNull != true) return null
+            val latValue = body["latitude"]?.jsonPrimitive ?: return null
+            val lonValue = body["longitude"]?.jsonPrimitive ?: return null
+            if (latValue.isString || lonValue.isString) return null
+            val lat = latValue.doubleOrNull ?: return null
+            val lon = lonValue.doubleOrNull ?: return null
+            if (!lat.isFinite() || lat !in -90.0..90.0 || !lon.isFinite() || lon !in -180.0..180.0) return null
             // Reject "null island" (0,0) — same guard as the Android fix path.
             if (lat == 0.0 && lon == 0.0) return null
             return LocationSnapshot(lat, lon)
         }
 
-        private fun fetchGeoIp(): String? {
-            val conn = (URL(URL_GEO_IP).openConnection() as HttpURLConnection).apply {
+        private suspend fun fetchGeoIp(): String? {
+            val conn = (URL(URL_GEO_IP).openConnection() as HttpsURLConnection).apply {
                 connectTimeout = TIMEOUT_MS
                 readTimeout = TIMEOUT_MS
                 requestMethod = "GET"
+                instanceFollowRedirects = false // Never move the public-IP disclosure to another host.
+            }
+            // HttpURLConnection is blocking; disconnecting closes its socket when the owning scope is cancelled.
+            val cancellation = coroutineContext.job.invokeOnCompletion { cause ->
+                if (cause != null) conn.disconnect()
             }
             return try {
-                if (conn.responseCode != HttpURLConnection.HTTP_OK) null
-                else conn.inputStream.bufferedReader().use { it.readText() }
+                if (conn.responseCode != HttpsURLConnection.HTTP_OK) null
+                else conn.inputStream.use { readBounded(it, conn.contentLengthLong) }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
             } catch (_: Exception) {
                 null
             } finally {
+                cancellation.dispose()
                 conn.disconnect()
             }
+        }
+
+        internal suspend fun readBounded(input: InputStream, declaredBytes: Long = -1L): String? {
+            if (declaredBytes > MAX_RESPONSE_BYTES) return null
+            val output = ByteArrayOutputStream()
+            val buffer = ByteArray(4 * 1024)
+            while (true) {
+                coroutineContext.ensureActive()
+                val count = input.read(buffer)
+                if (count < 0) break
+                if (output.size() + count > MAX_RESPONSE_BYTES) return null
+                output.write(buffer, 0, count)
+            }
+            return output.toString(Charsets.UTF_8.name())
         }
     }
 }

--- a/platform/src/test/kotlin/com/tideo/autobrightness/platform/context/GeoIpLocationClientTest.kt
+++ b/platform/src/test/kotlin/com/tideo/autobrightness/platform/context/GeoIpLocationClientTest.kt
@@ -1,7 +1,9 @@
 package com.tideo.autobrightness.platform.context
 
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.CancellationException
 import org.junit.Test
+import java.io.ByteArrayInputStream
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
@@ -35,10 +37,36 @@ class GeoIpLocationClientTest {
     }
 
     @Test
+    fun requiresExplicitSuccessAndValidCoordinateRanges() {
+        assertNull(GeoIpLocationClient.parse("""{"latitude":52.0,"longitude":5.0}"""))
+        assertNull(GeoIpLocationClient.parse("""{"success":true,"latitude":91,"longitude":5}"""))
+        assertNull(GeoIpLocationClient.parse("""{"success":true,"latitude":52,"longitude":181}"""))
+        assertNull(GeoIpLocationClient.parse("""{"success":true,"latitude":"52","longitude":5}"""))
+    }
+
+    @Test
     fun resolveUsesInjectedFetch() = runTest {
         val ok = GeoIpLocationClient(fetch = { successBody }).resolve()
         assertEquals(LocationSnapshot(52.0907, 5.1214), ok)
 
         assertNull(GeoIpLocationClient(fetch = { null }).resolve()) // network failure
+    }
+
+    @Test(expected = CancellationException::class)
+    fun resolveDoesNotConvertCancellationToFailure() = runTest {
+        GeoIpLocationClient(fetch = { throw CancellationException("test cancellation") }).resolve()
+    }
+
+    @Test
+    fun boundedReadRejectsDeclaredAndStreamedOversizeBodies() = runTest {
+        val exact = ByteArray(GeoIpLocationClient.MAX_RESPONSE_BYTES) { 'x'.code.toByte() }
+        assertEquals(String(exact), GeoIpLocationClient.readBounded(ByteArrayInputStream(exact)))
+        assertNull(
+            GeoIpLocationClient.readBounded(
+                ByteArrayInputStream(byteArrayOf()),
+                GeoIpLocationClient.MAX_RESPONSE_BYTES + 1L,
+            ),
+        )
+        assertNull(GeoIpLocationClient.readBounded(ByteArrayInputStream(exact + byteArrayOf(0))))
     }
 }


### PR DESCRIPTION
### Motivation

- Close several privacy and safety gaps in the optional geo-IP fallback so a third-party request remains explicit opt-in, bounded, and fails closed. 
- Prevent malformed or malicious responses from corrupting circadian state and reduce unnecessary public-IP disclosure and battery use from retry loops. 
- Improve documentation and UI disclosure so the user is clearly informed about the third-party endpoint, public-IP exposure, frequency, and local persistence.

### Description

- Require HTTPS and tighten transport: `GeoIpLocationClient` now uses `HttpsURLConnection`, refuses redirects, only accepts HTTP 200, disconnects on coroutine cancellation, and preserves 30s connect/read timeouts.  
- Parse and validate responses structurally: replace regex extraction with `kotlinx.serialization` JSON parsing, require literal `success:true`, reject string-valued coords, enforce latitude `[-90,90]` and longitude `[-180,180]`, and reject `(0,0)`.  
- Bound response size and streaming reads: add a 16 KiB declared-and-streamed response cap with a safe `readBounded` reader and cancellation-aware disconnection.  
- Fail-closed consumer & persistence guards: `CircadianWindowProvider` validates every acquired `LocationSnapshot` before applying or persisting it, rejects invalid cached coordinates, and records an automatic-attempt day so automatic acquisitions disclose the public IP at most once per calendar day (per process), while preserving the explicit per-tap `Use current location` behavior.  
- DataStore and UI changes: `ExperimentPrefsStore` gained `geo_ip_attempt_day` read/write and `validCoordinates()` checks, the opt-in help string, README, and store description were expanded to disclose ipwho.is, public-IP exposure, daily automatic bound, per-tap manual requests, and on-device coordinate persistence.  
- Tests and docs: added/extended `GeoIpLocationClientTest` and `CircadianWindowProviderTest` cases for parsing, range checks, cancellation propagation, bounded reads, invalid-cache rejection, and persisted-attempt gating; added `docs/rebuild/architecture/geo_ip_audit.md`; updated deviation/state ledgers and committed build dependency `kotlinx.serialization.json` in `platform/build.gradle.kts`.

### Testing

- Ran targeted unit tests: `./gradlew :platform:testDebugUnitTest --tests '*GeoIpLocationClientTest' :app:testDebugUnitTest --tests '*CircadianWindowProviderTest'` and they passed.  
- Ran `scripts/ladder.sh --guards-only` and `git diff --check`, both passed; a full `scripts/ladder.sh` run attempted but unrelated Robolectric suites could not download Maven artifacts due to an environment `SocketException` (targeted changed-path tests still passed).  
- Per the glue-review protocol, a fresh-context review was performed and all findings (retry/validation/persistence/cancellation) were fixed and re-reviewed.  

Notes: on-device/emulator verification was not performed in this environment (no KVM/emulator available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a0cd3b854832180a6988b4d9f658c)