### PR TITLE
Harden display-write teardown and Extra Dim ordering to avoid recovery short-circuits (DA-038)

### DIFF
--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringService.kt
@@ -291,6 +291,10 @@ class AmbientMonitoringService : Service() {
      * a startForegroundService), so the notification only blips.
      */
     private fun stopNotRunning(startId: Int): Int {
+        // A fresh instance may be recovering after process death while the old process left MANUAL
+        // mode or Extra Dim behind. The graph did not start, but controller.stop() is deliberately
+        // recovery-safe and clears those persisted/unknown residues without starting a sensor.
+        controller.stop()
         ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
         stopSelf(startId)
         return START_NOT_STICKY

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineController.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineController.kt
@@ -157,10 +157,7 @@ class BrightnessPipelineController(
         consumerJob?.cancel(); consumerJob = null
         proximityTracker.stop()
         inCycle.set(false)
-        // Stop is also the crash/restart recovery boundary (DA-038): after all future frames are
-        // cancelled, best-effort clear a possibly pre-death Extra Dim residue and return ownership
-        // of SCREEN_BRIGHTNESS_MODE to the user. Both are idempotent and independent so one provider
-        // failure cannot suppress the other safety restoration.
+        // DA-038: independently clear pre-death Extra Dim residue and return brightness-mode ownership.
         runCatching { dimming.disengage() }
         runCatching { brightness.restoreMode() }
     }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineController.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineController.kt
@@ -157,6 +157,12 @@ class BrightnessPipelineController(
         consumerJob?.cancel(); consumerJob = null
         proximityTracker.stop()
         inCycle.set(false)
+        // Stop is also the crash/restart recovery boundary (DA-038): after all future frames are
+        // cancelled, best-effort clear a possibly pre-death Extra Dim residue and return ownership
+        // of SCREEN_BRIGHTNESS_MODE to the user. Both are idempotent and independent so one provider
+        // failure cannot suppress the other safety restoration.
+        runCatching { dimming.disengage() }
+        runCatching { brightness.restoreMode() }
     }
 
     // Lifecycle entry points — the service posts these; they run in consumer order.

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/PanicHandler.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/PanicHandler.kt
@@ -14,10 +14,13 @@ class PanicHandler(
 ) {
     /** task528 act6-8: force manual mode, write 255, restore mode, disable super dimming. */
     fun execute() {
-        brightness.forceManualMode()
-        brightness.write(PANIC_BRIGHTNESS) // task528 act6: Set Display Brightness 255
-        brightness.restoreMode()
-        dimming.disengage() // task528 act7/8: Disable Super Dimming
+        // Every operation is best-effort and independent (DA-038). A SettingsProvider/OEM failure
+        // in an earlier write must never prevent the later screen-safety operations, especially the
+        // Extra Dim OFF attempt. restoreMode also runs even when the brightness write fails.
+        runCatching { brightness.forceManualMode() }
+        runCatching { brightness.write(PANIC_BRIGHTNESS) } // task528 act6
+        runCatching { brightness.restoreMode() }
+        runCatching { dimming.disengage() } // task528 act7/8
     }
 
     companion object {

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/SuperDimmingCoordinator.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/runtime/SuperDimmingCoordinator.kt
@@ -163,17 +163,20 @@ class SuperDimmingCoordinator(
             return
         }
 
-        // task650 act10-14: write reduce_bright_colors_activated=1 once, then the level each cycle.
+        // Write the bounded level BEFORE activation. If the process dies between the two writes the
+        // feature remains off; the reverse order can briefly apply an OEM/default stale level and
+        // produce an extreme unintended dim. Do not advance the latch on a failed write: a revoked
+        // permission or SettingsProvider failure must be retried by the next cycle/cleanup rather
+        // than being mistaken for successfully engaged state (DA-038).
         // NOTE (G2-F9, device gate): these are the AOSP "Extra dim" secure keys
         // (reduce_bright_colors_activated / reduce_bright_colors_level). Some OEM skins ship a
         // renamed/relocated key (or require the accessibility feature pre-enabled); if engagement
         // logs "ON" here (debug 5) but the screen does not visibly dim on a given device, that is OEM
         // secure-key variance, not a logic bug — see SecureDimmingController + STATE.md D-048.
-        if (engaged != true) {
-            secureDimming.setActivated(true)
-            engaged = true
+        val levelWritten = secureDimming.setLevel(level).isSuccess
+        if (engaged != true && levelWritten) {
+            if (secureDimming.setActivated(true).isSuccess) engaged = true
         }
-        secureDimming.setLevel(level)
         val mode = if (pwmPath) "PWM" else "SD"
         emitDebug(settings) { "ON ($mode) level $level (target $targetBrightness < ${settings.dimmingThreshold})" }
     }
@@ -208,8 +211,10 @@ class SuperDimmingCoordinator(
      *  only a known-off latch skips the writes, so a fresh process clears any pre-death residual. */
     override fun disengage() {
         if (engaged == false) return
-        secureDimming.setLevel(0)
-        secureDimming.setActivated(false)
-        engaged = false
+        // Clear activation even when the level clear fails: OFF is the safety-critical write. Keep
+        // the latch unknown unless BOTH writes succeeded, so a later stop/cycle retries cleanup.
+        val levelCleared = secureDimming.setLevel(0).isSuccess
+        val deactivated = secureDimming.setActivated(false).isSuccess
+        if (levelCleared && deactivated) engaged = false
     }
 }

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineControllerTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/BrightnessPipelineControllerTest.kt
@@ -39,11 +39,12 @@ class BrightnessPipelineControllerTest {
     private class FakeBrightness : ScreenBrightnessController {
         val writes = mutableListOf<Int>()
         var current = 0
+        var modeRestores = 0
         private var lastWrite: Int? = null
         override fun read(): Int = current
         override fun write(level: Int) { current = level; lastWrite = level; writes += level }
         override fun forceManualMode() = Unit
-        override fun restoreMode() = Unit
+        override fun restoreMode() { modeRestores++ }
         override fun isSelfWrite(rawDeviceValue: Int): Boolean = rawDeviceValue == lastWrite
         override fun isOnScreenSelfWrite(): Boolean = current == lastWrite
         override fun clearSelfWriteMarker() { lastWrite = null }
@@ -75,6 +76,24 @@ class BrightnessPipelineControllerTest {
         trustUnreliableSensor = true,
         scalingEnabled = false,
     )
+
+    @Test
+    fun stop_clearsDimmingAndRestoresBrightnessMode_DA038() = runTest {
+        val brightness = FakeBrightness()
+        val dimming = FakeDimming()
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val controller = BrightnessPipelineController(
+            lightSensor = FakeSensor(), brightness = brightness, brightnessObserver = FakeObserver(),
+            settingsProvider = { settings }, scope = scope, dimming = dimming,
+        )
+
+        controller.start()
+        controller.stop()
+
+        assertEquals(1, dimming.disengaged)
+        assertEquals(1, brightness.modeRestores)
+        scope.cancel()
+    }
 
     // Unconfined dispatcher so the sensor/observer collectors subscribe eagerly and emissions are
     // delivered synchronously; animation delays still respect virtual time (advanceUntilIdle).

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/PanicHandlerTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/PanicHandlerTest.kt
@@ -1,0 +1,30 @@
+package com.tideo.autobrightness.app.runtime
+
+import com.tideo.autobrightness.app.settings.AabSettings
+import com.tideo.autobrightness.platform.brightness.ScreenBrightnessController
+import kotlin.test.assertEquals
+import org.junit.Test
+
+class PanicHandlerTest {
+    @Test
+    fun providerFailures_doNotShortCircuitLaterSafetyWrites_DA038() {
+        val calls = mutableListOf<String>()
+        val brightness = object : ScreenBrightnessController {
+            override fun read() = 0
+            override fun write(level: Int) { calls += "brightness:$level"; error("provider") }
+            override fun forceManualMode() { calls += "manual"; error("provider") }
+            override fun restoreMode() { calls += "restore"; error("provider") }
+            override fun isSelfWrite(rawDeviceValue: Int) = false
+            override fun isOnScreenSelfWrite() = false
+            override fun clearSelfWriteMarker() = Unit
+        }
+        val dimming = object : DimmingCoordinator {
+            override fun apply(targetBrightness: Int, settings: AabSettings, scaleDynamic: Double) = Unit
+            override fun disengage() { calls += "dimmingOff" }
+        }
+
+        PanicHandler(brightness, dimming).execute()
+
+        assertEquals(listOf("manual", "brightness:255", "restore", "dimmingOff"), calls)
+    }
+}

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/SuperDimmingCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/SuperDimmingCoordinatorTest.kt
@@ -13,13 +13,18 @@ class SuperDimmingCoordinatorTest {
     private class FakeSecureDimming : SecureDimmingController {
         var activated: Boolean? = null
         val levels = mutableListOf<Int>()
+        val writes = mutableListOf<String>()
+        var failLevel = false
+        var failActivation = false
         override fun setLevel(level: Int): Result<Unit> {
             levels += level
-            return Result.success(Unit)
+            writes += "level:$level"
+            return if (failLevel) Result.failure(SecurityException("revoked")) else Result.success(Unit)
         }
         override fun setActivated(on: Boolean): Result<Unit> {
             activated = on
-            return Result.success(Unit)
+            writes += "activated:$on"
+            return if (failActivation) Result.failure(SecurityException("revoked")) else Result.success(Unit)
         }
     }
 
@@ -61,6 +66,34 @@ class SuperDimmingCoordinatorTest {
         assertEquals(true, secure.activated, "reduce_bright_colors_activated should be set on")
         assertTrue(secure.levels.isNotEmpty(), "a dim level should be written")
         assertTrue(secure.levels.last() > 0, "below-threshold dimming should be a positive level")
+        assertTrue(secure.writes.first().startsWith("level:"), "safe ordering writes level before activation")
+    }
+
+    @Test
+    fun failedLevelWrite_doesNotActivateAndRetriesNextCycle_DA038() {
+        val secure = FakeSecureDimming().apply { failLevel = true }
+        val coordinator = SuperDimmingCoordinator(secure) { Tier.ELEVATED }
+
+        coordinator.apply(targetBrightness = 5, settings = dimmingOn)
+        assertEquals(null, secure.activated, "a missing level must never activate an unknown OEM level")
+
+        secure.failLevel = false
+        coordinator.apply(targetBrightness = 5, settings = dimmingOn)
+        assertEquals(true, secure.activated, "failed engagement must remain retryable")
+    }
+
+    @Test
+    fun failedDeactivate_keepsCleanupRetryable_DA038() {
+        val secure = FakeSecureDimming()
+        val coordinator = SuperDimmingCoordinator(secure) { Tier.ELEVATED }
+        coordinator.apply(targetBrightness = 5, settings = dimmingOn)
+        secure.failActivation = true
+
+        coordinator.disengage()
+        val firstOffAttempts = secure.writes.count { it == "activated:false" }
+        coordinator.disengage()
+
+        assertEquals(firstOffAttempts + 1, secure.writes.count { it == "activated:false" })
     }
 
     // G2R-F65 (REOPENED): PWM-sensitive mode also engages Extra Dim below the threshold (via the

--- a/docs/rebuild/DEVIATIONS_LEDGER_A.md
+++ b/docs/rebuild/DEVIATIONS_LEDGER_A.md
@@ -909,3 +909,16 @@
   `[cited]`: `GeoIpLocationClient.kt` and `CircadianWindowProvider.kt` (transport/parser/cancellation and
   consumer/retry boundaries, including a persisted daily attempt marker); full caller, policy, persistence and trust assessment in
   `architecture/geo_ip_audit.md`.
+
+- DA-038 [cited]: the end-to-end display-write safety audit made teardown and failure ordering
+  explicit. Normal controller stop now independently clears Extra Dim and restores the user's
+  persisted brightness mode after cancelling future frames; even a fresh null-intent/control-created
+  service runs that residue cleanup without starting sensors. Panic attempts manual mode, brightness
+  255, mode restoration and Extra Dim OFF independently, so a SettingsProvider/OEM exception cannot
+  short-circuit later recovery. Extra Dim now writes its bounded level before activation, never marks
+  a failed engage/disengage successful, attempts activation OFF even if level-zero fails, and retries
+  unknown cleanup after revocation/provider failures. The audit records every brightness/display
+  writer, OEM normalization, typed/bounded inputs, observer suppression, cancellation and sticky-
+  restart ordering, unavoidable hard-kill/revoked-grant limits, and the adversarial lifecycle matrix.
+  `[cited]`: `BrightnessPipelineController.kt`, `AmbientMonitoringService.kt`, `PanicHandler.kt`,
+  `SuperDimmingCoordinator.kt`, and `architecture/runtime_display_safety_audit.md`.

--- a/docs/rebuild/STATE.md
+++ b/docs/rebuild/STATE.md
@@ -31,7 +31,7 @@ required it. Train tip `claude/badge-workflow-verify-77m62f` (DA-025) → `…-8
 infrastructure) and is open as **PR #96 → `main`** — the owner is keeping it as the base for the
 next fix/feature. **Stacked on it: PR #99** (`claude/fold-prs-97-98-cdi4dp` → `…-870gh3`), which
 folds the two concept PRs #97/#98 in as DA-029 (bounded profile import) + DA-030 (sticky-restart
-gate); #97/#98 are superseded and close unmerged. So vc20 is **no longer a packaging-only release** —
+gate); #97/#98 are superseded and close unmerged. The pending vc20 is **not a packaging-only release** —
 it carries `app/` source and `changelogs/20.txt` says so; `domain/` and `platform/` are still
 byte-identical to 1.8.1. #99 is **merged** into the train branch and PR #96's title/body have been
 rewritten to the net `origin/main..HEAD` payload (DA-002 — the body becomes the squash commit), so
@@ -99,6 +99,11 @@ TODO/FIXME 0; `parity_gaps.md` 0 open. Changes per `RUNBOOK.md`; deviations in
   (D-144/D-149).
 
 ## Changelog
+
+- 2026-07-29 — DA-038 traced every sensor/display write and hardened screen-safety recovery: stop
+  restores persisted brightness mode and clears possible Extra Dim residue (including disabled sticky
+  recreation), panic failures cannot skip later recovery attempts, and Extra Dim uses level-before-on
+  ordering with failure-aware retryable latches. Added the adversarial lifecycle contract matrix.
 
 - 2026-07-29 — DA-037 completed the geo-IP fallback review: retained explicit default-off consent and
   local-first ordering; added redirect refusal, a 16 KiB response cap, structural JSON and strict

--- a/docs/rebuild/architecture/runtime_display_safety_audit.md
+++ b/docs/rebuild/architecture/runtime_display_safety_audit.md
@@ -1,0 +1,97 @@
+# Runtime display safety audit (DA-038)
+
+Scope: the complete ambient-sensor pipeline and every runtime path that writes brightness,
+Extra Dim, Night Light, color/accessibility display modes, screen persistence/timeout behavior,
+HDR refresh behavior, or force-dark state. Extreme unintended darkness or brightness is treated as
+a safety failure, not merely a cosmetic defect.
+
+## Sensor-to-write trace
+
+1. `AmbientMonitoringService.ensureRunning()` starts the graph composed by `AppModule`: context and
+   display-toggle collectors, panic detector, and `BrightnessPipelineController`.
+2. `LightSensorSource.samples()` enters `BrightnessPipelineController.onSensorSample()`. The cached
+   opt-in, sensor reliability, dead-band, throttle and atomic `inCycle` gate reject or claim it.
+   Accepted ticks enter the single consumer channel; ticks while a cycle/animation is active drop.
+3. `PipelineCycleRunner.runCycle()` reads validated effective settings, smooths lux, invokes the
+   domain `BrightnessEngine`, applies the PWM hardware floor, and either direct-writes or calls
+   `AnimationRunner.animate()`.
+4. `AnimationRunner` bounds the frame count to at least one; its inputs and engine target are integer
+   domain brightness. Every actual write reaches `AndroidScreenBrightnessController.write()`, which
+   clamps `0..255`, normalizes with `Math.round` to the OEM device maximum, and records the raw
+   successful self-write for observer-echo rejection. Reads clamp the OEM value before normalizing
+   back. No floating-point value crosses this adapter boundary.
+5. The un-floored target also enters `SuperDimmingCoordinator`. Domain dimming math may use doubles,
+   but the resulting integer is accepted only when positive and the platform adapter clamps it to
+   `0..1000`. DA-038 writes the bounded level before activation and advances its state latch only on
+   successful writes. Disengage attempts both level-zero and activation-off and remains retryable
+   after either failure.
+6. `BrightnessObserver` and `OverrideMonitor` reject current-value self echoes and post qualifying
+   external changes back to the same consumer. `PipelineCycleRunner.handleOverride()` settles,
+   rechecks gates/current brightness, clears Extra Dim and pauses. Animation's independent band and
+   consecutive-read check catches a manual write during a long transition.
+
+## Other system-write owners
+
+| State | Writer and trigger | Bounds / ordering / restoration |
+|---|---|---|
+| Brightness + mode | cycle/reapply/resume; `PanicHandler`; controller stop restores the saved system auto/manual mode | `0..255` then OEM normalization. Saved mode is synchronously persisted before MANUAL and survives process death. Panic best-effort attempts manual, 255, mode restore, and Extra Dim off independently. |
+| Extra Dim | `SuperDimmingCoordinator` on every accepted target, pause, hibernate, override, panic, stop | Adapter clamps `0..1000`; level-before-on, level-zero-before-off; unknown initial latch forces a residual clear after process recreation. Failed writes do not become false no-op state. |
+| Night Light / temperature | `DisplayTogglesCoordinator` profile changes and circadian ticker; panic reset | booleans are `0/1`; controller sanity-clamps temperature `1000..10000 K`. Coordinator diff-suppresses unchanged opinions and serializes tick/swap/stop/panic. Stop returns to baseline; panic unconditionally disables. A hard process kill cannot execute baseline restoration, so the next profile transition or panic is the recovery path. |
+| Color mode | display coordinator: daltonizer/grayscale and inversion | enum-only daltonizer values; value is written before enable to avoid a one-frame stale matrix. Panic disables both; normal stop restores baseline. |
+| Screen persistence / timeout | display coordinator: AOD and `STAY_ON_WHILE_PLUGGED_IN` | boolean / fixed all-charger mask, not caller-provided integers. Stop restores baseline; panic disables. The app does not write `SCREEN_OFF_TIMEOUT`. |
+| Refresh/HDR behavior | display coordinator force-SDR | Android 14 gate. Disable-list is populated before enforcement; enforcement is removed before clearing. The app does not write peak/min refresh-rate settings. |
+| Force dark | Tools UI and service reassert through `ForceDarkController` | fixed property name and literal boolean only; Shizuku then bounded root fallback. A mutex serializes rapid requests. Property is reboot-volatile; service startup reasserts the persisted opt-in. |
+
+All secure/global writers tier-check immediately before the write and return `Result`; revoked grants
+and provider exceptions therefore remain contained. A revoked permission necessarily prevents the
+app from restoring the protected setting until the grant returns; panic still attempts every
+unprotected and protected recovery independently rather than short-circuiting.
+
+## Lifecycle and concurrency findings
+
+* `emergencyStop()` cancels and **joins** the consumer before the panic 255, making 255 the final
+  brightness write even when panic interrupts animation. Ordinary stop cancels the consumer before
+  teardown; animation suspends between frames, so cancellation prevents subsequent frames.
+* Display-toggle stop cancels collection, then synchronously takes the same mutex used by tick/apply
+  before baseline restoration. Panic tears that coordinator down first, so `onDestroy()` cannot
+  resurrect an impairing baseline afterward.
+* A null-intent sticky restart posts the foreground notification but starts no sensor/writer until a
+  generation-checked DataStore read confirms opt-in. Read failure fails closed. Explicit commands
+  supersede the pending decision; destruction increments the generation and cancels it.
+* Brightness self-write detection compares against the latest raw device value rather than consuming
+  callback tokens; delayed observer callbacks therefore cannot consume a newer frame's suppression.
+* Settings validation is the floating-point boundary: non-finite imported numbers are rejected and
+  runtime brightness writes accept integers. Platform clamps remain defense in depth. Force-dark and
+  display toggles accept typed booleans/enums rather than arbitrary strings or numeric values.
+
+## Adversarial lifecycle contract tests
+
+The executable suite must retain these cases:
+
+1. **Stop during animation:** park in frame delay, stop, release virtual time, assert no later frame;
+   mode/baseline cleanup still runs.
+2. **Panic during animation:** park mid-frame, panic, assert consumer unwound and 255 is final; inject
+   failures into manual-mode/brightness restoration and assert Extra Dim OFF is still attempted.
+3. **Permission revocation:** revoke secure access between tier sample and write; assert a failed
+   level never enables Extra Dim, failed OFF remains retryable, and display writes return failures.
+4. **SettingsProvider exceptions:** make brightness/provider operations throw independently; assert
+   panic attempts all recovery effects. Make sticky settings read throw; assert zero runtime starts.
+5. **Null-intent sticky restart:** cover disabled, enabled, unreadable, destroy-before-read, and a
+   newer explicit command winning after the read's last suspension.
+6. **Rapid control broadcasts:** issue pause/resume/reapply/disable/panic without advancing the test
+   dispatcher; assert serialization or terminal teardown, no resurrection, and no post-panic frame.
+7. **Process recreation with engaged secure dimming:** construct a fresh coordinator with unknown
+   latch and an above-threshold target; assert `level=0` and `activated=false`, then assert the known-
+   off path suppresses later no-op writes.
+8. **Stale observer echoes / OEM range:** animate across a non-255 OEM maximum, deliver delayed
+   callbacks that reread the latest frame, and assert no false override; then write outside the band
+   twice and assert pause.
+9. **Display apply/stop/panic race:** hold the coordinator mutex in an apply, cancel/stop or panic,
+   then release it; assert baseline or panic defaults are final and no queued apply trails them.
+10. **Bounds and malformed numbers:** test brightness below/above `0..255`, secure level below/above
+    `0..1000`, temperature outside its sanity band, invalid imported NaN/infinity, and OEM maxima both
+    below and above 255.
+
+Items 2, 3, 4, 5, 7, 8 and 9 have direct regression coverage in the current unit/Robolectric suite;
+items 1, 6 and 10 are split across controller, service, adapter, settings-validation and coordinator
+tests because the production ownership is likewise split.

--- a/fastlane/metadata/android/en-US/changelogs/20.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20.txt
@@ -1,7 +1,5 @@
-Maintenance release.
+Maintenance and safety release.
 
-Updated the Android build toolchain (Android Gradle Plugin 8.13.2), which clears the last build warnings and keeps future Gradle versions supported. Verified against F-Droid's own build image so the reproducible build is preserved.
+Updated the Android build toolchain while preserving F-Droid reproducibility. Profile imports now reject oversized or unreadable files, and a system restart respects the service-off setting.
 
-Importing a profile now reads the file safely and says so when it is too large or unreadable. A service restarted by the system stays off if you switched it off.
-
-Brightness curves, profiles and context rules are unchanged.
+Stopping restores Android's brightness mode and clears leftover Extra Dim state. Emergency Reset continues its recovery steps if one system setting fails, and Extra Dim activation no longer risks applying a stale level.


### PR DESCRIPTION
### Motivation
- Harden runtime display safety so provider/permission failures cannot short-circuit later recovery writes and to remove residual Extra Dim / mode state left by a crashed process.
- Make normal stop, panic, and process-restart cleanup idempotent and retryable so a failed write never falsely advances an engaged latch.
- Capture the audit findings (DA-038) and document the sensor→write trace and lifecycle contract for future regression testing.

### Description
- Ensure a fresh null-intent service instance runs cleanup by calling `controller.stop()` from `AmbientMonitoringService.stopNotRunning()` so persisted Extra Dim / manual-mode residue is cleared without starting sensors.
- Make `BrightnessPipelineController.stop()` best-effort and independent by wrapping `dimming.disengage()` and `brightness.restoreMode()` in `runCatching { ... }` so one failure cannot prevent the other safety restores.
- Convert `PanicHandler.execute()` to run every step in isolation using `runCatching { ... }` so manual mode, brightness 255, mode restoration, and Extra Dim OFF are attempted regardless of earlier exceptions.
- Change `SuperDimmingCoordinator` engagement ordering to write the bounded level before activation and only advance the `engaged` latch on successful writes; `disengage()` now treats OFF as safety-critical and only clears the known-on latch if both level-zero and deactivation succeed, keeping cleanup retryable on failure.
- Add/modify unit tests that validate the new failure-tolerant semantics and ordering: `PanicHandlerTest`, `BrightnessPipelineControllerTest.stop_clearsDimmingAndRestoresBrightnessMode_DA038`, and new/updated `SuperDimmingCoordinatorTest` cases asserting level-before-activation ordering and retryable cleanup.
- Add documentation and release notes: `runtime_display_safety_audit.md`, update `DEVIATIONS_LEDGER_A.md`, `STATE.md`, and the changelog entry for this safety audit (DA-038).

### Testing
- Ran JVM unit tests including `PanicHandlerTest`, the updated `BrightnessPipelineControllerTest`, and extended `SuperDimmingCoordinatorTest` scenarios; the new and modified tests executed and passed.
- Executed the unit test suite via `./gradlew test` to validate stop/panic/disengage ordering and failure-isolation behavior, with no regressions detected.
- Added audit documentation and mapped the new tests to the adversarial lifecycle contract so these cases remain covered by CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a3112c5748321983863e5353758d8)