### PR TITLE
Fix v1.9.0 device-test regressions

### DIFF
--- a/app/src/main/kotlin/com/tideo/autobrightness/app/control/ControlReceiver.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/control/ControlReceiver.kt
@@ -72,8 +72,7 @@ class ControlReceiver : BroadcastReceiver() {
      * so cap it and drop control/bidi characters — an 8 KB or RTL-override "name" is not a label.
      */
     private fun String.forFlash(): String =
-        take(FLASH_ARG_MAX).map { if (it.isISOControl() || it in BIDI_CONTROLS) '�' else it }
-            .joinToString("")
+        filterNot { it.isISOControl() || it in BIDI_CONTROLS }.take(FLASH_ARG_MAX)
 
     internal suspend fun route(appContext: Context, action: String, profileName: String? = null) {
         when (action) {

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/state/DisplayTogglesViewModel.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/state/DisplayTogglesViewModel.kt
@@ -139,16 +139,18 @@ class DisplayTogglesViewModel @JvmOverloads constructor(
                         add(display.setHdrForceSdr(settings.hdrForceSdrEnabled))
                     }
                 }
-                if (display.hdrForceSdrAvailable && hdrState == null) {
-                    _deviceSnapshot.value = _deviceSnapshot.value?.copy(hdrForceSdr = null)
-                }
+                // DB-047: publish the post-write device truth; retaining the pre-Apply snapshot
+                // makes the draft merge immediately undo the visible toggle.
+                val snapshot = readSnapshotLocked()
                 _state.update {
                     it.copy(
-                        hdrAvailable = display.hdrForceSdrAvailable && hdrState != null,
-                        hdrPreferenceCustom = display.hdrForceSdrAvailable && hdrState == null,
+                        hdrAvailable = display.hdrForceSdrAvailable && snapshot?.hdrForceSdr != null,
+                        hdrPreferenceCustom = display.hdrForceSdrAvailable &&
+                            snapshot != null && snapshot.hdrForceSdr == null,
                         writeFailed = results.any { r -> r.isFailure },
                     )
                 }
+                _deviceSnapshot.value = snapshot
             }
         }
     }

--- a/app/src/main/kotlin/com/tideo/autobrightness/app/state/DisplayTogglesViewModel.kt
+++ b/app/src/main/kotlin/com/tideo/autobrightness/app/state/DisplayTogglesViewModel.kt
@@ -16,6 +16,7 @@ import com.tideo.autobrightness.platform.privilege.ShizukuGrantGateway
 import com.tideo.autobrightness.platform.privilege.Tier
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -67,8 +68,11 @@ class DisplayTogglesViewModel @JvmOverloads constructor(
     val deviceSnapshot: StateFlow<DeviceDisplaySnapshot?> = _deviceSnapshot.asStateFlow()
 
 
-    // Serializes device access: [io] is a thread POOL; prevent refresh/applyNow interleave (D-143).
+    // DB-047: invocation-ordered device access with atomic stale-publication suppression.
     private val deviceLock = Mutex()
+    private val deviceScheduleLock = Any()
+    private var deviceRequestGeneration = 0L
+    private var deviceOperationTail: Job? = null
 
     init {
         // Live tier: in-app Shizuku/root grant flips screen from grant card to toggles without leaving.
@@ -82,21 +86,24 @@ class DisplayTogglesViewModel @JvmOverloads constructor(
     fun refresh() {
         privilegeManager.refresh()
         _state.update { it.copy(shizukuAvailability = privilegeManager.shizukuAvailability()) }
-        viewModelScope.launch(io) {
+        scheduleDeviceOperation { generation ->
             deviceLock.withLock {
                 val snapshot = readSnapshotLocked()
-                _state.update {
-                    it.copy(
-                        nightLightAutoMode = display.readNightLightAutoMode(),
-                        nightLightAvailable = display.nightLightAvailable,
-                        alwaysOnDisplayAvailable = display.alwaysOnDisplayAvailable,
-                        hdrAvailable = display.hdrForceSdrAvailable && snapshot?.hdrForceSdr != null,
-                        hdrPreferenceCustom = display.hdrForceSdrAvailable &&
-                            snapshot != null && snapshot.hdrForceSdr == null,
-                        writeFailed = false,
-                    )
+                val nightLightAutoMode = display.readNightLightAutoMode()
+                publishIfCurrent(generation) {
+                    _state.update {
+                        it.copy(
+                            nightLightAutoMode = nightLightAutoMode,
+                            nightLightAvailable = display.nightLightAvailable,
+                            alwaysOnDisplayAvailable = display.alwaysOnDisplayAvailable,
+                            hdrAvailable = display.hdrForceSdrAvailable && snapshot?.hdrForceSdr != null,
+                            hdrPreferenceCustom = display.hdrForceSdrAvailable &&
+                                snapshot != null && snapshot.hdrForceSdr == null,
+                            writeFailed = false,
+                        )
+                    }
+                    _deviceSnapshot.value = snapshot
                 }
-                _deviceSnapshot.value = snapshot
             }
         }
     }
@@ -120,7 +127,7 @@ class DisplayTogglesViewModel @JvmOverloads constructor(
      * All fields idempotent; null temperature and unavailable HDR stay untouched.
      */
     fun applyNow(settings: AabSettings) {
-        viewModelScope.launch(io) {
+        scheduleDeviceOperation(invalidateSnapshot = true) { generation ->
             deviceLock.withLock {
                 val hdrState = if (display.hdrForceSdrAvailable) display.readHdrForceSdr() else null
                 val results = buildList {
@@ -142,16 +149,39 @@ class DisplayTogglesViewModel @JvmOverloads constructor(
                 // DB-047: publish the post-write device truth; retaining the pre-Apply snapshot
                 // makes the draft merge immediately undo the visible toggle.
                 val snapshot = readSnapshotLocked()
-                _state.update {
-                    it.copy(
-                        hdrAvailable = display.hdrForceSdrAvailable && snapshot?.hdrForceSdr != null,
-                        hdrPreferenceCustom = display.hdrForceSdrAvailable &&
-                            snapshot != null && snapshot.hdrForceSdr == null,
-                        writeFailed = results.any { r -> r.isFailure },
-                    )
+                publishIfCurrent(generation) {
+                    _state.update {
+                        it.copy(
+                            hdrAvailable = display.hdrForceSdrAvailable && snapshot?.hdrForceSdr != null,
+                            hdrPreferenceCustom = display.hdrForceSdrAvailable &&
+                                snapshot != null && snapshot.hdrForceSdr == null,
+                            writeFailed = results.any { r -> r.isFailure },
+                        )
+                    }
+                    _deviceSnapshot.value = snapshot
                 }
-                _deviceSnapshot.value = snapshot
             }
+        }
+    }
+
+    private fun scheduleDeviceOperation(
+        invalidateSnapshot: Boolean = false,
+        operation: suspend (Long) -> Unit,
+    ) {
+        synchronized(deviceScheduleLock) {
+            val generation = ++deviceRequestGeneration
+            if (invalidateSnapshot) _deviceSnapshot.value = null
+            val predecessor = deviceOperationTail
+            deviceOperationTail = viewModelScope.launch(io) {
+                predecessor?.join()
+                operation(generation)
+            }
+        }
+    }
+
+    private fun publishIfCurrent(generation: Long, publication: () -> Unit) {
+        synchronized(deviceScheduleLock) {
+            if (generation == deviceRequestGeneration) publication()
         }
     }
 

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/control/ControlReceiverTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/control/ControlReceiverTest.kt
@@ -153,13 +153,15 @@ class ControlReceiverTest {
     fun loadProfile_unknownName_isClampedAndStrippedBeforeDisplay() {
         // The caller picks this text and AabFlash may render it in the system-wide overlay.
         seed(AabSettings(debugLevel = DebugCategory.CONTEXT_AUTOMATION.level))
-        val hostile = "‮Enter your PIN‬" + "A".repeat(8_000)
+        val hostile = "‮Enter\n\u0000your PIN‬" + "A".repeat(8_000)
         val flashes = captureFlashes {
             runBlocking { receiver.route(application, ControlReceiver.ACTION_LOAD_PROFILE, hostile) }
         }
         val flash = flashes.single()
         assertTrue(flash.length < 200, "an 8 KB name must not reach the overlay verbatim")
         assertFalse(flash.contains('‮'), "bidi overrides must be stripped")
+        assertFalse(flash.contains('\n') || flash.contains('\u0000'), "ISO controls must be stripped")
+        assertFalse(flash.contains('�'), "stripped controls must not become replacement glyphs")
     }
 
     @Test

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringServiceTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/runtime/AmbientMonitoringServiceTest.kt
@@ -227,8 +227,7 @@ class AmbientMonitoringServiceTest {
         assertTrue(shadowOf(service).isStoppedBySelf, "REAPPLY on a not-running service must not start the pipeline (D-140)")
     }
 
-    // DB-037: panic confirms itself however it was triggered — the gesture already vibrated, the
-    // control intent and the notification's Reset button did not. D-155: PANIC is also exempt from
+    // DB-037: panic confirms itself however it was triggered. D-155: PANIC is also exempt from
     // the D-140 not-running gate that stops PAUSE/REAPPLY/RESUME_CONTEXT, so it runs here.
     @Test
     fun panicByIntent_vibratesSosOnce_andIsNotRefusedByTheNotRunningGate() {

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/state/DisplayTogglesViewModelTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/state/DisplayTogglesViewModelTest.kt
@@ -7,10 +7,13 @@ import androidx.test.core.app.ApplicationProvider
 import com.tideo.autobrightness.app.settings.AabSettings
 import com.tideo.autobrightness.platform.display.NightLightAutoMode
 import com.tideo.autobrightness.platform.display.AndroidSecureDisplayController
+import com.tideo.autobrightness.platform.display.SecureDisplayController
 import com.tideo.autobrightness.platform.privilege.AndroidPrivilegeManager
 import com.tideo.autobrightness.platform.privilege.Tier
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
@@ -54,6 +57,7 @@ class DisplayTogglesViewModelTest {
     private fun vm(
         nightLightAvailable: Boolean = true,
         alwaysOnDisplayAvailable: Boolean = true,
+        io: CoroutineDispatcher = dispatcher,
     ): DisplayTogglesViewModel {
         val privileges = AndroidPrivilegeManager(app)
         return DisplayTogglesViewModel(
@@ -64,7 +68,7 @@ class DisplayTogglesViewModelTest {
                 nightLightAvailable = nightLightAvailable,
                 alwaysOnDisplayAvailable = alwaysOnDisplayAvailable,
             ),
-            io = dispatcher,
+            io = io,
         )
     }
 
@@ -111,6 +115,71 @@ class DisplayTogglesViewModelTest {
         assertEquals(true, assertNotNull(vm.deviceSnapshot.value).nightLight)
         // null temperature = "device default": the key must stay unset.
         assertEquals(-999, Settings.Secure.getInt(resolver, "night_display_color_temperature", -999))
+    }
+
+    @Test
+    fun applyNow_invalidatesTheOldSnapshotBeforeItsAsyncWriteCanRun() {
+        grantElevated()
+        val controlledIo = StandardTestDispatcher(dispatcher.scheduler)
+        val vm = vm(io = controlledIo)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(false, assertNotNull(vm.deviceSnapshot.value).nightLight)
+
+        vm.applyNow(AabSettings(nightLightEnabled = true))
+
+        assertNull(vm.deviceSnapshot.value, "the old OFF snapshot must be invalid before Apply advances the draft epoch")
+        assertEquals(
+            -999,
+            Settings.Secure.getInt(app.contentResolver, "night_display_activated", -999),
+            "the controlled dispatcher must keep the device write pending",
+        )
+
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(true, assertNotNull(vm.deviceSnapshot.value).nightLight)
+    }
+
+    @Test
+    fun applyNow_suppressesAnOlderRefreshCompletionBeforeThePendingWrite() {
+        grantElevated()
+        val controlledIo = StandardTestDispatcher(dispatcher.scheduler)
+        val privileges = AndroidPrivilegeManager(app)
+        val realDisplay = AndroidSecureDisplayController(
+            app,
+            privileges,
+            nightLightAvailable = true,
+            alwaysOnDisplayAvailable = true,
+        )
+        var onAutoModeRead: (() -> Unit)? = null
+        var beforeNightLightWrite: (() -> Unit)? = null
+        val display = object : SecureDisplayController by realDisplay {
+            override fun readNightLightAutoMode(): NightLightAutoMode = realDisplay.readNightLightAutoMode().also {
+                onAutoModeRead?.invoke()
+            }
+
+            override fun setNightLight(on: Boolean): Result<Unit> {
+                beforeNightLightWrite?.invoke()
+                return realDisplay.setNightLight(on)
+            }
+        }
+        val vm = DisplayTogglesViewModel(app, privileges, display, controlledIo)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(false, assertNotNull(vm.deviceSnapshot.value).nightLight)
+
+        onAutoModeRead = {
+            onAutoModeRead = null
+            vm.applyNow(AabSettings(nightLightEnabled = true))
+        }
+        beforeNightLightWrite = {
+            assertNull(
+                vm.deviceSnapshot.value,
+                "the superseded refresh must not republish OFF after Apply invalidates it",
+            )
+        }
+
+        vm.refresh()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(true, assertNotNull(vm.deviceSnapshot.value).nightLight)
     }
 
     @Test

--- a/app/src/test/kotlin/com/tideo/autobrightness/app/state/DisplayTogglesViewModelTest.kt
+++ b/app/src/test/kotlin/com/tideo/autobrightness/app/state/DisplayTogglesViewModelTest.kt
@@ -108,6 +108,7 @@ class DisplayTogglesViewModelTest {
         assertEquals(0, Settings.Secure.getInt(resolver, "accessibility_display_daltonizer", -999))
         assertEquals(1, Settings.Secure.getInt(resolver, "accessibility_display_inversion_enabled", -999))
         assertEquals(1, Settings.Secure.getInt(resolver, "doze_always_on", -999))
+        assertEquals(true, assertNotNull(vm.deviceSnapshot.value).nightLight)
         // null temperature = "device default": the key must stay unset.
         assertEquals(-999, Settings.Secure.getInt(resolver, "night_display_color_temperature", -999))
     }

--- a/docs/LEDGER_B.md
+++ b/docs/LEDGER_B.md
@@ -630,3 +630,11 @@
   as unrepresentable null. It passed only when another test leaked canonical OFF into shared
   Robolectric Settings and failed in CI's order. The test now seeds flag `1` plus a blank list before
   asserting OFF; production semantics stay unchanged.
+
+- DB-047 [cited]: **After a direct write, stale read-back is an active rollback of visible state.**
+  Night Light wrote ON, then Compose immediately showed OFF: `applyNow` retained its pre-write
+  snapshot, and Apply reopened the merge gate so stale OFF replaced the committed ON draft. Direct
+  Apply now reads and publishes device truth while still holding the lock. The same device pass
+  showed that overlay bounding worked but stripping did not: `forFlash` substituted U+FFFD and
+  truncated before sanitizing. It now removes controls/bidi before the 40-character bound.
+  `[cited]`: `DisplayTogglesViewModel.applyNow`, `ControlReceiver.forFlash`.

--- a/docs/LEDGER_B.md
+++ b/docs/LEDGER_B.md
@@ -634,7 +634,8 @@
 - DB-047 [cited]: **After a direct write, stale read-back is an active rollback of visible state.**
   Night Light wrote ON, then Compose immediately showed OFF: `applyNow` retained its pre-write
   snapshot, and Apply reopened the merge gate so stale OFF replaced the committed ON draft. Direct
-  Apply now reads and publishes device truth while still holding the lock. The same device pass
+  Apply now invalidates synchronously before its coroutine can yield; ordered operations plus
+  request generations stop older completions republishing stale truth. The same device pass
   showed that overlay bounding worked but stripping did not: `forFlash` substituted U+FFFD and
   truncated before sanitizing. It now removes controls/bidi before the 40-character bound.
   `[cited]`: `DisplayTogglesViewModel.applyNow`, `ControlReceiver.forFlash`.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -99,11 +99,15 @@ branch protection and secret-scanning settings in DA-006/DA-041.
 Newest first; ledger rows are the durable detail.
 
 - 2026-08-15 — **Device-report fixes (DB-047).** Direct Privileged Display Apply now publishes a
-  post-write snapshot instead of letting stale pre-write read-back visually undo the toggle; control
-  diagnostics remove control/bidi characters before their 40-character bound; the round script uses
-  the debug application/component and `name` extra. Panic call-site audit found no gesture-local
-  vibration in the surviving tree, so the unexplained device-only double remains queued rather than
-  receiving a speculative change.
+  post-write snapshot instead of letting stale pre-write read-back visually undo the toggle. Review
+  found that async startup still left the old snapshot mergeable while the draft advanced its Apply
+  epoch, and that an older refresh could republish OFF after invalidation. `applyNow` now invalidates
+  synchronously and request generations suppress superseded publications; controlled-dispatcher
+  tests hold the write pending and inject Apply during an older refresh read. Control diagnostics
+  remove control/bidi characters before their 40-character bound; the round script uses the debug
+  application/component and `name`
+  extra. Panic call-site audit found no gesture-local vibration in the surviving tree, so the
+  unexplained device-only double remains queued rather than receiving a speculative change.
 - 2026-08-15 — **Privileged Display capability safety + reviews (DB-041…DB-046).** Night Light and AOD now fail
   closed on their AOSP framework capability resources at the platform-controller boundary, so
   profile swaps, circadian ticks, direct Apply and panic cannot bypass the gate; unavailable UI is

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -63,11 +63,18 @@ ledger: `LEDGER_B.md`.
 
 > Protected by D-167. Test observable claims before restating them; preserve unresolved items.
 
-1. Device-verify the Tasker-parity train: **§11.39a** (Privileged Display read-back, DB-034),
-   **§13.44a** (control drop reasons, DB-035), and **§5.14a** (panic vibration, DB-037). No
-   emulator/KVM is available locally.
-2. Device-verify supported Night Light/AOD behavior and the unavailable-feature hiding/no-write
-   safety boundary from DB-041…DB-043 and experimental Disable HDR behavior (DB-044/DB-045), including reboot/brief-blank caveats. No emulator/KVM locally.
+1. Device-retest **§11.39a** and **§13.44a** after DB-047. The first pass reproduced stale
+   post-Apply/external read-back and replacement-glyph sanitization; both now have regression tests.
+2. Investigate/retest **§5.14a step 12**: the owner observed two S.O.S. vibrations from a gesture.
+   Repository-wide Kotlin call-site coverage (`rg -n -i 'vibrat|sos|morse' app platform`) finds only
+   the shared `panicAndStop` call, and its per-service `panicInFlight` gate tests one buzz for repeat
+   admission. No second call was removed without an evidenced source.
+3. Device-verify the unavailable-feature hiding/no-write boundary from DB-041…DB-043 on hardware
+   that reports Night Light/AOD unavailable. OnePlus 13 reports Night Light available, so the first
+   pass could not exercise it.
+4. Complete experimental Disable HDR verification (DB-044/DB-045): record secure-setting read-back
+   and preservation after an unrelated Apply. The first pass saw no flicker/blanking and displayed
+   the custom/malformed preservation notice, but did not record those two state checks.
 
 Open questions and owed reviews: none.
 
@@ -91,6 +98,12 @@ branch protection and secret-scanning settings in DA-006/DA-041.
 
 Newest first; ledger rows are the durable detail.
 
+- 2026-08-15 — **Device-report fixes (DB-047).** Direct Privileged Display Apply now publishes a
+  post-write snapshot instead of letting stale pre-write read-back visually undo the toggle; control
+  diagnostics remove control/bidi characters before their 40-character bound; the round script uses
+  the debug application/component and `name` extra. Panic call-site audit found no gesture-local
+  vibration in the surviving tree, so the unexplained device-only double remains queued rather than
+  receiving a speculative change.
 - 2026-08-15 — **Privileged Display capability safety + reviews (DB-041…DB-046).** Night Light and AOD now fail
   closed on their AOSP framework capability resources at the platform-controller boundary, so
   profile swaps, circadian ticks, direct Apply and panic cannot bypass the gate; unavailable UI is

--- a/docs/rebuild/DEVICE_TEST_SCRIPT_1.9.0.md
+++ b/docs/rebuild/DEVICE_TEST_SCRIPT_1.9.0.md
@@ -1,0 +1,75 @@
+# DEVICE_TEST_SCRIPT_1.9.0 — round script for the v1.9.0 train (DB-034…DB-046)
+
+**Ephemeral (D-155/DB-010).** Covers only what THIS unreleased train changed — not the full app.
+Numbered to match the corresponding step in the standing `DEVICE_TEST_SCRIPT.md` so results fold
+back cleanly (append/extend, never renumber) and this file is **deleted** once v1.9.0 ships. Build
++ install the debug APK (`applicationIdSuffix=".debug"`, coexists with a release install per
+D-106 — run only one variant's service at a time, D-128).
+
+Legend: **[ELEVATED]** needs WRITE_SECURE_SETTINGS.
+
+## §11.32 — Night Light / AOD hide + fail closed when unsupported (DB-041…DB-043)
+
+On a device (or OEM build) where the framework reports the feature unavailable:
+
+1. Open **Menu → Privileged → Privileged Display**. **Expected:** the **Night Light** row is
+   hidden entirely if `config_nightDisplayAvailable` is false; the **Always-on display** row is
+   hidden if `config_nightDisplayAvailable` is false OR `config_dozeComponent` is empty (AOD
+   requires both — DB-043's conjunction, not just the headline flag).
+2. With a profile/context rule that *would* carry Night Light or AOD, trigger a profile swap,
+   a circadian tick, direct Apply, and panic in turn. **Expected:** every path is a harmless
+   no-op on the unsupported field — no write, no crash, no stale UI claiming an unsupported
+   value is set.
+3. On a device where the feature IS supported, confirm the row is shown and still behaves as
+   before (see §11.32 in the standing script for the full write+read-back check) — this train
+   must not regress the supported case while fixing the unsupported one.
+
+## §11.32 — Disable HDR (experimental, Android 14+) (DB-044/DB-045)
+
+4. **Menu → Privileged → Privileged Display → Disable HDR (experimental)** on. **Expected:**
+   read back `user_disabled_hdr_formats=1,2,3,4` and
+   `are_user_disabled_hdr_formats_allowed=0`. Off: `allowed` returns `1`, formats clears.
+   **Expected:** this is a stored-preference write, not Force-SDR — either direction may require
+   a reboot, and an HDR/display-mode transition may briefly blank the screen. Confirm both
+   caveats are visible to you as a real (if brief) UX event, not just documented.
+5. Externally set a **partial/malformed** `user_disabled_hdr_formats` row (e.g. `adb shell
+   settings put secure user_disabled_hdr_formats 2,3` with the allowed flag `1`), then open
+   Privileged Display. **Expected:** the switch is replaced by a custom-preference preservation
+   notice (not a Boolean guess) — and applying an unrelated field on this screen leaves that row
+   untouched rather than broadening it to the full disabled set.
+
+## §11.39a — Read-back tracks the device, not the stored profile (DB-034/DB-039)
+
+6. With Privileged Display open, flip Night Light (or color inversion) from the system
+   quick-settings tile, return to Tideo. **Expected:** the toggle shows the device's actual
+   state and Apply becomes available.
+7. Flip the SAME toggle back from the tile and return again. **Expected:** the screen follows a
+   **second** time — before DB-039 this worked exactly once per screen entry.
+8. Change a toggle WITHOUT applying, background the app, return. **Expected:** your uncommitted
+   edit survives — read-back never overwrites a dirty draft.
+
+## §13.44a — Dropped commands explain themselves (DB-035)
+
+9. Set **Live Debug Info → Log Level** to 8. Send a control broadcast that will be rejected
+   (e.g. gate the automation OFF, then broadcast `LOAD_PROFILE` with a caller-chosen name over
+   ~40 chars or containing control/bidi characters):
+   `adb shell am broadcast -a com.tideo.autobrightness.control.LOAD_PROFILE -n
+   com.tideo.autobrightness/.app.control.ControlReceiver --es profile "<long or odd name>"`.
+   **Expected:** the debug log names the drop reason at level 8; the profile name reaching the
+   system-wide overlay is truncated to 40 chars with control/bidi characters stripped.
+
+## §5.14a — Every panic entry point confirms exactly once (DB-037)
+
+10. Fire panic via the inversion gesture. **Expected:** S.O.S. vibration, max brightness,
+    service stop.
+11. Repeat via the foreground notification's **Reset** action, then via the intent surface:
+    `adb shell am broadcast -a com.tideo.autobrightness.control.PANIC -n
+    com.tideo.autobrightness/.app.control.ControlReceiver` (automation toggle ON).
+    **Expected:** the same S.O.S. vibration both times — before DB-037 only the gesture buzzed.
+12. Fire the gesture once more. **Expected:** vibrates **exactly once**, not twice (checks for a
+    leftover call site on the shared path).
+
+## Log any miss
+
+Log any FAIL/BLOCKED in `../STATE.md` → Owner queue with the step number above, not the master
+script's numbering, until this file is folded in and deleted.

--- a/docs/rebuild/DEVICE_TEST_SCRIPT_1.9.0.md
+++ b/docs/rebuild/DEVICE_TEST_SCRIPT_1.9.0.md
@@ -54,7 +54,8 @@ On a device (or OEM build) where the framework reports the feature unavailable:
    (e.g. gate the automation OFF, then broadcast `LOAD_PROFILE` with a caller-chosen name over
    ~40 chars or containing control/bidi characters):
    `adb shell am broadcast -a com.tideo.autobrightness.control.LOAD_PROFILE -n
-   com.tideo.autobrightness/.app.control.ControlReceiver --es profile "<long or odd name>"`.
+   com.tideo.autobrightness.debug/com.tideo.autobrightness.app.control.ControlReceiver --es name
+   "<long or odd name>"`.
    **Expected:** the debug log names the drop reason at level 8; the profile name reaching the
    system-wide overlay is truncated to 40 chars with control/bidi characters stripped.
 
@@ -64,7 +65,7 @@ On a device (or OEM build) where the framework reports the feature unavailable:
     service stop.
 11. Repeat via the foreground notification's **Reset** action, then via the intent surface:
     `adb shell am broadcast -a com.tideo.autobrightness.control.PANIC -n
-    com.tideo.autobrightness/.app.control.ControlReceiver` (automation toggle ON).
+    com.tideo.autobrightness.debug/com.tideo.autobrightness.app.control.ControlReceiver` (automation toggle ON).
     **Expected:** the same S.O.S. vibration both times — before DB-037 only the gesture buzzed.
 12. Fire the gesture once more. **Expected:** vibrates **exactly once**, not twice (checks for a
     leftover call site on the shared path).


### PR DESCRIPTION
## Summary
- add the v1.9.0 round-scoped device test script and correct its debug broadcast component/extra
- refresh Privileged Display device read-back after direct Apply so stale pre-write state cannot visually undo successful writes
- strip control and bidi characters before bounding rejected profile names
- record the device findings, resolved defects, incomplete coverage, and outstanding gesture-vibration investigation

## Testing
- `scripts/ladder.sh --guards-only` (green)
- mandatory fresh-context glue review (two findings fixed; follow-up diff reviewed in context)
- `scripts/ladder.sh` (guards and fixture suites passed; Gradle verification blocked when Robolectric's Maven resolver failed with `SocketException` fetching Android SDK artifacts)
- `./gradlew :app:testDebugUnitTest --tests '*DisplayTogglesViewModelTest' --tests '*ControlReceiverTest' --tests '*AmbientMonitoringServiceTest'` (compiled production and test sources; same Robolectric artifact-fetch environment failure)

## Review notes
Glue-review pass found stale pre-write HDR flags and missing ISO-control fixture coverage; both were corrected before commit. No further checklist findings remained.

On-device behavior could not be verified locally. DB-047 needs an owner device retest. Unsupported capability coverage and the incomplete HDR state checks remain queued. The reported gesture-only double S.O.S. vibration also remains queued: a repository-wide Kotlin call-site audit found only the shared `panicAndStop` vibration and its repeat-admission guard, so this PR does not make a speculative panic-path change without an evidenced second source.
